### PR TITLE
feat: Add flag to enable firestore emulator

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -72,6 +72,9 @@ Firebase emulator makes it very convinient to get responses quickly during devel
 - Select `firestore emulator.
 - Link your project you setup on firebase.
 
+**Using emulator in project**
+- To use emulator in project a flag named `EMULATED_FIRESTORE` needs to be set in the respective environment file that you're using. You can set the value of flag to `1`.
+
 ## All set!
 Now you should be able to run the project! Happy Coding :)
 

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -24,7 +24,7 @@ else {
   };
 }
 
-if(process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+if(process.env.NODE_ENV === "test" || process.env.EMULATED_FIRESTORE) {
   process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
   admin.initializeApp({
     projectId: process.env.FIRESTORE_PROJECT_ID


### PR DESCRIPTION
### Summary
This PR adds a flag for enabling firestore emulator. With this change, now you need to set a flag to use firestore emulator.


