### PR TITLE
Use expressbang for errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
+const expressBang = require("express-bang");
 
 const routes = require("./routes");
 const { routeNotFound, errorHandler } = require("./middlewares");
@@ -10,6 +11,7 @@ const app = express();
 app.use(cookieParser());
 app.use(cors({credentials: true}));
 app.use(express.json());
+app.use(expressBang());
 
 app.use("/", routes);
 

--- a/controllers/auth/signin/signin.js
+++ b/controllers/auth/signin/signin.js
@@ -17,39 +17,21 @@ async function signinController(req, res) {
   try {
     const { body: payload } = req;
     const { error, value } = signinPayloadSchema.validate(payload);
-    if (!!error) {
-      return res.status(422).json({
-        message: error.message,
-        statusCode: 422,
-        error: "unprocessable content",
-      });
-    }
+    if (!!error)
+      return res.bang.unprocessableEntity(error.message);
 
     const { email, password } = value;
     const user = await fetchUserByEmail(email);
-    if (!user) {
-      return res.status(400).json({
-        error: "bad request",
-        message: "Email or Password incorrect",
-        statusCode: 400,
-      });
-    }
-    if(user.isUserVerified()) {
-      return res.status(401).json({
-        error: "unauthorized access",
-        message: "Email is not verified",
-        statusCode: 401
-      });
-    }
+    if (!user)
+      return res.bang.badRequest("Email or Password incorrect");
+
+    if(user.isUserVerified())
+      return res.bang.unauthorized("Email is not verified");
 
     const matchPassword = await user.matchPassword(password);
-    if (!matchPassword) {
-      return res.status(400).json({
-        error: "bad request",
-        message: "Email or Password incorrect",
-        statusCode: 400,
-      });
-    }
+    if (!matchPassword)
+      return res.bang.badRequest("Email or Password incorrect");
+
     const subscription = await fetchSubscriptionByuserid(user.userId);
     const keys = await fetchKeyByuserid(user.userId);
 

--- a/controllers/auth/signin/signin.test.js
+++ b/controllers/auth/signin/signin.test.js
@@ -12,7 +12,7 @@ describe("Signin Controller", () => {
       expect(response.body).toEqual({
         message: "\"email\" is required",
         statusCode: 422,
-        error: "unprocessable content"
+        error: "Unprocessable Entity"
       });
     });
 
@@ -25,7 +25,7 @@ describe("Signin Controller", () => {
       expect(response.body).toEqual({
         message: "Email is not valid",
         statusCode: 422,
-        error: "unprocessable content"
+        error: "Unprocessable Entity"
       });
     });
   });

--- a/middlewares/auth/auth.js
+++ b/middlewares/auth/auth.js
@@ -6,23 +6,14 @@ module.exports = function (req, res, next) {
   try {
     const { jwt } = req.cookies;
 
-    if(!jwt) {
-      return res.status(401).json({
-        error: "Unauthorized",
-        message: "User not signed in",
-        statusCode: 401
-      });
-    }
+    if(!jwt)
+      return res.bang.unauthorized("User not signed in");
 
     const decodedData = JWT.verify(jwt, process.env.JWT_SECRET);
 
     const { data } = decodedData;
     if(!data || !data.email || !data.userId)
-      return res.status(403).json({
-        error: http.STATUS_CODES[403],
-        message: "Invalid credentials",
-        statusCode: 403
-      });
+      return res.bang.forbidden("Invalid credentials");
 
     Object.assign(req, { userData: decodedData.data });
     next();

--- a/middlewares/auth/auth.test.js
+++ b/middlewares/auth/auth.test.js
@@ -5,6 +5,7 @@ const jwt = require("jsonwebtoken");
 const cookieParser = require("cookie-parser");
 const User = require("../../models/Users");
 const { Timestamp } = require("firebase-admin/firestore");
+const expressBang = require("express-bang");
 
 const mockFn = jest.fn();
 const mockUser = new User({
@@ -24,6 +25,7 @@ describe("Auth middleware", () => {
   beforeAll(() => {
     process.env.JWT_SECRET = "mysecret";
     app.use(cookieParser());
+    app.use(expressBang());
     app.get("/", auth, (req, res) => mockFn(req, res));
     app.get("/error", auth, (req, res) => mockFn());
   });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-bang": "^0.2.0",
     "firebase-admin": "^11.10.1",
     "joi": "^17.11.0",
     "json-api-ify": "^1.1.1",


### PR DESCRIPTION
### Summary
This PR installs a package called express-bang, which is a low overhead middlware for creating http error objects.More on this [here](https://www.npmjs.com/package/express-bang)

### Description
`express-bang` package allows us to hook to response object of express, allowing us to create http errors in a convenient way. E.g
```js
// Earlier approach
return res.status(400).json({
  error: "Bad Request",
  message: "error message",
  statusCode: 400
});

// Using express-bang
return res.bang.badRequest("error message");
```

### How to Test the Changes
To test the changes, replace your response that is sending error with express bang and then test the response.

<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->


<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
