### PR TITLE
feat: Add support for admin only access in auth middleware

### DIFF
--- a/server/__tests__/unit/middlewares/auth.js
+++ b/server/__tests__/unit/middlewares/auth.js
@@ -5,27 +5,47 @@ const cookieParser = require("cookie-parser");
 const auth = require("../../../middlewares/auth");
 const { mockUsers } = require("../../../utils/mocks/Users");
 const { Users } = require("../../../models");
+const { STATUS_CODES } = require("http");
 
 const mockCtrl = jest.fn();
 
 describe("Auth middleware", () => {
+  const ENDPOINT = "/";
+  const ADMIN_ENDPOINT = "/adminOnly";
+
   afterEach(() => {
     jest.clearAllMocks();
   });
   beforeAll(() => {
     process.env.JWT_SECRET = "mysecret";
     app.use(cookieParser());
-    app.get("/", auth, (req, res) => mockCtrl(req, res));
+    app.get(ENDPOINT, auth(), (req, res) => mockCtrl(req, res));
+    app.get(ADMIN_ENDPOINT, auth({ adminOnly: true }), (req, res) => mockCtrl(req, res));
   });
 
-  it("Success - If user is signed in", async () => {
+  it("200 - If user is signed in (CUSTOMER)", async () => {
     mockCtrl.mockImplementation((req, res) => {
       return res.status(200).json(req.userData);
     });
     const mockUser = new Users(mockUsers[1]);
     const mockJWT = mockUser.generateJWT();
     const response = await request(app)
-      .get("/")
+      .get(ENDPOINT)
+      .set("Cookie", `jwt=${mockJWT}`);
+
+    expect(mockCtrl).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockUser.data);
+  });
+
+  it("200 - If user is signed in (ADMIN)", async () => {
+    mockCtrl.mockImplementation((req, res) => {
+      return res.status(200).json(req.userData);
+    });
+    const mockUser = new Users(mockUsers[2]);
+    const mockJWT = mockUser.generateJWT();
+    const response = await request(app)
+      .get(ADMIN_ENDPOINT)
       .set("Cookie", `jwt=${mockJWT}`);
 
     expect(mockCtrl).toHaveBeenCalledTimes(1);
@@ -34,21 +54,41 @@ describe("Auth middleware", () => {
   });
 
   it("401 - If user is not signed in / JWT not present", async () => {
-    const response = await request(app).get("/");
+    const response = await request(app).get(ENDPOINT);
 
     expect(response.status).toBe(401);
-    expect(response.body.message).toBe("User not signed in");
+    expect(response.body).toEqual({
+      error: STATUS_CODES[401],
+      message: "User not signed in",
+      statusCode: 401
+    });
   });
 
   it("403 - if JWT is invalid", async () => {
     const mockJWT = jwt.sign({ data: "hello" }, process.env.JWT_SECRET);
     const response = await request(app)
-      .get("/")
+      .get(ENDPOINT)
       .set("Cookie", `jwt=${mockJWT}`);
 
     expect(response.status).toBe(403);
-    expect(response.body.message).toBe("Invalid credentials");
-    expect(response.body.error).toBe("Forbidden");
+    expect(response.body).toEqual({
+      error: STATUS_CODES[403],
+      message: "Invalid credentials",
+      statusCode: 403
+    });
+  });
+
+  it("403 - The user is not admin", async () => {
+    const mockJWT = jwt.sign({ data: mockUsers[1] }, process.env.JWT_SECRET);
+
+    const response = await request(app).get(ADMIN_ENDPOINT).set("Cookie", `jwt=${mockJWT}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      error: STATUS_CODES[401],
+      message: "User not authorized",
+      statusCode: 401
+    });
   });
 
   it("500 - For unexpected errors", async () => {
@@ -58,7 +98,7 @@ describe("Auth middleware", () => {
 
     const mockJWT = new Users(mockUsers[1]).generateJWT();
     const response = await request(app)
-      .get("/")
+      .get(ENDPOINT)
       .set("Cookie", `jwt=${mockJWT}`);
 
     expect(response.status).toBe(500);

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -1,32 +1,46 @@
 const JWT = require("jsonwebtoken");
-const http = require("http");
+const { STATUS_CODES } = require("http");
+const { UserType } = require("../utils/constants");
 
 
-module.exports = function (req, res, next) {
-  try {
-    const { jwt } = req.cookies;
+/**
+	* @param {Object} options
+	* @param {boolean} options.adminOnly
+	**/
+module.exports = (options = {}) => {
+  return function (req, res, next) {
+    try {
+      const { jwt } = req.cookies;
 
-    if(!jwt) {
-      return res.status(401).json({
-        error: "Unauthorized",
-        message: "User not signed in",
-        statusCode: 401
-      });
+      if(!jwt) {
+        return res.status(401).json({
+          error: "Unauthorized",
+          message: "User not signed in",
+          statusCode: 401
+        });
+      }
+
+      const decodedData = JWT.verify(jwt, process.env.JWT_SECRET);
+
+      const { data } = decodedData;
+      if(!data || !data.email || !data.userId)
+        return res.status(403).json({
+          error: STATUS_CODES[403],
+          message: "Invalid credentials",
+          statusCode: 403
+        });
+
+      if(options.adminOnly && data.userType !== UserType.ADMIN)
+        return res.status(401).json({
+          error: STATUS_CODES[401],
+          message: "User not authorized",
+          statusCode: 401
+        });
+
+      Object.assign(req, { userData: decodedData.data });
+      next();
+    } catch (err) {
+      next(err);
     }
-
-    const decodedData = JWT.verify(jwt, process.env.JWT_SECRET);
-
-    const { data } = decodedData;
-    if(!data || !data.email || !data.userId)
-      return res.status(403).json({
-        error: http.STATUS_CODES[403],
-        message: "Invalid credentials",
-        statusCode: 403
-      });
-
-    Object.assign(req, { userData: decodedData.data });
-    next();
-  } catch (err) {
-    next(err);
-  }
+  };
 };

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -7,11 +7,11 @@ const destroyKeyController = require("../controllers/user/destroy");
 const updateProfileController = require("../controllers/user/update-profile.js");
 const deleteUserAccountController = require("../controllers/user/delete.js");
 
-router.get("/data", authMiddleware, getUserDataController);
-router.post("/update-password", authMiddleware, updatePasswordController);
-router.patch("/update-profile", authMiddleware, updateProfileController);
-router.delete("/delete", authMiddleware, deleteUserAccountController);
-router.post("/generate", authMiddleware, generateKeyController);
-router.delete("/destroy", authMiddleware, destroyKeyController);
+router.get("/data", authMiddleware(), getUserDataController);
+router.post("/update-password", authMiddleware(), updatePasswordController);
+router.patch("/update-profile", authMiddleware(), updateProfileController);
+router.delete("/delete", authMiddleware(), deleteUserAccountController);
+router.post("/generate", authMiddleware(), generateKeyController);
+router.delete("/destroy", authMiddleware(), destroyKeyController);
 
 module.exports = router;

--- a/server/utils/mocks/Users.js
+++ b/server/utils/mocks/Users.js
@@ -2,6 +2,9 @@ const bcrypt = require("bcrypt");
 const { UserType } = require("../constants");
 const { Timestamp } = require("firebase-admin/firestore");
 
+// 0 - Unverified CUSTOMER   
+// 1 - Verified CUSTOMER
+// 2 - Admin
 const mockUsers = [
   {
     userId: "0c1266ab-8ad2-4ab9-b56c-e1db6982f120",
@@ -22,6 +25,18 @@ const mockUsers = [
     password: bcrypt.hashSync("password123", 10), 
     createdAt: Timestamp.fromDate(new Date("01-01-2001")),
     updatedAt: Timestamp.fromDate(new Date("01-01-2001")),
+    userType: UserType.CUSTOMER,
+    isVerified: true
+  },
+  {
+    userId: "7a9b5ce6-ae35-4fb9-b7f6-bbf85f0536b8",
+    firstName: "John",
+    lastName: "Doe",
+    email: "johndoe@example.com",
+    password: bcrypt.hashSync("password123", 10), 
+    createdAt: Timestamp.fromDate(new Date("01-01-2001")),
+    updatedAt: Timestamp.fromDate(new Date("01-01-2001")),
+    userType: UserType.ADMIN,
     isVerified: true
   }
 ];


### PR DESCRIPTION
### Summary
Add support for admin only access in auth middelware

### Description
Since User collection now supports a `userType` and there are some api for users who have `ADMIN` user type, a middleware is needed to only allow admins to the api.
This is solved by modifying the auth middleware to contain options. We can use the same code and have a if-check to check if the user is ADMIN or not.
<!-- Describe your changes in detail. Include the task or issue that this PR resolves, if applicable. -->

### How to Test the Changes
Log in to an api using user data of a user which has `CUSTOMER` userType to access `admin` API
<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
- [x]  This pull request follows the project's coding guidelines.
