### PR TITLE
fix: make signin page protected

### DIFF
--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -6,7 +6,7 @@ import ApiDocs from './docs/ApiDocs';
 import ForgotPassword from './forgot-password/ForgotPassword';
 import ResetPassword from './reset-password/ResetPassword';
 import ResetPasswordSuccessCard from './reset-password/ResetPasswordSuccessCard';
-import {Signin} from './signin/Signin';
+import Signin from './signin/Signin';
 import {Signup} from './signup/Signup';
 import {Home} from './welcome/Home';
 import AdminDashboard from './admin/Admin';

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -7,8 +7,8 @@ import ForgotPassword from './forgot-password/ForgotPassword';
 import ResetPassword from './reset-password/ResetPassword';
 import ResetPasswordSuccessCard from './reset-password/ResetPasswordSuccessCard';
 import Signin from './signin/Signin';
-import {Signup} from './signup/Signup';
-import {Home} from './welcome/Home';
+import Signup from './signup/Signup';
+import Home from './welcome/Home';
 import AdminDashboard from './admin/Admin';
 
 export {

--- a/client/src/pages/signin/Signin.js
+++ b/client/src/pages/signin/Signin.js
@@ -1,10 +1,17 @@
+import {useContext} from 'react';
 import Signincard from '../../components/signincard/Signincard';
 import './Signin.css';
+import {Navigate} from 'react-router-dom';
+import {AuthContext} from '../../contexts/AuthContext';
 
-export const Signin = () => {
-	return (
+export default function Signin() {
+	const {isAuthenticated} = useContext(AuthContext);
+
+	return !isAuthenticated ? (
 		<div className='login-main'>
 			<Signincard />
 		</div>
+	) : (
+		<Navigate to='/dashboard' />
 	);
-};
+}

--- a/client/src/pages/signup/Signup.js
+++ b/client/src/pages/signup/Signup.js
@@ -1,13 +1,15 @@
-import {useState} from 'react';
-import {NavLink} from 'react-router-dom';
-import './Signup.css';
+import {useState, useContext} from 'react';
+import {NavLink, Navigate} from 'react-router-dom';
 import {useApi} from '../../hooks/useApi';
 import {INITIAL_SIGNUP_FORM_DATA} from '../../constants';
+import {AuthContext} from '../../contexts/AuthContext';
+import './Signup.css';
 
-export const Signup = () => {
+const Signup = () => {
 	const [formData, setFormData] = useState(INITIAL_SIGNUP_FORM_DATA);
 	const [validationErrors, setValidationErrors] = useState({});
 	const [isSignUpSuccess, setIsSignUpSuccess] = useState(false);
+	const {isAuthenticated} = useContext(AuthContext);
 	const {data, errorMsg, makeRequest} = useApi({
 		url: `api/auth/signup`,
 		method: 'post',
@@ -113,7 +115,7 @@ export const Signup = () => {
 		);
 	};
 
-	return (
+	return !isAuthenticated ? (
 		<div className='page-div'>
 			<form onSubmit={handleSubmit} noValidate className='form-box'>
 				<h2 className='form-title'>Sign up for free</h2>
@@ -217,5 +219,9 @@ export const Signup = () => {
 				</div>
 			</form>
 		</div>
+	) : (
+		<Navigate to='/dashboard' />
 	);
 };
+
+export default Signup;

--- a/client/src/pages/welcome/Home.js
+++ b/client/src/pages/welcome/Home.js
@@ -1,14 +1,20 @@
+import {useContext} from 'react';
+import {Navigate} from 'react-router-dom';
 import Demo from '../../components/demo/Demo';
 import {HeroSection} from '../../components/herosection/HeroSection';
-import './Home.css';
 import FAQs from '../../components/faqs/FAQs';
+import {AuthContext} from '../../contexts/AuthContext';
+import './Home.css';
 
 export const Home = () => {
-	return (
+	const {isAuthenticated} = useContext(AuthContext);
+	return !isAuthenticated ? (
 		<div className='home-container'>
 			<HeroSection />
 			<Demo />
 			<FAQs />
 		</div>
+	) : (
+		<Navigate to='/dashboard' />
 	);
 };


### PR DESCRIPTION
### Summary
Make signin route protected
<!-- Provide a general summary of your changes in the Title above -->

### Description
Currently when the `/signin` route is accessed the user is shown the signin form, when the user is already authenticated.
This PR changes this behavior to redirect the user to the `/dashboard` page.

<!-- Describe your changes in detail. Include the task or issue that this PR resolves, if applicable. -->

### How to Test the Changes
- Login the user
- Try to access signin page

<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Screenshots or Recordings (Optional)
**Before**
https://github.com/TeamShiksha/logoexecutive/assets/26207583/7ff1e465-2b9b-4051-9657-033dbe074d92

**After**
https://github.com/TeamShiksha/logoexecutive/assets/26207583/2db42cbe-61a0-49b9-be1c-ac0fefba7196



## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
- [x]  This pull request follows the project's coding guidelines.
