### PR TITLE
feat: Button component

### DIFF
--- a/client/src/components/Button/Button.jsx
+++ b/client/src/components/Button/Button.jsx
@@ -1,0 +1,24 @@
+import styles from './Button.module.css';
+
+/**
+ * @param {React.HTMLProps & { leftIcon?: React.Component, rightIcon?: React.Component, isLoading?: boolean }} props
+ **/
+export default function Button({
+	className,
+	leftIcon,
+	rightIcon,
+	isLoading,
+	...props
+}) {
+	return (
+		<button
+			className={`${styles.Button} ${className}`}
+			disabled={isLoading || props.disabled}
+			{...props}
+		>
+			{leftIcon && leftIcon}
+			{props.children}
+			{rightIcon && rightIcon}
+		</button>
+	);
+}

--- a/client/src/components/Button/Button.module.css
+++ b/client/src/components/Button/Button.module.css
@@ -1,0 +1,17 @@
+.Button {
+	background: var(--smooth-purple);
+	color: white;
+	padding: 8px 16px;
+	border: none;
+	border-radius: var(--bradius);
+	font-weight: bold;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	gap: 4px;
+}
+
+.Button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}

--- a/client/src/components/Button/Button.test.js
+++ b/client/src/components/Button/Button.test.js
@@ -1,0 +1,91 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import Button from './Button';
+
+describe('Button', () => {
+	it('Renders', async () => {
+		render(<Button>Click me</Button>);
+
+		const button = screen.getByRole('button');
+
+		expect(button).toBeInTheDocument();
+		expect(button.textContent).toBe('Click me');
+	});
+
+	it('Should support custom classname', async () => {
+		render(<Button className={`custom`}>Click me</Button>);
+
+		const button = screen.getByRole('button');
+
+		expect(button).toBeInTheDocument();
+		expect(button.className).toContain('custom');
+	});
+
+	it('Disabled when isLoading is true', async () => {
+		render(<Button isLoading={true}>Click me</Button>);
+
+		const button = screen.getByRole('button');
+
+		expect(button).toBeInTheDocument();
+		expect(button).toBeDisabled();
+	});
+
+	it('Disabled when disabled is true', async () => {
+		render(<Button disabled>Click me</Button>);
+
+		const button = screen.getByRole('button');
+
+		expect(button).toBeInTheDocument();
+		expect(button).toBeDisabled();
+	});
+
+	it('Renders leftIcon if present', async () => {
+		render(<Button leftIcon={<span>Left Icon </span>}>Click me</Button>);
+
+		const button = screen.getByRole('button');
+		const Icon = screen.getByText('Left Icon');
+
+		expect(button).toBeInTheDocument();
+		expect(button.textContent).toBe('Left Icon Click me');
+		expect(Icon).toBeInTheDocument();
+	});
+
+	it('Renders rightIcon if present', async () => {
+		render(<Button rightIcon={<span>Right Icon</span>}>Click me </Button>);
+
+		const button = screen.getByRole('button');
+		const Icon = screen.getByText('Right Icon');
+
+		expect(button).toBeInTheDocument();
+		expect(button.textContent).toBe('Click me Right Icon');
+		expect(Icon).toBeInTheDocument();
+	});
+
+	it('Triggers onclick when clicked', async () => {
+		const mockFn = jest.fn();
+		render(<Button onClick={mockFn}>Click me</Button>);
+
+		const button = screen.getByRole('button');
+		fireEvent.click(button);
+
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('Triggers onSubmit when clicked inside a form', async () => {
+		const mockFn = jest.fn();
+		render(
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					mockFn();
+				}}
+			>
+				<Button type='submit'>Click me</Button>
+			</form>,
+		);
+
+		const button = screen.getByRole('button');
+		fireEvent.click(button);
+
+		expect(mockFn).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
### Summary
Add reusable Button component

### Description
Currently button component is hardcoded in every page. This PR introduces a resuable Button component.


### How to Test the Changes
Automated tests have been written with 100% test coverage
![image](https://github.com/TeamShiksha/logoexecutive/assets/26207583/7ca5ce45-2e73-4c98-a6fe-a1c692c55a94)


### Context (Optional)

<!-- Provide any additional context about the problem or feature here. -->

### Screenshots or Recordings (Optional)
**Note**
- The button above is the previous component
- The button below is the reusable button component

![Screenshot from 2024-03-24 19-58-44](https://github.com/TeamShiksha/logoexecutive/assets/26207583/6e045c81-a495-452a-807c-5ea516b6d1ec)


<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
