### PR TITLE
[Test] - Test cases for Keys Service

### DIFF
--- a/server/__tests__/unit/services/Keys.js
+++ b/server/__tests__/unit/services/Keys.js
@@ -9,31 +9,9 @@ jest.mock("uuid", () => ({
     v4: jest.fn(() => mockKeys[0].keyId),
 }));
 
-
-describe("isAPIKeyPresent", () => {
-    test("should return true if the API key exists in the key collection", async () => {
-        await KeyCollection.doc(mockKeys[0].keyId).set(mockKeys[0]);
-        const result = await isAPIKeyPresent(mockKeys[0].key);
-        expect(result).toBe(true);
-    });
-
-    test("should return false if the API key does not exist in the key collection", async () => {
-        const mockApiKey = "mockApiKey";
-        const result = await isAPIKeyPresent(mockApiKey);
-        expect(result).toBe(false);
-    });
-
-    it("should throw an error if Firestore operation fails", async () => {
-        const mockApiKey = "mockApiKey";
-        const errorMessage = "Firestore operation failed";
-
-        jest.spyOn(KeyCollection, "where").mockReturnValue({
-            get: jest.fn().mockRejectedValueOnce(new Error(errorMessage))
-        });
-
-        await expect(isAPIKeyPresent(mockApiKey)).rejects.toThrow(errorMessage);
-    });
-});
+afterEach(() => {
+    jest.restoreAllMocks()
+})
 
 describe("createKey", () => {
     it("should create a key in the database and return the created key object", async () => {
@@ -78,6 +56,31 @@ describe("fetchKeysByuserid", () => {
             get: jest.fn().mockRejectedValueOnce(new Error(errorMessage))
         });
         await expect(fetchKeysByuserid(mockKeys[0].userId)).rejects.toThrow(errorMessage);
+    });
+});
+
+describe("isAPIKeyPresent", () => {
+    test("should return true if the API key exists in the key collection", async () => {
+        await KeyCollection.doc(mockKeys[0].keyId).set(mockKeys[0]);
+        const result = await isAPIKeyPresent(mockKeys[0].key);
+        expect(result).toBe(true);
+    });
+
+    test("should return false if the API key does not exist in the key collection", async () => {
+        const mockApiKey = "mockApiKey";
+        const result = await isAPIKeyPresent(mockApiKey);
+        expect(result).toBe(false);
+    });
+
+    it("should throw an error if Firestore operation fails", async () => {
+        const mockApiKey = "mockApiKey";
+        const errorMessage = "Firestore operation failed";
+
+        jest.spyOn(KeyCollection, "where").mockReturnValue({
+            get: jest.fn().mockRejectedValueOnce(new Error(errorMessage))
+        });
+
+        await expect(isAPIKeyPresent(mockApiKey)).rejects.toThrow(errorMessage);
     });
 });
 


### PR DESCRIPTION
### Description

Test cases for the keys services on the server-side. These test cases will evaluate the following functions:
1. `fetchUsers`
2. `fetchKeysByuserid`
3. `destroyKey`
4. `isAPIKeyPresent`

### How to Test the Changes
To test these changes:

1. Navigate to the root directory.
2. Run the command:
```bash
yarn test:server
```

### Screenshots
![Keys](https://github.com/TeamShiksha/logoexecutive/assets/65087180/2f1635d2-dcb3-4917-8bf1-35e097cef90a)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
