### PR TITLE
[Integration] - `/destroy` API integration with Frontend

### DIFF
--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import {FiCopy} from 'react-icons/fi';
 import {LuCopyCheck} from 'react-icons/lu';
 import {MdDeleteOutline} from 'react-icons/md';
+import {formatDate} from '../../utils/helpers';
 
 function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 	return (
@@ -55,13 +56,7 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 										<MdDeleteOutline />
 									</button>
 								</td>
-								<td>
-									{new Date(key?.createdAt).toLocaleDateString('en-us', {
-										month: 'long',
-										day: 'numeric',
-										year: 'numeric',
-									})}
-								</td>
+								<td>{formatDate(key?.createdAt)}</td>
 							</tr>
 						))}
 					</tbody>

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -60,7 +60,7 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 										month: 'long',
 										day: 'numeric',
 										year: 'numeric',
-									}) || ''}
+									})}
 								</td>
 							</tr>
 						))}

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -50,7 +50,7 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 									<button
 										className='api-key-delete-button'
 										data-testid='api-key-delete'
-										onClick={() => deleteKey(key.key)}
+										onClick={() => deleteKey(key.keyId)}
 									>
 										<MdDeleteOutline />
 									</button>

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -9,10 +9,10 @@ describe('ApiKeyTable', () => {
 			keyId: 'id1',
 			createdAt: '2024-02-29',
 		},
-		{keyDescription: 'Test Key 2', key: '456', keyId: 'id2', createdAt: ''},
+		{keyDescription: 'Test Key 2', key: '456', keyId: 'id2', createdAt: '2024-02-28'},
 	];
 
-	it('renders correctly', () => {
+	it('Renders correctly', () => {
 		render(
 			<ApiKeyTable
 				keys={keys}
@@ -21,18 +21,10 @@ describe('ApiKeyTable', () => {
 				deleteKey={() => {}}
 			/>,
 		);
-
 		expect(screen.getByText('Test Key 1')).toBeInTheDocument();
 		expect(screen.getByText('Test Key 2')).toBeInTheDocument();
 		expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
-		const elements = screen.getAllByText('');
-		let found = false;
-		elements.forEach((element) => {
-			if (element.tagName == 'TD') {
-				found = true;
-			}
-		});
-		expect(found).toBe(true);
+		expect(screen.getByText('February 28, 2024')).toBeInTheDocument();
 	});
 
 	it('handles copy to clipboard', () => {
@@ -45,7 +37,6 @@ describe('ApiKeyTable', () => {
 				deleteKey={() => {}}
 			/>,
 		);
-
 		const buttons = screen.getAllByTestId('api-key-copy');
 		fireEvent.click(buttons[0]);
 		expect(handleCopyToClipboard).toHaveBeenCalledWith('123');
@@ -67,7 +58,7 @@ describe('ApiKeyTable', () => {
 		expect(screen.getByTestId('api-key-copied')).toBeInTheDocument();
 	});
 
-	it('removes key when delete is clicked', () => {
+	it('Removes key when delete is clicked', () => {
 		const deleteKey = jest.fn();
 		render(
 			<ApiKeyTable

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -53,19 +53,19 @@ describe('ApiKeyTable', () => {
 		expect(screen.getByTestId('api-key-copied')).toBeInTheDocument();
 	});
 
-	it('removes key when delete is clicked', () => {
-		const deleteKey = jest.fn();
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={deleteKey}
-			/>,
-		);
+	// it('removes key when delete is clicked', () => {
+	// 	const deleteKey = jest.fn();
+	// 	render(
+	// 		<ApiKeyTable
+	// 			keys={keys}
+	// 			copiedKey=''
+	// 			handleCopyToClipboard={() => {}}
+	// 			deleteKey={deleteKey}
+	// 		/>,
+	// 	);
 
-		const buttons = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(buttons[0]);
-		expect(deleteKey).toHaveBeenCalledWith('123');
-	});
+	// 	const buttons = screen.getAllByTestId('api-key-delete');
+	// 	fireEvent.click(buttons[0]);
+	// 	expect(deleteKey).toHaveBeenCalledWith('123');
+	// });
 });

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -9,7 +9,12 @@ describe('ApiKeyTable', () => {
 			keyId: 'id1',
 			createdAt: '2024-02-29',
 		},
-		{keyDescription: 'Test Key 2', key: '456', keyId: 'id2', createdAt: '2024-02-28'},
+		{
+			keyDescription: 'Test Key 2',
+			key: '456',
+			keyId: 'id2',
+			createdAt: '2024-02-28',
+		},
 	];
 
 	it('Renders correctly', () => {

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -3,8 +3,13 @@ import ApiKeyTable from './ApiKeyTable';
 
 describe('ApiKeyTable', () => {
 	const keys = [
-		{keyDescription: 'Test Key 1', key: '123', createdAt: '2024-02-29'},
-		{keyDescription: 'Test Key 2', key: '456', createdAt: '2024-02-28'},
+		{
+			keyDescription: 'Test Key 1',
+			key: '123',
+			keyId: 'id1',
+			createdAt: '2024-02-29',
+		},
+		{keyDescription: 'Test Key 2', key: '456', keyId: 'id2', createdAt: ''},
 	];
 
 	it('renders correctly', () => {
@@ -19,6 +24,15 @@ describe('ApiKeyTable', () => {
 
 		expect(screen.getByText('Test Key 1')).toBeInTheDocument();
 		expect(screen.getByText('Test Key 2')).toBeInTheDocument();
+		expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
+		const elements = screen.getAllByText('');
+		let found = false;
+		elements.forEach((element) => {
+			if (element.tagName == 'TD') {
+				found = true;
+			}
+		});
+		expect(found).toBe(true);
 	});
 
 	it('handles copy to clipboard', () => {
@@ -53,19 +67,19 @@ describe('ApiKeyTable', () => {
 		expect(screen.getByTestId('api-key-copied')).toBeInTheDocument();
 	});
 
-	// it('removes key when delete is clicked', () => {
-	// 	const deleteKey = jest.fn();
-	// 	render(
-	// 		<ApiKeyTable
-	// 			keys={keys}
-	// 			copiedKey=''
-	// 			handleCopyToClipboard={() => {}}
-	// 			deleteKey={deleteKey}
-	// 		/>,
-	// 	);
+	it('removes key when delete is clicked', () => {
+		const deleteKey = jest.fn();
+		render(
+			<ApiKeyTable
+				keys={keys}
+				copiedKey=''
+				handleCopyToClipboard={() => {}}
+				deleteKey={deleteKey}
+			/>,
+		);
 
-	// 	const buttons = screen.getAllByTestId('api-key-delete');
-	// 	fireEvent.click(buttons[0]);
-	// 	expect(deleteKey).toHaveBeenCalledWith('123');
-	// });
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		expect(deleteKey).toHaveBeenCalledWith('id1');
+	});
 });

--- a/client/src/mocks/handlers.js
+++ b/client/src/mocks/handlers.js
@@ -9,6 +9,7 @@ import {userDataHandler} from './handlers/userData-handler';
 import {forgotPasswordHandler} from './handlers/forgot-password-handler';
 import userDeleteHandler from './handlers/user-delete';
 import {generateKeyHandler} from './handlers/generate_key-handler';
+import {destroyKeyHandler} from './handlers/destroyKey-handler';
 
 const handlers = [
 	...signinHandler,
@@ -22,6 +23,7 @@ const handlers = [
 	...forgotPasswordHandler,
 	...userDeleteHandler,
 	...generateKeyHandler,
+	...destroyKeyHandler,
 ];
 
 export default handlers;

--- a/client/src/mocks/handlers/destroyKey-handler.js
+++ b/client/src/mocks/handlers/destroyKey-handler.js
@@ -1,13 +1,26 @@
 import {rest} from 'msw';
+const {STATUS_CODES} = require('http');
 
 export const destroyKeyHandler = [
 	rest.delete('api/user/destroy', (req, res, ctx) => {
-		return res(
-			ctx.status(200),
-			ctx.json({
-				message: 'Key deleted successfully',
-				statusCode: 200,
-			}),
-		);
+		const keyId = req.url.searchParams.get('keyId');
+		if (keyId == '4d6544e38f5d4ad8bae546ea61e2b842') {
+			return res(
+				ctx.status(200),
+				ctx.json({
+					message: 'Key deleted successfully',
+					statusCode: STATUS_CODES[200],
+				}),
+			);
+		} else {
+			return res(
+				ctx.status(422),
+				ctx.json({
+					message: 'Key ID is required',
+					statusCode: STATUS_CODES[422],
+					error: STATUS_CODES[422],
+				}),
+			);
+		}
 	}),
 ];

--- a/client/src/mocks/handlers/destroyKey-handler.js
+++ b/client/src/mocks/handlers/destroyKey-handler.js
@@ -4,7 +4,7 @@ const {STATUS_CODES} = require('http');
 export const destroyKeyHandler = [
 	rest.delete('api/user/destroy', (req, res, ctx) => {
 		const keyId = req.url.searchParams.get('keyId');
-		if (keyId == '4d6544e38f5d4ad8bae546ea61e2b842') {
+		if (keyId === '4d6544e38f5d4ad8bae546ea61e2b842') {
 			return res(
 				ctx.status(200),
 				ctx.json({

--- a/client/src/mocks/handlers/destroyKey-handler.js
+++ b/client/src/mocks/handlers/destroyKey-handler.js
@@ -1,0 +1,13 @@
+import {rest} from 'msw';
+
+export const destroyKeyHandler = [
+	rest.delete('api/user/destroy', (req, res, ctx) => {
+		return res(
+			ctx.status(200),
+			ctx.json({
+				message: 'Key deleted successfully',
+				statusCode: 200,
+			}),
+		);
+	}),
+];

--- a/client/src/mocks/handlers/generate_key-handler.js
+++ b/client/src/mocks/handlers/generate_key-handler.js
@@ -1,4 +1,5 @@
 import {rest} from 'msw';
+import {formatDate} from '../../utils/helpers';
 
 var keyDescriptionMap = new Map();
 export const generateKeyHandler = [
@@ -16,16 +17,8 @@ export const generateKeyHandler = [
 						keyDescription: 'Test API Key',
 						key: '7D8ED2F3F2C748BC9B96CED7EE2DE1BF',
 						usageCount: 0,
-						createdAt: new Date().toLocaleDateString('en-US', {
-							day: '2-digit',
-							month: 'short',
-							year: 'numeric',
-						}),
-						updatedAt: new Date().toLocaleDateString('en-US', {
-							day: '2-digit',
-							month: 'short',
-							year: 'numeric',
-						}),
+						createdAt: formatDate(),
+						updatedAt: formatDate(),
 					},
 				}),
 			);

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState, useCallback} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import ApiKeyForm from '../../components/dashboard/ApiKeyForm';
 import ApiKeyTable from '../../components/dashboard/ApiKeyTable';
 import CurrentPlan from '../../components/dashboard/CurrentPlan';
@@ -23,7 +23,7 @@ function Dashboard() {
 	const [copiedKey, setCopiedKey] = useState(null);
 	const [keys, setKeys] = useState([]);
 	const {userData, fetchUserData} = useContext(UserContext);
-	const {data, errorMsg, makeRequest, isSuccess} = useApi({
+	const {data, errorMsg, makeRequest, isSuccess, loading} = useApi({
 		url: `api/user/generate`,
 		method: 'post',
 		data: {keyDescription: inputValue},
@@ -102,10 +102,6 @@ function Dashboard() {
 		await makeRequest();
 	}
 
-	const handleDeleteKey = async (apiKeyId) => {
-		setDeletedKey(apiKeyId);
-	};
-
 	const handleCopyToClipboard = async (apiKey) => {
 		await navigator.clipboard.writeText(apiKey);
 		setCopiedKey(apiKey);
@@ -126,6 +122,7 @@ function Dashboard() {
 							inputValue={inputValue}
 							setInputValue={setInputValue}
 							errorMessage={errorMessage}
+							loading={loading}
 							setErrorMessage={setErrorMessage}
 							handleGenerateKey={handleGenerateKey}
 						/>
@@ -136,7 +133,7 @@ function Dashboard() {
 					keys={keys}
 					copiedKey={copiedKey}
 					handleCopyToClipboard={handleCopyToClipboard}
-					deleteKey={handleDeleteKey}
+					deleteKey={setDeletedKey}
 				/>
 			</div>
 		</div>

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -5,8 +5,8 @@ import CurrentPlan from '../../components/dashboard/CurrentPlan';
 import Usage from '../../components/dashboard/Usage';
 import {isLettersAndSpacesOnly} from '../../constants';
 import {UserContext} from '../../contexts/UserContext';
-import './Dashboard.css';
 import {useApi} from '../../hooks/useApi';
+import './Dashboard.css';
 
 function getUsedCalls(keys) {
 	let result = 0;
@@ -18,6 +18,7 @@ function getUsedCalls(keys) {
 
 function Dashboard() {
 	const [inputValue, setInputValue] = useState('');
+	const [deletedKey, setDeletedKey] = useState('');
 	const [errorMessage, setErrorMessage] = useState('');
 	const [copiedKey, setCopiedKey] = useState(null);
 	const [keys, setKeys] = useState([]);
@@ -26,6 +27,11 @@ function Dashboard() {
 		url: `api/user/generate`,
 		method: 'post',
 		data: {keyDescription: inputValue},
+	});
+	const {data: deleteKeyData, makeRequest: makeDeleteRequest} = useApi({
+		url: `api/user/destroy`,
+		method: 'delete',
+		params: {keyId: deletedKey},
 	});
 
 	useEffect(() => {
@@ -53,6 +59,20 @@ function Dashboard() {
 		}
 	}, [userData, isSuccess, errorMsg]);
 
+	useEffect(() => {
+		const deleteKeyFunction = async () => {
+			if (deletedKey) {
+				const success = await makeDeleteRequest();
+				if (success) {
+					setKeys(keys.filter((key) => key.keyId !== deletedKey));
+				} else {
+					setErrorMessage(deleteKeyData?.message);
+				}
+			}
+		};
+		deleteKeyFunction();
+	}, [deletedKey]);
+
 	async function handleGenerateKey(e) {
 		e.preventDefault();
 		if (inputValue.trim() === '') {
@@ -69,8 +89,8 @@ function Dashboard() {
 		await makeRequest();
 	}
 
-	const handleDeleteKey = (apiKey) => {
-		setKeys(keys.filter((key) => key.key !== apiKey));
+	const handleDeleteKey = async (apiKeyId) => {
+		setDeletedKey(apiKeyId);
 	};
 	const handleCopyToClipboard = async (apiKey) => {
 		await navigator.clipboard.writeText(apiKey);

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import Dashboard from './Dashboard';
 import {UserContext} from '../../contexts/UserContext';
+import {formatDate} from '../../utils/helpers';
 
 describe('Dashboard Component', () => {
 	const mockUserData = {
@@ -16,16 +17,8 @@ describe('Dashboard Component', () => {
 				key: '4d6544e38f5d4ad8bae546ea61e2b842',
 				usageCount: '0',
 				keyDescription: 'Demo Key',
-				updatedAt: new Date().toLocaleDateString('en-US', {
-					day: '2-digit',
-					month: 'short',
-					year: 'numeric',
-				}),
-				createdAt: new Date().toLocaleDateString('en-US', {
-					day: '2-digit',
-					month: 'short',
-					year: 'numeric',
-				}),
+				updatedAt: formatDate(),
+				createdAt: formatDate(),
 			},
 		],
 		subscription: {
@@ -84,16 +77,8 @@ describe('Dashboard Component', () => {
 					key: '4d6544e38f5d4ad8bae546ea61e2b842',
 					usageCount: '0',
 					keyDescription: 'Demo Key',
-					updatedAt: new Date().toLocaleDateString('en-US', {
-						day: '2-digit',
-						month: 'short',
-						year: 'numeric',
-					}),
-					createdAt: new Date().toLocaleDateString('en-US', {
-						day: '2-digit',
-						month: 'short',
-						year: 'numeric',
-					}),
+					updatedAt: formatDate(),
+					createdAt: formatDate(),
 				},
 			],
 			subscription: {
@@ -128,15 +113,7 @@ describe('Dashboard Component', () => {
 		const tableElement = screen.getByRole('table');
 		const keyRows = screen.queryAllByRole('row', {container: tableElement});
 		expect(keyRows).toHaveLength(3);
-		expect(
-			screen.getAllByText(
-				new Date().toLocaleDateString('en-US', {
-					day: 'numeric',
-					month: 'long',
-					year: 'numeric',
-				}),
-			),
-		).toHaveLength(2);
+		expect(screen.getAllByText(formatDate())).toHaveLength(2);
 		expect(descriptionInput).toHaveValue('');
 	});
 

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -71,7 +71,7 @@ describe('Dashboard Component', () => {
 		});
 	});
 
-	it('Tries to delete the key, but fails', async () => {
+	it('Delete API Key fails on wrong keyId', async () => {
 		const wrongKeyData = {
 			firstName: 'Anoop',
 			lastName: 'Singh',

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -71,6 +71,51 @@ describe('Dashboard Component', () => {
 		});
 	});
 
+	it('Tries to delete the key, but fails', async () => {
+		const wrongKeyData = {
+			firstName: 'Anoop',
+			lastName: 'Singh',
+			email: 'aps08@gmail.com',
+			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+			userType: 'CUSTOMER',
+			keys: [
+				{
+					keyId: 'LogoExecutive@007',
+					key: '4d6544e38f5d4ad8bae546ea61e2b842',
+					usageCount: '0',
+					keyDescription: 'Demo Key',
+					updatedAt: new Date().toLocaleDateString('en-US', {
+						day: '2-digit',
+						month: 'short',
+						year: 'numeric',
+					}),
+					createdAt: new Date().toLocaleDateString('en-US', {
+						day: '2-digit',
+						month: 'short',
+						year: 'numeric',
+					}),
+				},
+			],
+			subscription: {
+				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+				subscriptionType: 'HOBBY',
+				keyLimit: 2,
+				usageLimit: 500,
+				isActive: false,
+				createdAt: '2024-04-11T10:24:38.501Z',
+				updatedAt: '2024-04-11T10:24:38.501Z',
+			},
+		};
+		renderDashboard(wrongKeyData);
+		const deleteButton = screen.getAllByTestId('api-key-delete');
+		const deletedApiKeyDescription = screen.queryByText('Demo Key');
+		fireEvent.click(deleteButton[0]);
+		await waitFor(() => {
+			expect(screen.getByText('Key ID is required')).toBeInTheDocument();
+		});
+		expect(deletedApiKeyDescription).toBeInTheDocument();
+	});
+
 	it('generates API key and adds to the list', async () => {
 		renderDashboard();
 		const descriptionInput = screen.getByLabelText('Description For API Key');
@@ -139,17 +184,15 @@ describe('Dashboard Component', () => {
 				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
 				subscriptionType: 'HOBBY',
 				keyLimit: 2,
-				usageLimit: 400,
+				usageLimit: 0,
 				isActive: false,
 				createdAt: '2024-04-11T10:24:38.501Z',
 				updatedAt: '2024-04-11T10:24:38.501Z',
 			},
 		};
 		renderDashboard(mockNullData);
-		expect(screen.getByText('0 calls')).toBeInTheDocument();
-		expect(
-			screen.getByText(mockNullData.subscription.usageLimit + ' calls'),
-		).toHaveClass('data');
+		const zeroCalls = screen.getAllByText('0 calls');
+		expect(zeroCalls).toHaveLength(2);
 	});
 
 	it('Throws error when same key description is given again', async () => {

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -61,6 +61,16 @@ describe('Dashboard Component', () => {
 		expect(apiKeyTableComponent).toBeInTheDocument();
 	});
 
+	it('Delete API key and removes it from the list', async () => {
+		renderDashboard();
+		const deleteButton = screen.getAllByTestId('api-key-delete');
+		const deletedApiKeyDescription = screen.queryByText('Demo Key');
+		fireEvent.click(deleteButton[0]);
+		await waitFor(() => {
+			expect(deletedApiKeyDescription).not.toBeInTheDocument();
+		});
+	});
+
 	it('generates API key and adds to the list', async () => {
 		renderDashboard();
 		const descriptionInput = screen.getByLabelText('Description For API Key');
@@ -168,14 +178,6 @@ describe('Dashboard Component', () => {
 				),
 			).toBeInTheDocument();
 		});
-	});
-
-	it('Delete API key and remove from the list', () => {
-		renderDashboard();
-		const deleteButton = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(deleteButton[0]);
-		const deletedApiKeyDescription = screen.queryByText('Demo Key');
-		expect(deletedApiKeyDescription).not.toBeInTheDocument();
 	});
 
 	it('shows an error message when trying to generate a key without a description', async () => {

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -25,3 +25,12 @@ export const isValidMessage = (message) => {
 	const messageRegex = /^[^!@#$%^&*(){}[\]\\.;'",.<>/?`~|0-9]*$/;
 	return messageRegex.test(message);
 };
+
+export const formatDate = (dateString) => {
+	if (!dateString) return '';
+	return new Date(dateString).toLocaleDateString('en-us', {
+		month: 'long',
+		day: 'numeric',
+		year: 'numeric',
+	});
+};

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -27,8 +27,8 @@ export const isValidMessage = (message) => {
 };
 
 export const formatDate = (dateString) => {
-	if (!dateString) return '';
-	return new Date(dateString).toLocaleDateString('en-us', {
+	const date = dateString ? new Date(dateString) : new Date();
+	return date.toLocaleDateString('en-us', {
 		month: 'long',
 		day: 'numeric',
 		year: 'numeric',

--- a/client/src/utils/helpers.test.js
+++ b/client/src/utils/helpers.test.js
@@ -29,6 +29,12 @@ describe('Helper functions', () => {
 
 	test('formatDate', () => {
 		expect(formatDate('2024-05-23T07:23:21.816Z')).toBe('May 23, 2024');
-		expect(formatDate()).toBe('');
+		expect(formatDate()).toBe(
+			new Date().toLocaleDateString('en-us', {
+				month: 'long',
+				day: 'numeric',
+				year: 'numeric',
+			}),
+		);
 	});
 });

--- a/client/src/utils/helpers.test.js
+++ b/client/src/utils/helpers.test.js
@@ -3,6 +3,7 @@ import {
 	isValidPassword,
 	isSQLInjectionAttempt,
 	isValidMessage,
+	formatDate,
 } from './helpers';
 
 describe('Helper functions', () => {
@@ -24,5 +25,10 @@ describe('Helper functions', () => {
 	test('isValidMessage', () => {
 		expect(isValidMessage('Hello world')).toBeTruthy();
 		expect(isValidMessage('Invalid message 123!')).toBeFalsy();
+	});
+
+	test('formatDate', () => {
+		expect(formatDate('2024-05-23T07:23:21.816Z')).toBe('May 23, 2024');
+		expect(formatDate()).toBe('');
 	});
 });


### PR DESCRIPTION
**Issue**
#305 

**Description**
The `/destroy` API that deletes API key is now integrated with frontend. To test, login to dashboard, and click the bin icon to delete the corresponding API key. 

**Screenshots (Coverage)**
![deleteKey_coverage](https://github.com/TeamShiksha/logoexecutive/assets/46561984/7a833bd7-5230-4109-9274-12a416028f81)

**Screen Recording**

https://github.com/TeamShiksha/logoexecutive/assets/46561984/0c135590-dca6-46b9-a561-eef191c7a93b




