### PR TITLE
`test` Remove the firebase function mocks in services where not necessary

### DIFF
--- a/server/__tests__/unit/services/Users.js
+++ b/server/__tests__/unit/services/Users.js
@@ -10,17 +10,25 @@ const { emailRecordExists,
 const { UserCollection, db, SubscriptionCollection, KeyCollection } = require("../../../utils/firestore");
 const { Users } = require("../../../models");
 const { mockUsers } = require("../../../utils/mocks/Users");
+const { mockKeys } = require("../../../utils/mocks/Keys");
+const { mockSubscriptions } = require("../../../utils/mocks/Subscriptions");
 
 describe("emailRecordExists", () => {
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
+
   test("should return true if email exists in user collection", async () => {
-    const user = await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
+    await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
     const exists = await emailRecordExists(mockUsers[0].email);
+
     expect(exists).toBe(true);
   });
 
   test("should return false if email does not exist in user collection", async () => {
-    const user = await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
+    await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
     const exists = await emailRecordExists(mockUsers[1].email);
+
     expect(exists).toBe(false);
   });
 
@@ -29,6 +37,7 @@ describe("emailRecordExists", () => {
       get: jest.fn().mockResolvedValue({ empty: true })
     });
     const exists = await emailRecordExists(mockUsers[2].email);
+
     expect(exists).toBe(false);
   });
 
@@ -44,6 +53,10 @@ describe("emailRecordExists", () => {
 });
 
 describe("fetchUsers", () => {
+  afterEach(() => {
+    jest.clearAllMocks(); 
+  });
+
   it("should fetch all users from the user collection", async () => {
     const batch = db.batch();
     mockUsers.forEach((user) => {
@@ -52,23 +65,22 @@ describe("fetchUsers", () => {
     });
 
     await batch.commit();
-
     const result = await fetchUsers();
+
     expect(result.data.length).toBe(mockUsers.length);
     expect(result.data[0]).toBeInstanceOf(Users);
   });
 
   it("should handle empty user collection", async () => {
     jest.spyOn(UserCollection, "get").mockResolvedValueOnce({ docs: [] });
-
     const result = await fetchUsers();
+
     expect(result.data.length).toBe(0);
   });
 
   it("should fetch users from non-empty user collection", async () => {
-    jest.spyOn(UserCollection, "get").mockResolvedValueOnce({ docs: mockUsers.map(user => ({ id: user.userId, data: () => user })) });
-
     const result = await fetchUsers();
+
     expect(result.data.length).toBe(mockUsers.length);
     for (let user = 0; user < mockUsers.length; user++) {
       expect(result.data[user].email).toBe(mockUsers[user].email);
@@ -85,15 +97,14 @@ describe("fetchUsers", () => {
 });
 
 describe("fetchUserByEmail", () => {
+  afterEach(() => {
+    jest.clearAllMocks(); 
+  });
+
   it("should fetch user by email from the user collection", async () => {
     await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
-    jest.spyOn(UserCollection, "where").mockReturnValue({
-      limit: jest.fn().mockReturnValue({
-        get: jest.fn().mockResolvedValue({ empty: false, docs: [{ data: () => mockUsers[0] }] }),
-      }),
-    });
-
     const user = await fetchUserByEmail(mockUsers[0].email);
+
     expect(user).toBeInstanceOf(Users);
     expect(user.userId).toBe(mockUsers[0].userId);
   });
@@ -105,11 +116,10 @@ describe("fetchUserByEmail", () => {
         get: jest.fn().mockResolvedValue(mockUserRef),
       }),
     });
-
     const user = await fetchUserByEmail(mockUsers[1].email);
+
     expect(user).toBeNull();
   });
-
 
   test("should return false if the query result is empty", async () => {
     const mockUserRef = { empty: true };
@@ -117,6 +127,7 @@ describe("fetchUserByEmail", () => {
       get: jest.fn().mockResolvedValueOnce(mockUserRef),
     });
     const exists = await emailRecordExists(mockUsers[2].email);
+
     expect(exists).toBe(false);
   });
 
@@ -133,9 +144,13 @@ describe("fetchUserByEmail", () => {
 });
 
 describe("createUser", () => {
-  it("should create a user in the database and return the created user object", async () => {
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
 
+  it("should create a user in the database and return the created user object", async () => {
     const createdUser = await createUser(mockUsers[0]);
+
     expect(createdUser).toBeInstanceOf(Users);
     expect(createdUser.email).toBe(mockUsers[0].email);
   });
@@ -146,18 +161,15 @@ describe("createUser", () => {
     jest.spyOn(UserCollection, "doc").mockReturnValueOnce({
       set: jest.fn().mockResolvedValueOnce(null),
     });
-
     delete mockUser.email;
-
     const createdUser = await createUser(mockUser);
+
     expect(createdUser).toBeNull();
   });
 
   it("should return null if data is improper", async () => {
-    const mockUser = mockUsers[0];
-    jest.spyOn(Users, "NewUser").mockReturnValueOnce(null);
+    const createdUser = await createUser(mockUsers[0]);
 
-    const createdUser = await createUser(mockUser);
     expect(createdUser).toBeNull();
   });
 
@@ -172,11 +184,14 @@ describe("createUser", () => {
 });
 
 describe("updatePasswordbyUser", () => {
-  it("should update user password in the database", async () => {
-    const mockUserRef = { update: jest.fn().mockResolvedValue(true) };
-    jest.spyOn(UserCollection, "doc").mockReturnValue(mockUserRef);
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
 
+  it("should update user password in the database", async () => {
+    const mockUserRef = UserCollection.doc(mockUsers[0].userId);
     const updated = await updatePasswordbyUser({ userRef: mockUserRef }, "newhashedpassword");
+
     expect(updated).toBe(true);
   });
 
@@ -191,32 +206,21 @@ describe("updatePasswordbyUser", () => {
 });
 
 describe("fetchUserFromId", () => {
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
+
   it("should fetch user by user ID from the user collection", async () => {
     const mockUserId = mockUsers[0].userId;
-    const mockUserSnapshot = {
-      empty: false,
-      docs: [{ data: () => ({ userId: mockUserId }) }],
-    };
-    jest.spyOn(UserCollection, "where").mockReturnValueOnce({
-      limit: jest.fn().mockReturnValueOnce({
-        get: jest.fn().mockResolvedValueOnce(mockUserSnapshot),
-      }),
-    });
-
     const user = await fetchUserFromId(mockUserId);
+
     expect(user).toBeInstanceOf(Users);
     expect(user.userId).toBe(mockUserId);
   });
 
   it("should return null if user does not exist for the provided user ID", async () => {
-    const mockUserSnapshot = { empty: true };
-    jest.spyOn(UserCollection, "where").mockReturnValueOnce({
-      limit: jest.fn().mockReturnValueOnce({
-        get: jest.fn().mockResolvedValueOnce(mockUserSnapshot),
-      }),
-    });
-
     const user = await fetchUserFromId("nonexistentUserId");
+
     expect(user).toBeNull();
   });
 
@@ -230,26 +234,28 @@ describe("fetchUserFromId", () => {
 });
 
 describe("verifyUser", () => {
-  it("should verify user in the database", async () => {
-    const mockUserRef = { update: jest.fn().mockResolvedValueOnce(true) };
-    jest.spyOn(UserCollection, "doc").mockReturnValueOnce(mockUserRef);
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
 
-    const verified = await verifyUser({ userRef: mockUserRef });
+  it("should verify user in the database", async () => {
+    const userRef = await UserCollection.doc(mockUsers[0].userId);
+    const verified = await verifyUser({ userRef: userRef });
+
     expect(verified).toBe(true);
   });
 
   it("should return false if verification fails", async () => {
     const mockUserRef = { update: jest.fn().mockResolvedValueOnce(false) };
     jest.spyOn(UserCollection, "doc").mockReturnValueOnce(mockUserRef);
-
     const verified = await verifyUser({ userRef: mockUserRef });
+
     expect(verified).toBe(false);
   });
 
   it("should throw an error if an error occurs while verifying user", async () => {
     const errorMessage = "Firestore operation failed";
     const mockUserRef = { update: jest.fn().mockRejectedValueOnce(new Error(errorMessage)) };
-
     const user = { userRef: mockUserRef };
 
     await expect(verifyUser(user)).rejects.toThrow(errorMessage);
@@ -258,19 +264,21 @@ describe("verifyUser", () => {
 });
 
 describe("updateUser", () => {
-  it("should update user profile in the database", async () => {
-    const mockUserRef = { update: jest.fn().mockResolvedValueOnce(true) };
-    jest.spyOn(UserCollection, "doc").mockReturnValueOnce(mockUserRef);
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
 
-    const updated = await updateUser(["NewFirstName", "NewLastName"], { userRef: mockUserRef });
+  it("should update user profile in the database", async () => {
+    const mockUserRef = await UserCollection.doc(mockUsers[0].userId);
+    const updated = await updateUser({firstName:"NewFirstName",lastName:"NewLastName"}, { userRef: mockUserRef });
+
     expect(updated).toBe(true);
   });
 
   it("should return false if update fails", async () => {
     const mockUserRef = { update: jest.fn().mockResolvedValueOnce(false) };
-    jest.spyOn(UserCollection, "doc").mockReturnValueOnce(mockUserRef);
+    const updated = await updateUser({firstName:"NewFirstName",lastName:"NewLastName"}, { userRef: mockUserRef });
 
-    const updated = await updateUser(["NewFirstName", "NewLastName"], { userRef: mockUserRef });
     expect(updated).toBe(false);
   });
 
@@ -286,15 +294,32 @@ describe("updateUser", () => {
 });
 
 describe("deleteUserAccount", () => {
-  it("should delete user account and related data from the database", async () => {
-    const mockTransaction = {
-      delete: jest.fn(),
-    };
-    jest.spyOn(db, "runTransaction").mockImplementationOnce(async (callback) => {
-      await callback(mockTransaction);
-    });
-    await expect(deleteUserAccount(mockUsers[0].userId)).resolves.not.toThrow();
+  afterEach(() => {
+    jest.restoreAllMocks(); 
+  });
 
+  test("should delete key documents successfully", async () => {
+    const userId = "0c1266ab-8ad2-4ab9-b56c-e1db6982f12";
+    await KeyCollection.doc(mockKeys[0].keyId).set(mockKeys[0]);
+    const keySnapshot = await KeyCollection.where("userId", "==", userId).get();
+    await deleteUserAccount(userId);
+    
+    expect(keySnapshot.empty).toBe(true);
+  });
+
+  it("should delete user account and related data from multiple collections within a Firestore transaction", async () => {
+    const userId = mockUsers[0].userId;
+    await UserCollection.doc(mockUsers[0].userId).set(mockUsers[0]);
+    await KeyCollection.doc(mockKeys[0].keyId).set(mockKeys[0]);
+    await SubscriptionCollection.doc(mockSubscriptions[0].subscriptionId).set(mockSubscriptions[0]);
+    await deleteUserAccount(userId);
+    const userSnapshot = await UserCollection.where("userId", "==", userId).get();
+    const subscriptionSnapshot = await SubscriptionCollection.where("userId", "==", userId).get();
+    const keySnapshot = await KeyCollection.where("userId", "==", userId).get();
+
+    expect(userSnapshot.empty).toBe(true);
+    expect(subscriptionSnapshot.empty).toBe(true);
+    expect(keySnapshot.empty).toBe(true);
   });
 
   it("should throw an error if Firestore operation fails", async () => {
@@ -305,62 +330,4 @@ describe("deleteUserAccount", () => {
     await expect(deleteUserAccount(mockUsers[0].userId)).rejects.toThrow("Firestore transaction failed");
   });
 
-  it("should delete user account and related data from multiple collections within a Firestore transaction", async () => {
-    const userId = "mockUserId";
-    const mockUserDocRef = { delete: jest.fn() };
-    const mockUserSnapshot = {
-      empty: false,
-      docs: [{ ref: mockUserDocRef }],
-    };
-
-    const mockSubscriptionDocs = [{ ref: { delete: jest.fn() } }];
-    const mockSubscriptionSnapshot = {
-      forEach: (callback) => {
-        mockSubscriptionDocs.forEach(callback);
-      },
-    };
-
-    const mockKeyDocs = [{ ref: { delete: jest.fn() } }];
-    const mockKeySnapshot = {
-      empty: false,
-      forEach: (callback) => {
-        mockKeyDocs.forEach(callback);
-      },
-    };
-
-    jest.spyOn(UserCollection, "where").mockReturnValueOnce({
-      limit: jest.fn().mockReturnValue({
-        get: jest.fn().mockResolvedValue(mockUserSnapshot),
-      }),
-    });
-
-    jest.spyOn(SubscriptionCollection, "where").mockReturnValueOnce({
-      get: jest.fn().mockResolvedValueOnce(mockSubscriptionSnapshot),
-    });
-
-    jest.spyOn(KeyCollection, "where").mockReturnValueOnce({
-      get: jest.fn().mockResolvedValueOnce(mockKeySnapshot),
-    });
-
-    jest.spyOn(db, "runTransaction").mockImplementationOnce(async (callback) => {
-      const mockTransaction = { delete: jest.fn() };
-      await callback(mockTransaction);
-
-      expect(mockTransaction.delete).toHaveBeenCalledWith(mockUserDocRef);
-      mockSubscriptionDocs.forEach((doc) => {
-        expect(mockTransaction.delete).toHaveBeenCalledWith(doc.ref);
-      });
-      mockKeyDocs.forEach((doc) => {
-        expect(mockTransaction.delete).toHaveBeenCalledWith(doc.ref);
-      });
-    });
-
-    await deleteUserAccount(userId);
-
-    expect(UserCollection.where).toHaveBeenCalledWith("userId", "==", userId);
-    expect(SubscriptionCollection.where).toHaveBeenCalledWith("userId", "==", userId);
-    expect(KeyCollection.where).toHaveBeenCalledWith("userId", "==", userId);
-  });
-
 });
-


### PR DESCRIPTION
### Summary

closes #298 

### Description

Enhanced the tests for **services/UserToken** and **services/Users** by removing the mocks of firebase functions (i.e: get, docs, where, etc.) where not necessary.

### How to Test the Changes

`yarn test:server`

### Screenshots or Recordings (Optional)

<img width="741" alt="Screenshot 2024-05-26 at 9 24 52 AM" src="https://github.com/TeamShiksha/logoexecutive/assets/145339995/f7de608b-fd40-4bdf-85c1-d6c300fd24f5">
<img width="376" alt="Screenshot 2024-05-26 at 10 46 50 AM" src="https://github.com/TeamShiksha/logoexecutive/assets/145339995/86e2e62b-11ae-44e2-83c5-be96b5cb99f5">

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
