### PR TITLE
Implement Admin dashboard only accessible to userType: ADMIN.

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -49,7 +49,7 @@ function App() {
 				<Route
 					path='/admin'
 					element={
-						<ProtectedRoute>
+						<ProtectedRoute adminOnly={true}>
 							<AdminDashboard />
 						</ProtectedRoute>
 					}

--- a/client/src/utils/ProtectedRoute.js
+++ b/client/src/utils/ProtectedRoute.js
@@ -1,11 +1,33 @@
 import PropTypes from 'prop-types';
-import {useContext} from 'react';
+import {useContext, useEffect} from 'react';
 import {AuthContext} from '../contexts/AuthContext';
 import {Navigate, useLocation} from 'react-router';
+import {UserContext} from '../contexts/UserContext';
+import Spinner from '../components/spinner/Spinner';
 
-function ProtectedRoute({children}) {
+function ProtectedRoute({adminOnly, children}) {
 	const {isAuthenticated} = useContext(AuthContext);
+	const {userData, loading, fetchUserData} = useContext(UserContext);
 	const location = useLocation();
+
+	useEffect(() => {
+		if (adminOnly && isAuthenticated && (loading || !userData)) {
+			fetchUserData();
+		}
+	}, []);
+
+	if (adminOnly && isAuthenticated && (loading || !userData)) {
+		return <Spinner />;
+	}
+
+	if (adminOnly && isAuthenticated) {
+		if (userData.userType === 'ADMIN') {
+			return children;
+		} else {
+			return <Navigate to='/welcome' replace={true} />;
+		}
+	}
+
 	return isAuthenticated ? (
 		children
 	) : (
@@ -15,6 +37,7 @@ function ProtectedRoute({children}) {
 
 ProtectedRoute.propTypes = {
 	children: PropTypes.node.isRequired,
+	adminOnly: PropTypes.bool,
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
### Summary
closes #311 
Implemented Admin dashboard only accessible to userType: ADMIN.
<!-- Provide a general summary of your changes in the Title above -->

### Description

Modified the ProtectedRoute utility component to accept an `adminOnly` prop. When set to `true`, the component will check if the authenticated user's `userType` is `'ADMIN'`. 
If the user is an admin, they will be granted access to the protected route. 
If the user is not an admin, they will be redirected to the `/welcome` route. 
If the user is not authenticated, they will be redirected to Signin page.

<!-- Describe your changes in detail. Include the task or issue that this PR resolves, if applicable. -->

### How to Test the Changes
1. Sign in as a non-admin user.
2. Attempt to navigate to the `/admin` route. You should be redirected to the `/welcome` route.
3. Sign in as an admin user.
4. Navigate to the `/admin` route. You should be able to access the Admin Dashboard.
<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Context (Optional)

<!-- Provide any additional context about the problem or feature here. -->

### Screenshots or Recordings (Optional)

https://github.com/TeamShiksha/logoexecutive/assets/88454618/75998e5b-2fcc-4372-9f49-a392ca6f645a

![protected-route-coverage](https://github.com/TeamShiksha/logoexecutive/assets/88454618/b114238e-1a2d-434e-b6fa-b711947c6a4d)

<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
