### PR TITLE
updating the subscription test cases

### DIFF
--- a/server/__tests__/unit/services/Subscriptions.js
+++ b/server/__tests__/unit/services/Subscriptions.js
@@ -5,40 +5,34 @@ const {
 
 const { mockUsers } = require("../../../utils/mocks/Users");
 const { SubscriptionCollection } = require("../../../utils/firestore");
+const { Subscriptions } = require("../../../models");
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 describe("createSubscription", () => {
   test("should create a subscription collection of a user", async () => {
     const createdSubscription = await createSubscription(mockUsers[0].userId);
-    expect(createdSubscription.subscriptionId).toBeTruthy();
+    expect(createdSubscription).toBeInstanceOf(Subscriptions);
   });
 
   test("should throw an error if an error ocurrs while creating a subscription", async () => {
     const errorMessage = "Firestore operation failed";
-
     jest.spyOn(SubscriptionCollection, "doc").mockReturnValueOnce({
       set: jest.fn().mockRejectedValue(new Error(errorMessage)),
     });
-
-    await expect(createSubscription(mockUsers[0].userId)).rejects.toThrow(
-      errorMessage
-    );
+    await expect(createSubscription(mockUsers[0].userId)).rejects.toThrow(errorMessage);
   });
 });
 
 describe("fetchSubscriptionByuserid", () => {
   test("should return subscription for user if userid matches", async () => {
-    const fetchUsersSubscription = await fetchSubscriptionByuserid(
-      mockUsers[0].userId
-    );
-    expect(fetchUsersSubscription.subscriptionId).toBeTruthy();
+    await createSubscription(mockUsers[0].userId);
+    const fetchUsersSubscription = await fetchSubscriptionByuserid(mockUsers[0].userId);
+    expect(fetchUsersSubscription).toBeInstanceOf(Subscriptions);
   });
 
   test("should return null if userid does not match", async () => {
-    jest.spyOn(SubscriptionCollection, "where").mockReturnValue({
-      limit: jest.fn().mockReturnValueOnce({
-        get: jest.fn().mockResolvedValueOnce({ empty: true }),
-      }),
-    });
     const value = await fetchSubscriptionByuserid(mockUsers[1].userId);
     expect(value).toBeNull();
   });
@@ -51,9 +45,6 @@ describe("fetchSubscriptionByuserid", () => {
         get: jest.fn().mockRejectedValue(new Error(errorMessage)),
       }),
     });
-
-    await expect(
-      fetchSubscriptionByuserid(mockUsers[0].userId)
-    ).rejects.toThrow(errorMessage);
+    await expect(fetchSubscriptionByuserid(mockUsers[0].userId)).rejects.toThrow(errorMessage);
   });
 });


### PR DESCRIPTION
### Description
Test cases for the Subscription services on the server-side. These test cases will evaluate the following functions:

Function Overview of Admin Service:
1 `createSubscription`
- This function is responsible for creating a new subscription for a user
2 `fetchSubscriptionByuserid`
- This function retrieves the subscription details of a user based on their userId
I have written test cases for the Subscription service to make a subscription. The test cases I wrote are:
1 `createSubscription`

- `Create Subscription` It will try to create a subscription and return the instance Of Subscription on Success
- `Firestore Operation Fails`: Verifies that the function throws an error if there is a failure in the Firestore operation.

2 `fetchSubscriptionByuserid`

- `Fetch Subscription By userId` It will return the instance Of Subscription if it exists for the user
- `Fetch Subscription By userId` Return null if subscription does not exist for that user
- `Firestore Operation Fails`: Verifies that the function throws an error if there is a failure in the Firestore operation.

### How to Test the Changes

1. Navigate to the root directory.
2. Run the command:
```bash
yarn test:server
```

### Screenshots or Recordings 
![Screenshot 2024-05-31 191712](https://github.com/TeamShiksha/logoexecutive/assets/65087180/5b1ced2b-c6da-460b-9d04-0db5d0eddf93)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
