### PR TITLE
feat:show confirmation modal on click of delete api key button

### DIFF
--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -10,7 +10,7 @@ function Modal({
 	showButtons,
 	containerClassName,
 	showCloseIcon = true,
-	loading=false,
+	loading = false,
 }) {
 	const closeModal = () => setModal(false);
 	const stopPropagation = (event) => event.stopPropagation();

--- a/client/src/components/common/modal/Modal.js
+++ b/client/src/components/common/modal/Modal.js
@@ -10,7 +10,7 @@ function Modal({
 	showButtons,
 	containerClassName,
 	showCloseIcon = true,
-	loading,
+	loading=false,
 }) {
 	const closeModal = () => setModal(false);
 	const stopPropagation = (event) => event.stopPropagation();

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -3,8 +3,24 @@ import {FiCopy} from 'react-icons/fi';
 import {LuCopyCheck} from 'react-icons/lu';
 import {MdDeleteOutline} from 'react-icons/md';
 import {formatDate} from '../../utils/helpers';
-
+import Modal from '../common/modal/Modal';
+import { useRef, useState } from 'react';
 function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
+
+	const apiKeyToBeDeleted = useRef(null);
+	const [modalOpen, setModalOpen] = useState(false);
+
+	const showConfirmationModal = (keyId) => {
+		apiKeyToBeDeleted.current = keyId;
+		setModalOpen(true);
+	}
+
+	const confirmActionHandler = () => {
+		setModalOpen(false);
+		deleteKey(apiKeyToBeDeleted.current);
+		apiKeyToBeDeleted.current = null;
+	}
+
 	return (
 		<section className='dashboard-content-section'>
 			<div className='dashboard-content-item api-key-table'>
@@ -51,7 +67,7 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 									<button
 										className='api-key-delete-button'
 										data-testid='api-key-delete'
-										onClick={() => deleteKey(key.keyId)}
+										onClick={() => showConfirmationModal(key.keyId)}
 									>
 										<MdDeleteOutline />
 									</button>
@@ -62,6 +78,17 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 					</tbody>
 				</table>
 			</div>
+			<Modal
+				modalOpen={modalOpen}
+				setModal={setModalOpen}
+				showButtons={true}
+				handleConfirm={confirmActionHandler}
+			>
+				<h2>Are you sure?</h2>
+				<p className='settings-confirm-message'>
+					Please confirm that you want to delete this permanently, as this action cannot be undone.
+				</p>
+			</Modal>
 		</section>
 	);
 }

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -4,22 +4,21 @@ import {LuCopyCheck} from 'react-icons/lu';
 import {MdDeleteOutline} from 'react-icons/md';
 import {formatDate} from '../../utils/helpers';
 import Modal from '../common/modal/Modal';
-import { useRef, useState } from 'react';
+import {useRef, useState} from 'react';
 function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
-
 	const apiKeyToBeDeleted = useRef(null);
 	const [modalOpen, setModalOpen] = useState(false);
 
 	const showConfirmationModal = (keyId) => {
 		apiKeyToBeDeleted.current = keyId;
 		setModalOpen(true);
-	}
+	};
 
 	const confirmActionHandler = () => {
 		setModalOpen(false);
 		deleteKey(apiKeyToBeDeleted.current);
 		apiKeyToBeDeleted.current = null;
-	}
+	};
 
 	return (
 		<section className='dashboard-content-section'>
@@ -86,7 +85,8 @@ function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
 			>
 				<h2>Are you sure?</h2>
 				<p className='settings-confirm-message'>
-					Please confirm that you want to delete this permanently, as this action cannot be undone.
+					Please confirm that you want to delete this permanently, as this
+					action cannot be undone.
 				</p>
 			</Modal>
 		</section>

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -65,12 +65,12 @@ describe('ApiKeyTable', () => {
 
 	it('show confirmation modal when delete button is clicked', () => {
 		render(
-		  <ApiKeyTable
-			keys={keys}
-			copiedKey=""
-			handleCopyToClipboard={() => {}}
-			deleteKey={() => {}}
-		  />
+			<ApiKeyTable
+				keys={keys}
+				copiedKey=''
+				handleCopyToClipboard={() => {}}
+				deleteKey={() => {}}
+			/>,
 		);
 		const buttons = screen.getAllByTestId('api-key-delete');
 		fireEvent.click(buttons[0]);
@@ -79,12 +79,12 @@ describe('ApiKeyTable', () => {
 
 	it('close the confirmation modal when cancel button is clicked in modal', () => {
 		render(
-		  <ApiKeyTable
-			keys={keys}
-			copiedKey=""
-			handleCopyToClipboard={() => {}}
-			deleteKey={() => {}}
-		  />
+			<ApiKeyTable
+				keys={keys}
+				copiedKey=''
+				handleCopyToClipboard={() => {}}
+				deleteKey={() => {}}
+			/>,
 		);
 
 		const buttons = screen.getAllByTestId('api-key-delete');
@@ -98,12 +98,12 @@ describe('ApiKeyTable', () => {
 	it('remove key when delete is confirmed', () => {
 		const deleteKey = jest.fn();
 		render(
-		  <ApiKeyTable
-			keys={keys}
-			copiedKey=""
-			handleCopyToClipboard={() => {}}
-			deleteKey={deleteKey}
-		  />
+			<ApiKeyTable
+				keys={keys}
+				copiedKey=''
+				handleCopyToClipboard={() => {}}
+				deleteKey={deleteKey}
+			/>,
 		);
 
 		const buttons = screen.getAllByTestId('api-key-delete');
@@ -118,12 +118,12 @@ describe('ApiKeyTable', () => {
 	it('does not remove key when delete is cancelled', () => {
 		const deleteKey = jest.fn();
 		render(
-		  <ApiKeyTable
-			keys={keys}
-			copiedKey=""
-			handleCopyToClipboard={() => {}}
-			deleteKey={deleteKey}
-		  />
+			<ApiKeyTable
+				keys={keys}
+				copiedKey=''
+				handleCopyToClipboard={() => {}}
+				deleteKey={deleteKey}
+			/>,
 		);
 
 		const buttons = screen.getAllByTestId('api-key-delete');

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -63,19 +63,74 @@ describe('ApiKeyTable', () => {
 		expect(screen.getByTestId('api-key-copied')).toBeInTheDocument();
 	});
 
-	it('Removes key when delete is clicked', () => {
-		const deleteKey = jest.fn();
+	it('show confirmation modal when delete button is clicked', () => {
 		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={deleteKey}
-			/>,
+		  <ApiKeyTable
+			keys={keys}
+			copiedKey=""
+			handleCopyToClipboard={() => {}}
+			deleteKey={() => {}}
+		  />
+		);
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		expect(screen.getByText(/Are you sure?/i)).toBeInTheDocument();
+	});
+
+	it('close the confirmation modal when cancel button is clicked in modal', () => {
+		render(
+		  <ApiKeyTable
+			keys={keys}
+			copiedKey=""
+			handleCopyToClipboard={() => {}}
+			deleteKey={() => {}}
+		  />
 		);
 
 		const buttons = screen.getAllByTestId('api-key-delete');
 		fireEvent.click(buttons[0]);
+		const modalTitle = screen.getByText(/Are you sure?/i);
+		const cancelButton = screen.getByText(/Cancel/i);
+		fireEvent.click(cancelButton);
+		expect(modalTitle).not.toBeInTheDocument();
+	});
+
+	it('remove key when delete is confirmed', () => {
+		const deleteKey = jest.fn();
+		render(
+		  <ApiKeyTable
+			keys={keys}
+			copiedKey=""
+			handleCopyToClipboard={() => {}}
+			deleteKey={deleteKey}
+		  />
+		);
+
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		const confirmButton = screen.getByText(/Okay/i);
+
+		fireEvent.click(confirmButton);
 		expect(deleteKey).toHaveBeenCalledWith('id1');
+		expect(deleteKey).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not remove key when delete is cancelled', () => {
+		const deleteKey = jest.fn();
+		render(
+		  <ApiKeyTable
+			keys={keys}
+			copiedKey=""
+			handleCopyToClipboard={() => {}}
+			deleteKey={deleteKey}
+		  />
+		);
+
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		const cancelButton = screen.getByText(/Cancel/i);
+
+		fireEvent.click(cancelButton);
+		expect(deleteKey).not.toHaveBeenCalled();
 	});
 });

--- a/client/src/contexts/ScrollContext.test.js
+++ b/client/src/contexts/ScrollContext.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, act} from '@testing-library/react';
+import {render} from '@testing-library/react';
 import {MemoryRouter, Routes, Route} from 'react-router-dom';
 import {ScrollProvider} from './ScrollContext';
 
@@ -38,9 +38,7 @@ describe('ScrollContext', () => {
 		location = {pathname: '/new-path'};
 		useLocation.mockReturnValue(location);
 
-		act(() => {
-			rerender(<App path='/new-path' />);
-		});
+		rerender(<App path='/new-path' />);
 
 		expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
 	});

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -59,6 +59,8 @@ describe('Dashboard Component', () => {
 		const deleteButton = screen.getAllByTestId('api-key-delete');
 		const deletedApiKeyDescription = screen.queryByText('Demo Key');
 		fireEvent.click(deleteButton[0]);
+		const confirmButton = screen.getByText(/Okay/i);
+		fireEvent.click(confirmButton);
 		await waitFor(() => {
 			expect(deletedApiKeyDescription).not.toBeInTheDocument();
 		});
@@ -95,6 +97,8 @@ describe('Dashboard Component', () => {
 		const deleteButton = screen.getAllByTestId('api-key-delete');
 		const deletedApiKeyDescription = screen.queryByText('Demo Key');
 		fireEvent.click(deleteButton[0]);
+		const confirmButton = screen.getByText(/Okay/i);
+		fireEvent.click(confirmButton);
 		await waitFor(() => {
 			expect(screen.getByText('Key ID is required')).toBeInTheDocument();
 		});


### PR DESCRIPTION
### Summary

Fixes issue [#342](https://github.com/TeamShiksha/logoexecutive/issues/342)

### Description

Added confirmation alert on click of delete action button and -
- if user confirms, then API key is deleted
- if user declined confirmation, it does not delete API key

### How to Test the Changes

1. Clone the repository and switch to the branch(feat-add-confirmation-on-delete-apikey) where this PR is made-
```
git clone https://github.com/TeamShiksha/logoexecutive.git
cd logoexecutive
git checkout <branch-name>
```

2. Go to the project directory and ensure Yarn is installed and dependencies are up-to-date & run below command
```
yarn install
```
3. Configure env and required stuffs to run project according to [Development guide](https://github.com/TeamShiksha/logoexecutive/blob/dev/docs/DEVELOPMENT.md)

4. Start the application
```
yarn start
```

5. Login to account and navigate to dashboard. Now create API keys and click on delete action button and verify if it shows confirmation modal or not.

### Context (Optional)
Clicking on delete action button does not display any confirmation alert to the user.

### Screenshots or Recordings (Optional)
![Test cases](https://github.com/user-attachments/assets/5375ea66-07d3-4038-a68a-28958d97f071)

[![Watch the video](https://github.com/user-attachments/assets/5375ea66-07d3-4038-a68a-28958d97f071)](https://github.com/user-attachments/assets/327b3f28-6bdf-4822-aad2-9babcc7d8473)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [x] I have tested the changes locally and they work as expected.
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] This pull request follows the project's coding guidelines.
