### PR TITLE
Implements One-time API Key View/Copy 

### DIFF
--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -1,0 +1,46 @@
+import { IoMdClose } from 'react-icons/io';
+import PropTypes from 'prop-types';
+import { FaCopy, FaEye, FaEyeSlash } from 'react-icons/fa';
+import { useState } from 'react';
+
+function ApiKey({ Key, handleCloseKey, handleCopyToClipboard }) {
+  const [hideKey, setHideKey] = useState(true);
+  return (
+    <div className='dashboard-content-item'>
+      <div className='current-plan-header'>
+        <p className='api-key-warning'>
+          Make sure to copy your API KEY now. You won’t be able to see it again!
+        </p>
+
+        <button className='api-key-buttons' onClick={() => handleCloseKey()}>
+          <IoMdClose />
+        </button>
+      </div>
+      <div className='api-key-div dashboard-content-item'>
+        <p>{hideKey ? '*******************' : Key}</p>
+        <div className='api-key-buttons-div'>
+          <button
+            className='api-key-buttons'
+            onClick={() => setHideKey(!hideKey)}
+          >
+            {hideKey ? <FaEye /> : <FaEyeSlash />}{' '}
+            {/* Replace with appropriate icons */}
+          </button>
+          <button
+            className='api-key-buttons'
+            onClick={() => handleCopyToClipboard(Key)}
+          >
+            <FaCopy />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+ApiKey.propTypes = {
+  Key: PropTypes.string.isRequired,
+  handleCloseKey: PropTypes.func.isRequired,
+  handleCopyToClipboard: PropTypes.func.isRequired,
+};
+
+export default ApiKey;

--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -4,21 +4,21 @@ import {FaCopy} from 'react-icons/fa';
 
 function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
 	return (
-		<div className='dashboard-content-item'>
-			<div className='current-plan-header'>
+		<div className='api-key-container-main'>
+			<div className='api-key-header'>
 				<p className='api-key-warning'>
 					Make sure to copy your API KEY now. You won’t be able to see it again!
 				</p>
 
 				<button
-					className='api-key-buttons'
+					className='api-key-buttons close-btn-ak'
 					onClick={() => handleCloseKey()}
 					aria-label='Close'
 				>
 					<IoMdClose />
 				</button>
 			</div>
-			<div className='api-key-div dashboard-content-item'>
+			<div className='api-key-div '>
 				<p>*******************</p>
 				<div className='api-key-buttons-div'>
 					<button

--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -1,51 +1,42 @@
-import {IoMdClose} from 'react-icons/io';
+import { IoMdClose } from 'react-icons/io';
 import PropTypes from 'prop-types';
-import {FaCopy, FaEye, FaEyeSlash} from 'react-icons/fa';
-import {useState} from 'react';
+import { FaCopy, } from 'react-icons/fa';
 
-function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
-	const [hideKey, setHideKey] = useState(true);
-	return (
-		<div className='dashboard-content-item'>
-			<div className='current-plan-header'>
-				<p className='api-key-warning'>
-					Make sure to copy your API KEY now. You won’t be able to see it again!
-				</p>
+function ApiKey({ Key, handleCloseKey, handleCopyToClipboard }) {
+  return (
+    <div className='dashboard-content-item'>
+      <div className='current-plan-header'>
+        <p className='api-key-warning'>
+          Make sure to copy your API KEY now. You won’t be able to see it again!
+        </p>
 
-				<button
-					className='api-key-buttons'
-					onClick={() => handleCloseKey()}
-					aria-label='Close'
-				>
-					<IoMdClose />
-				</button>
-			</div>
-			<div className='api-key-div dashboard-content-item'>
-				<p>{hideKey ? '*******************' : Key}</p>
-				<div className='api-key-buttons-div'>
-					<button
-						className='api-key-buttons'
-						onClick={() => setHideKey(!hideKey)}
-						aria-label='Show/Hide API Key'
-					>
-						{hideKey ? <FaEye /> : <FaEyeSlash />}{' '}
-					</button>
-					<button
-						className='api-key-buttons'
-						onClick={() => handleCopyToClipboard(Key)}
-						aria-label='Copy API Key'
-					>
-						<FaCopy />
-					</button>
-				</div>
-			</div>
-		</div>
-	);
+        <button
+          className='api-key-buttons'
+          onClick={() => handleCloseKey()}
+          aria-label='Close'
+        >
+          <IoMdClose />
+        </button>
+      </div>
+      <div className='api-key-div dashboard-content-item'>
+        <p>*******************</p>
+        <div className='api-key-buttons-div'>
+          <button
+            className='api-key-buttons'
+            onClick={() => handleCopyToClipboard(Key)}
+            aria-label='Copy API Key'
+          >
+            <FaCopy />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 ApiKey.propTypes = {
-	Key: PropTypes.string.isRequired,
-	handleCloseKey: PropTypes.func.isRequired,
-	handleCopyToClipboard: PropTypes.func.isRequired,
+  Key: PropTypes.string.isRequired,
+  handleCloseKey: PropTypes.func.isRequired,
+  handleCopyToClipboard: PropTypes.func.isRequired,
 };
 
 export default ApiKey;

--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -1,42 +1,42 @@
-import { IoMdClose } from 'react-icons/io';
+import {IoMdClose} from 'react-icons/io';
 import PropTypes from 'prop-types';
-import { FaCopy, } from 'react-icons/fa';
+import {FaCopy} from 'react-icons/fa';
 
-function ApiKey({ Key, handleCloseKey, handleCopyToClipboard }) {
-  return (
-    <div className='dashboard-content-item'>
-      <div className='current-plan-header'>
-        <p className='api-key-warning'>
-          Make sure to copy your API KEY now. You won’t be able to see it again!
-        </p>
+function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
+	return (
+		<div className='dashboard-content-item'>
+			<div className='current-plan-header'>
+				<p className='api-key-warning'>
+					Make sure to copy your API KEY now. You won’t be able to see it again!
+				</p>
 
-        <button
-          className='api-key-buttons'
-          onClick={() => handleCloseKey()}
-          aria-label='Close'
-        >
-          <IoMdClose />
-        </button>
-      </div>
-      <div className='api-key-div dashboard-content-item'>
-        <p>*******************</p>
-        <div className='api-key-buttons-div'>
-          <button
-            className='api-key-buttons'
-            onClick={() => handleCopyToClipboard(Key)}
-            aria-label='Copy API Key'
-          >
-            <FaCopy />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+				<button
+					className='api-key-buttons'
+					onClick={() => handleCloseKey()}
+					aria-label='Close'
+				>
+					<IoMdClose />
+				</button>
+			</div>
+			<div className='api-key-div dashboard-content-item'>
+				<p>*******************</p>
+				<div className='api-key-buttons-div'>
+					<button
+						className='api-key-buttons'
+						onClick={() => handleCopyToClipboard(Key)}
+						aria-label='Copy API Key'
+					>
+						<FaCopy />
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }
 ApiKey.propTypes = {
-  Key: PropTypes.string.isRequired,
-  handleCloseKey: PropTypes.func.isRequired,
-  handleCopyToClipboard: PropTypes.func.isRequired,
+	Key: PropTypes.string.isRequired,
+	handleCloseKey: PropTypes.func.isRequired,
+	handleCopyToClipboard: PropTypes.func.isRequired,
 };
 
 export default ApiKey;

--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -1,46 +1,46 @@
-import { IoMdClose } from 'react-icons/io';
+import {IoMdClose} from 'react-icons/io';
 import PropTypes from 'prop-types';
-import { FaCopy, FaEye, FaEyeSlash } from 'react-icons/fa';
-import { useState } from 'react';
+import {FaCopy, FaEye, FaEyeSlash} from 'react-icons/fa';
+import {useState} from 'react';
 
-function ApiKey({ Key, handleCloseKey, handleCopyToClipboard }) {
-  const [hideKey, setHideKey] = useState(true);
-  return (
-    <div className='dashboard-content-item'>
-      <div className='current-plan-header'>
-        <p className='api-key-warning'>
-          Make sure to copy your API KEY now. You won’t be able to see it again!
-        </p>
+function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
+	const [hideKey, setHideKey] = useState(true);
+	return (
+		<div className='dashboard-content-item'>
+			<div className='current-plan-header'>
+				<p className='api-key-warning'>
+					Make sure to copy your API KEY now. You won’t be able to see it again!
+				</p>
 
-        <button className='api-key-buttons' onClick={() => handleCloseKey()}>
-          <IoMdClose />
-        </button>
-      </div>
-      <div className='api-key-div dashboard-content-item'>
-        <p>{hideKey ? '*******************' : Key}</p>
-        <div className='api-key-buttons-div'>
-          <button
-            className='api-key-buttons'
-            onClick={() => setHideKey(!hideKey)}
-          >
-            {hideKey ? <FaEye /> : <FaEyeSlash />}{' '}
-            {/* Replace with appropriate icons */}
-          </button>
-          <button
-            className='api-key-buttons'
-            onClick={() => handleCopyToClipboard(Key)}
-          >
-            <FaCopy />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+				<button className='api-key-buttons' onClick={() => handleCloseKey()}>
+					<IoMdClose />
+				</button>
+			</div>
+			<div className='api-key-div dashboard-content-item'>
+				<p>{hideKey ? '*******************' : Key}</p>
+				<div className='api-key-buttons-div'>
+					<button
+						className='api-key-buttons'
+						onClick={() => setHideKey(!hideKey)}
+					>
+						{hideKey ? <FaEye /> : <FaEyeSlash />}{' '}
+						{/* Replace with appropriate icons */}
+					</button>
+					<button
+						className='api-key-buttons'
+						onClick={() => handleCopyToClipboard(Key)}
+					>
+						<FaCopy />
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }
 ApiKey.propTypes = {
-  Key: PropTypes.string.isRequired,
-  handleCloseKey: PropTypes.func.isRequired,
-  handleCopyToClipboard: PropTypes.func.isRequired,
+	Key: PropTypes.string.isRequired,
+	handleCloseKey: PropTypes.func.isRequired,
+	handleCopyToClipboard: PropTypes.func.isRequired,
 };
 
 export default ApiKey;

--- a/client/src/components/dashboard/ApiKey.js
+++ b/client/src/components/dashboard/ApiKey.js
@@ -12,7 +12,11 @@ function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
 					Make sure to copy your API KEY now. You won’t be able to see it again!
 				</p>
 
-				<button className='api-key-buttons' onClick={() => handleCloseKey()}>
+				<button
+					className='api-key-buttons'
+					onClick={() => handleCloseKey()}
+					aria-label='Close'
+				>
 					<IoMdClose />
 				</button>
 			</div>
@@ -22,13 +26,14 @@ function ApiKey({Key, handleCloseKey, handleCopyToClipboard}) {
 					<button
 						className='api-key-buttons'
 						onClick={() => setHideKey(!hideKey)}
+						aria-label='Show/Hide API Key'
 					>
 						{hideKey ? <FaEye /> : <FaEyeSlash />}{' '}
-						{/* Replace with appropriate icons */}
 					</button>
 					<button
 						className='api-key-buttons'
 						onClick={() => handleCopyToClipboard(Key)}
+						aria-label='Copy API Key'
 					>
 						<FaCopy />
 					</button>

--- a/client/src/components/dashboard/ApiKey.test.js
+++ b/client/src/components/dashboard/ApiKey.test.js
@@ -1,63 +1,62 @@
-import { render, fireEvent, screen } from '@testing-library/react';
+import {render, fireEvent, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ApiKey from './ApiKey';
 
 describe('ApiKey', () => {
-  it('renders correctly', () => {
-    const handleCloseKey = jest.fn();
-    const handleCopyToClipboard = jest.fn();
-    const key = 'test_api_key';
+	it('renders correctly', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
 
-    render(
-      <ApiKey
-        Key={key}
-        handleCloseKey={handleCloseKey}
-        handleCopyToClipboard={handleCopyToClipboard}
-      />,
-    );
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
 
-    expect(
-      screen.getByText(
-        'Make sure to copy your API KEY now. You won’t be able to see it again!',
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText('*******************')).toBeInTheDocument();
-  });
+		expect(
+			screen.getByText(
+				'Make sure to copy your API KEY now. You won’t be able to see it again!',
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText('*******************')).toBeInTheDocument();
+	});
 
-  it('closes when the close button is clicked', () => {
-    const handleCloseKey = jest.fn();
-    const handleCopyToClipboard = jest.fn();
-    const key = 'test_api_key';
+	it('closes when the close button is clicked', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
 
-    render(
-      <ApiKey
-        Key={key}
-        handleCloseKey={handleCloseKey}
-        handleCopyToClipboard={handleCopyToClipboard}
-      />,
-    );
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
 
-    const closeButton = screen.getByRole('button', { name: 'Close' });
-    fireEvent.click(closeButton);
-    expect(handleCloseKey).toHaveBeenCalledTimes(1);
-  });
+		const closeButton = screen.getByRole('button', {name: 'Close'});
+		fireEvent.click(closeButton);
+		expect(handleCloseKey).toHaveBeenCalledTimes(1);
+	});
 
-  it('copies the API key to clipboard when clicked', () => {
-    const handleCloseKey = jest.fn();
-    const handleCopyToClipboard = jest.fn();
-    const key = 'test_api_key';
+	it('copies the API key to clipboard when clicked', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
 
-    render(
-      <ApiKey
-        Key={key}
-        handleCloseKey={handleCloseKey}
-        handleCopyToClipboard={handleCopyToClipboard}
-      />,
-    );
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
 
-    const copyButton = screen.getByLabelText('Copy API Key');
-    userEvent.click(copyButton);
-    expect(handleCopyToClipboard).toHaveBeenCalledWith(key);
-  });
-
+		const copyButton = screen.getByLabelText('Copy API Key');
+		userEvent.click(copyButton);
+		expect(handleCopyToClipboard).toHaveBeenCalledWith(key);
+	});
 });

--- a/client/src/components/dashboard/ApiKey.test.js
+++ b/client/src/components/dashboard/ApiKey.test.js
@@ -1,83 +1,63 @@
-import {render, fireEvent, screen} from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ApiKey from './ApiKey';
 
 describe('ApiKey', () => {
-	it('renders correctly', () => {
-		const handleCloseKey = jest.fn();
-		const handleCopyToClipboard = jest.fn();
-		const key = 'test_api_key';
+  it('renders correctly', () => {
+    const handleCloseKey = jest.fn();
+    const handleCopyToClipboard = jest.fn();
+    const key = 'test_api_key';
 
-		render(
-			<ApiKey
-				Key={key}
-				handleCloseKey={handleCloseKey}
-				handleCopyToClipboard={handleCopyToClipboard}
-			/>,
-		);
+    render(
+      <ApiKey
+        Key={key}
+        handleCloseKey={handleCloseKey}
+        handleCopyToClipboard={handleCopyToClipboard}
+      />,
+    );
 
-		expect(
-			screen.getByText(
-				'Make sure to copy your API KEY now. You won’t be able to see it again!',
-			),
-		).toBeInTheDocument();
-		expect(screen.getByText('*******************')).toBeInTheDocument();
-	});
+    expect(
+      screen.getByText(
+        'Make sure to copy your API KEY now. You won’t be able to see it again!',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('*******************')).toBeInTheDocument();
+  });
 
-	it('closes when the close button is clicked', () => {
-		const handleCloseKey = jest.fn();
-		const handleCopyToClipboard = jest.fn();
-		const key = 'test_api_key';
+  it('closes when the close button is clicked', () => {
+    const handleCloseKey = jest.fn();
+    const handleCopyToClipboard = jest.fn();
+    const key = 'test_api_key';
 
-		render(
-			<ApiKey
-				Key={key}
-				handleCloseKey={handleCloseKey}
-				handleCopyToClipboard={handleCopyToClipboard}
-			/>,
-		);
+    render(
+      <ApiKey
+        Key={key}
+        handleCloseKey={handleCloseKey}
+        handleCopyToClipboard={handleCopyToClipboard}
+      />,
+    );
 
-		const closeButton = screen.getByRole('button', {name: 'Close'});
-		fireEvent.click(closeButton);
-		expect(handleCloseKey).toHaveBeenCalledTimes(1);
-	});
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
+    expect(handleCloseKey).toHaveBeenCalledTimes(1);
+  });
 
-	it('copies the API key to clipboard when clicked', () => {
-		const handleCloseKey = jest.fn();
-		const handleCopyToClipboard = jest.fn();
-		const key = 'test_api_key';
+  it('copies the API key to clipboard when clicked', () => {
+    const handleCloseKey = jest.fn();
+    const handleCopyToClipboard = jest.fn();
+    const key = 'test_api_key';
 
-		render(
-			<ApiKey
-				Key={key}
-				handleCloseKey={handleCloseKey}
-				handleCopyToClipboard={handleCopyToClipboard}
-			/>,
-		);
+    render(
+      <ApiKey
+        Key={key}
+        handleCloseKey={handleCloseKey}
+        handleCopyToClipboard={handleCopyToClipboard}
+      />,
+    );
 
-		const copyButton = screen.getByLabelText('Copy API Key');
-		userEvent.click(copyButton);
-		expect(handleCopyToClipboard).toHaveBeenCalledWith(key);
-	});
+    const copyButton = screen.getByLabelText('Copy API Key');
+    userEvent.click(copyButton);
+    expect(handleCopyToClipboard).toHaveBeenCalledWith(key);
+  });
 
-	it('toggles visibility of the API key', () => {
-		const handleCloseKey = jest.fn();
-		const handleCopyToClipboard = jest.fn();
-		const key = 'test_api_key';
-
-		render(
-			<ApiKey
-				Key={key}
-				handleCloseKey={handleCloseKey}
-				handleCopyToClipboard={handleCopyToClipboard}
-			/>,
-		);
-
-		const showHideButton = screen.getByLabelText('Show/Hide API Key');
-		userEvent.click(showHideButton);
-		expect(screen.getByText(key)).toBeInTheDocument();
-
-		userEvent.click(showHideButton);
-		expect(screen.getByText('*******************')).toBeInTheDocument();
-	});
 });

--- a/client/src/components/dashboard/ApiKey.test.js
+++ b/client/src/components/dashboard/ApiKey.test.js
@@ -1,0 +1,83 @@
+import {render, fireEvent, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ApiKey from './ApiKey';
+
+describe('ApiKey', () => {
+	it('renders correctly', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
+
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				'Make sure to copy your API KEY now. You won’t be able to see it again!',
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText('*******************')).toBeInTheDocument();
+	});
+
+	it('closes when the close button is clicked', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
+
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
+
+		const closeButton = screen.getByRole('button', {name: 'Close'});
+		fireEvent.click(closeButton);
+		expect(handleCloseKey).toHaveBeenCalledTimes(1);
+	});
+
+	it('copies the API key to clipboard when clicked', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
+
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
+
+		const copyButton = screen.getByLabelText('Copy API Key');
+		userEvent.click(copyButton);
+		expect(handleCopyToClipboard).toHaveBeenCalledWith(key);
+	});
+
+	it('toggles visibility of the API key', () => {
+		const handleCloseKey = jest.fn();
+		const handleCopyToClipboard = jest.fn();
+		const key = 'test_api_key';
+
+		render(
+			<ApiKey
+				Key={key}
+				handleCloseKey={handleCloseKey}
+				handleCopyToClipboard={handleCopyToClipboard}
+			/>,
+		);
+
+		const showHideButton = screen.getByLabelText('Show/Hide API Key');
+		userEvent.click(showHideButton);
+		expect(screen.getByText(key)).toBeInTheDocument();
+
+		userEvent.click(showHideButton);
+		expect(screen.getByText('*******************')).toBeInTheDocument();
+	});
+});

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -1,87 +1,87 @@
 import PropTypes from 'prop-types';
-import { MdDeleteOutline } from 'react-icons/md';
-import { formatDate } from '../../utils/helpers';
+import {MdDeleteOutline} from 'react-icons/md';
+import {formatDate} from '../../utils/helpers';
 import Modal from '../common/modal/Modal';
-import { useRef, useState } from 'react';
-function ApiKeyTable({ keys, deleteKey, handleCloseKey }) {
-  const apiKeyToBeDeleted = useRef(null);
-  const [modalOpen, setModalOpen] = useState(false);
+import {useRef, useState} from 'react';
+function ApiKeyTable({keys, deleteKey, handleCloseKey}) {
+	const apiKeyToBeDeleted = useRef(null);
+	const [modalOpen, setModalOpen] = useState(false);
 
-  const showConfirmationModal = (keyId) => {
-    apiKeyToBeDeleted.current = keyId;
-    setModalOpen(true);
-  };
+	const showConfirmationModal = (keyId) => {
+		apiKeyToBeDeleted.current = keyId;
+		setModalOpen(true);
+	};
 
-  const confirmActionHandler = () => {
-    setModalOpen(false);
-    deleteKey(apiKeyToBeDeleted.current);
-    apiKeyToBeDeleted.current = null;
-    handleCloseKey();
-  };
+	const confirmActionHandler = () => {
+		setModalOpen(false);
+		deleteKey(apiKeyToBeDeleted.current);
+		apiKeyToBeDeleted.current = null;
+		handleCloseKey();
+	};
 
-  return (
-    <section className='dashboard-content-section'>
-      <div className='dashboard-content-item api-key-table'>
-        <table>
-          <thead>
-            <tr>
-              <th>DESCRIPTION</th>
-              <th>ACTION</th>
-              <th>CREATE DATE</th>
-            </tr>
-          </thead>
-          <tbody>
-            {!keys.length && (
-              <tr>
-                <td colSpan='3' className='no-keys'>
-                  Your api keys will be visible here, click on generate key to
-                  add new api key
-                </td>
-              </tr>
-            )}
-            {keys.map((key, index) => (
-              <tr key={index}>
-                <td>{key.keyDescription}</td>
-                <td>
-                  <button
-                    className='api-key-delete-button'
-                    data-testid='api-key-delete'
-                    onClick={() => showConfirmationModal(key.keyId)}
-                  >
-                    <MdDeleteOutline />
-                  </button>
-                </td>
-                <td>{formatDate(key?.createdAt)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <Modal
-        modalOpen={modalOpen}
-        setModal={setModalOpen}
-        showButtons={true}
-        handleConfirm={confirmActionHandler}
-      >
-        <h2>Are you sure?</h2>
-        <p className='settings-confirm-message'>
-          Please confirm that you want to delete this permanently, as this
-          action cannot be undone.
-        </p>
-      </Modal>
-    </section>
-  );
+	return (
+		<section className='dashboard-content-section'>
+			<div className='dashboard-content-item api-key-table'>
+				<table>
+					<thead>
+						<tr>
+							<th>DESCRIPTION</th>
+							<th>ACTION</th>
+							<th>CREATE DATE</th>
+						</tr>
+					</thead>
+					<tbody>
+						{!keys.length && (
+							<tr>
+								<td colSpan='3' className='no-keys'>
+									Your api keys will be visible here, click on generate key to
+									add new api key
+								</td>
+							</tr>
+						)}
+						{keys.map((key, index) => (
+							<tr key={index}>
+								<td>{key.keyDescription}</td>
+								<td>
+									<button
+										className='api-key-delete-button'
+										data-testid='api-key-delete'
+										onClick={() => showConfirmationModal(key.keyId)}
+									>
+										<MdDeleteOutline />
+									</button>
+								</td>
+								<td>{formatDate(key?.createdAt)}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+			<Modal
+				modalOpen={modalOpen}
+				setModal={setModalOpen}
+				showButtons={true}
+				handleConfirm={confirmActionHandler}
+			>
+				<h2>Are you sure?</h2>
+				<p className='settings-confirm-message'>
+					Please confirm that you want to delete this permanently, as this
+					action cannot be undone.
+				</p>
+			</Modal>
+		</section>
+	);
 }
 
 ApiKeyTable.propTypes = {
-  keys: PropTypes.arrayOf(
-    PropTypes.shape({
-      description: PropTypes.string,
-      apiKey: PropTypes.string,
-    }),
-  ).isRequired,
-  deleteKey: PropTypes.func.isRequired,
-  handleCloseKey: PropTypes.func.isRequired,
+	keys: PropTypes.arrayOf(
+		PropTypes.shape({
+			description: PropTypes.string,
+			apiKey: PropTypes.string,
+		}),
+	).isRequired,
+	deleteKey: PropTypes.func.isRequired,
+	handleCloseKey: PropTypes.func.isRequired,
 };
 
 export default ApiKeyTable;

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -1,108 +1,87 @@
 import PropTypes from 'prop-types';
-import {FiCopy} from 'react-icons/fi';
-import {LuCopyCheck} from 'react-icons/lu';
-import {MdDeleteOutline} from 'react-icons/md';
-import {formatDate} from '../../utils/helpers';
+import { MdDeleteOutline } from 'react-icons/md';
+import { formatDate } from '../../utils/helpers';
 import Modal from '../common/modal/Modal';
-import {useRef, useState} from 'react';
-function ApiKeyTable({keys, copiedKey, handleCopyToClipboard, deleteKey}) {
-	const apiKeyToBeDeleted = useRef(null);
-	const [modalOpen, setModalOpen] = useState(false);
+import { useRef, useState } from 'react';
+function ApiKeyTable({ keys, deleteKey, handleCloseKey }) {
+  const apiKeyToBeDeleted = useRef(null);
+  const [modalOpen, setModalOpen] = useState(false);
 
-	const showConfirmationModal = (keyId) => {
-		apiKeyToBeDeleted.current = keyId;
-		setModalOpen(true);
-	};
+  const showConfirmationModal = (keyId) => {
+    apiKeyToBeDeleted.current = keyId;
+    setModalOpen(true);
+  };
 
-	const confirmActionHandler = () => {
-		setModalOpen(false);
-		deleteKey(apiKeyToBeDeleted.current);
-		apiKeyToBeDeleted.current = null;
-	};
+  const confirmActionHandler = () => {
+    setModalOpen(false);
+    deleteKey(apiKeyToBeDeleted.current);
+    apiKeyToBeDeleted.current = null;
+    handleCloseKey();
+  };
 
-	return (
-		<section className='dashboard-content-section'>
-			<div className='dashboard-content-item api-key-table'>
-				<table>
-					<thead>
-						<tr>
-							<th>DESCRIPTION</th>
-							<th>API KEY</th>
-							<th>ACTION</th>
-							<th>CREATE DATE</th>
-						</tr>
-					</thead>
-					<tbody>
-						{!keys.length && (
-							<tr>
-								<td colSpan='4' className='no-keys'>
-									Your api keys will be visible here, click on generate key to
-									add new api key
-								</td>
-							</tr>
-						)}
-						{keys.map((key, index) => (
-							<tr key={index}>
-								<td>{key.keyDescription}</td>
-								<td className='api-key-column'>
-									{copiedKey === key.key ? (
-										<div
-											className='api-key-copied'
-											data-testid='api-key-copied'
-										>
-											<LuCopyCheck />
-										</div>
-									) : (
-										<button
-											className='api-key-copy'
-											data-testid='api-key-copy'
-											onClick={() => handleCopyToClipboard(key.key)}
-										>
-											<FiCopy />
-										</button>
-									)}
-								</td>
-								<td>
-									<button
-										className='api-key-delete-button'
-										data-testid='api-key-delete'
-										onClick={() => showConfirmationModal(key.keyId)}
-									>
-										<MdDeleteOutline />
-									</button>
-								</td>
-								<td>{formatDate(key?.createdAt)}</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
-			<Modal
-				modalOpen={modalOpen}
-				setModal={setModalOpen}
-				showButtons={true}
-				handleConfirm={confirmActionHandler}
-			>
-				<h2>Are you sure?</h2>
-				<p className='settings-confirm-message'>
-					Please confirm that you want to delete this permanently, as this
-					action cannot be undone.
-				</p>
-			</Modal>
-		</section>
-	);
+  return (
+    <section className='dashboard-content-section'>
+      <div className='dashboard-content-item api-key-table'>
+        <table>
+          <thead>
+            <tr>
+              <th>DESCRIPTION</th>
+              <th>ACTION</th>
+              <th>CREATE DATE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {!keys.length && (
+              <tr>
+                <td colSpan='3' className='no-keys'>
+                  Your api keys will be visible here, click on generate key to
+                  add new api key
+                </td>
+              </tr>
+            )}
+            {keys.map((key, index) => (
+              <tr key={index}>
+                <td>{key.keyDescription}</td>
+                <td>
+                  <button
+                    className='api-key-delete-button'
+                    data-testid='api-key-delete'
+                    onClick={() => showConfirmationModal(key.keyId)}
+                  >
+                    <MdDeleteOutline />
+                  </button>
+                </td>
+                <td>{formatDate(key?.createdAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Modal
+        modalOpen={modalOpen}
+        setModal={setModalOpen}
+        showButtons={true}
+        handleConfirm={confirmActionHandler}
+      >
+        <h2>Are you sure?</h2>
+        <p className='settings-confirm-message'>
+          Please confirm that you want to delete this permanently, as this
+          action cannot be undone.
+        </p>
+      </Modal>
+    </section>
+  );
 }
 
 ApiKeyTable.propTypes = {
-	keys: PropTypes.arrayOf(
-		PropTypes.shape({
-			description: PropTypes.string,
-			apiKey: PropTypes.string,
-		}),
-	).isRequired,
-	copiedKey: PropTypes.string,
-	handleCopyToClipboard: PropTypes.func.isRequired,
-	deleteKey: PropTypes.func.isRequired,
+  keys: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      apiKey: PropTypes.string,
+    }),
+  ).isRequired,
+  deleteKey: PropTypes.func.isRequired,
+  handleCloseKey: PropTypes.func.isRequired,
 };
 
 export default ApiKeyTable;

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -16,7 +16,7 @@ function ApiKeyTable({keys, deleteKey, handleCloseKey}) {
 		setModalOpen(false);
 		deleteKey(apiKeyToBeDeleted.current);
 		apiKeyToBeDeleted.current = null;
-		handleCloseKey();
+		handleCloseKey(true);
 	};
 
 	return (

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -1,101 +1,100 @@
-import { render, fireEvent, screen } from '@testing-library/react';
+import {render, fireEvent, screen} from '@testing-library/react';
 import ApiKeyTable from './ApiKeyTable';
 
 describe('ApiKeyTable', () => {
-  const keys = [
-    {
-      keyDescription: 'Test Key 1',
-      key: '123',
-      keyId: 'id1',
-      createdAt: '2024-02-29',
-    },
-    {
-      keyDescription: 'Test Key 2',
-      key: '456',
-      keyId: 'id2',
-      createdAt: '2024-02-28',
-    },
-  ];
+	const keys = [
+		{
+			keyDescription: 'Test Key 1',
+			key: '123',
+			keyId: 'id1',
+			createdAt: '2024-02-29',
+		},
+		{
+			keyDescription: 'Test Key 2',
+			key: '456',
+			keyId: 'id2',
+			createdAt: '2024-02-28',
+		},
+	];
 
-  it('Renders correctly', () => {
-    render(
-      <ApiKeyTable
-        keys={keys}
-        handleCloseKey={() => { }}
-        deleteKey={() => { }}
-      />,
-    );
-    expect(screen.getByText('Test Key 1')).toBeInTheDocument();
-    expect(screen.getByText('Test Key 2')).toBeInTheDocument();
-    expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
-    expect(screen.getByText('February 28, 2024')).toBeInTheDocument();
-  });
+	it('Renders correctly', () => {
+		render(
+			<ApiKeyTable
+				keys={keys}
+				handleCloseKey={() => {}}
+				deleteKey={() => {}}
+			/>,
+		);
+		expect(screen.getByText('Test Key 1')).toBeInTheDocument();
+		expect(screen.getByText('Test Key 2')).toBeInTheDocument();
+		expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
+		expect(screen.getByText('February 28, 2024')).toBeInTheDocument();
+	});
 
-  it('show confirmation modal when delete button is clicked', () => {
-    render(
-      <ApiKeyTable
-        keys={keys}
-        handleCloseKey={() => { }}
-        deleteKey={() => { }}
-      />,
-    );
-    const buttons = screen.getAllByTestId('api-key-delete');
-    fireEvent.click(buttons[0]);
-    expect(screen.getByText(/Are you sure?/i)).toBeInTheDocument();
-  });
+	it('show confirmation modal when delete button is clicked', () => {
+		render(
+			<ApiKeyTable
+				keys={keys}
+				handleCloseKey={() => {}}
+				deleteKey={() => {}}
+			/>,
+		);
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		expect(screen.getByText(/Are you sure?/i)).toBeInTheDocument();
+	});
 
-  it('close the confirmation modal when cancel button is clicked in modal', () => {
-    render(
-      <ApiKeyTable
-        keys={keys}
-        handleCloseKey={() => { }}
-        deleteKey={() => { }}
-      />,
-    );
+	it('close the confirmation modal when cancel button is clicked in modal', () => {
+		render(
+			<ApiKeyTable
+				keys={keys}
+				handleCloseKey={() => {}}
+				deleteKey={() => {}}
+			/>,
+		);
 
-    const buttons = screen.getAllByTestId('api-key-delete');
-    fireEvent.click(buttons[0]);
-    const modalTitle = screen.getByText(/Are you sure?/i);
-    const cancelButton = screen.getByText(/Cancel/i);
-    fireEvent.click(cancelButton);
-    expect(modalTitle).not.toBeInTheDocument();
-  });
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		const modalTitle = screen.getByText(/Are you sure?/i);
+		const cancelButton = screen.getByText(/Cancel/i);
+		fireEvent.click(cancelButton);
+		expect(modalTitle).not.toBeInTheDocument();
+	});
 
-  it('remove key when delete is confirmed', () => {
-    const deleteKey = jest.fn();
-    render(
-      <ApiKeyTable
-        keys={keys}
-        handleCloseKey={() => { }}
-        deleteKey={deleteKey}
-      />,
-    );
+	it('remove key when delete is confirmed', () => {
+		const deleteKey = jest.fn();
+		render(
+			<ApiKeyTable
+				keys={keys}
+				handleCloseKey={() => {}}
+				deleteKey={deleteKey}
+			/>,
+		);
 
-    const buttons = screen.getAllByTestId('api-key-delete');
-    fireEvent.click(buttons[0]);
-    const confirmButton = screen.getByText(/Okay/i);
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		const confirmButton = screen.getByText(/Okay/i);
 
-    fireEvent.click(confirmButton);
-    expect(deleteKey).toHaveBeenCalledWith('id1');
-    expect(deleteKey).toHaveBeenCalledTimes(1);
-  });
+		fireEvent.click(confirmButton);
+		expect(deleteKey).toHaveBeenCalledWith('id1');
+		expect(deleteKey).toHaveBeenCalledTimes(1);
+	});
 
-  it('does not remove key when delete is cancelled', () => {
-    const deleteKey = jest.fn();
-    render(
-      <ApiKeyTable
-        keys={keys}
-        handleCloseKey={() => { }}
-        deleteKey={deleteKey}
-      />,
-    );
+	it('does not remove key when delete is cancelled', () => {
+		const deleteKey = jest.fn();
+		render(
+			<ApiKeyTable
+				keys={keys}
+				handleCloseKey={() => {}}
+				deleteKey={deleteKey}
+			/>,
+		);
 
-    const buttons = screen.getAllByTestId('api-key-delete');
-    fireEvent.click(buttons[0]);
-    const cancelButton = screen.getByText(/Cancel/i);
+		const buttons = screen.getAllByTestId('api-key-delete');
+		fireEvent.click(buttons[0]);
+		const cancelButton = screen.getByText(/Cancel/i);
 
-    fireEvent.click(cancelButton);
-    expect(deleteKey).not.toHaveBeenCalled();
-  });
+		fireEvent.click(cancelButton);
+		expect(deleteKey).not.toHaveBeenCalled();
+	});
 });
-

--- a/client/src/components/dashboard/ApiKeyTable.test.js
+++ b/client/src/components/dashboard/ApiKeyTable.test.js
@@ -1,136 +1,101 @@
-import {render, fireEvent, screen} from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import ApiKeyTable from './ApiKeyTable';
 
 describe('ApiKeyTable', () => {
-	const keys = [
-		{
-			keyDescription: 'Test Key 1',
-			key: '123',
-			keyId: 'id1',
-			createdAt: '2024-02-29',
-		},
-		{
-			keyDescription: 'Test Key 2',
-			key: '456',
-			keyId: 'id2',
-			createdAt: '2024-02-28',
-		},
-	];
+  const keys = [
+    {
+      keyDescription: 'Test Key 1',
+      key: '123',
+      keyId: 'id1',
+      createdAt: '2024-02-29',
+    },
+    {
+      keyDescription: 'Test Key 2',
+      key: '456',
+      keyId: 'id2',
+      createdAt: '2024-02-28',
+    },
+  ];
 
-	it('Renders correctly', () => {
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={() => {}}
-			/>,
-		);
-		expect(screen.getByText('Test Key 1')).toBeInTheDocument();
-		expect(screen.getByText('Test Key 2')).toBeInTheDocument();
-		expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
-		expect(screen.getByText('February 28, 2024')).toBeInTheDocument();
-	});
+  it('Renders correctly', () => {
+    render(
+      <ApiKeyTable
+        keys={keys}
+        handleCloseKey={() => { }}
+        deleteKey={() => { }}
+      />,
+    );
+    expect(screen.getByText('Test Key 1')).toBeInTheDocument();
+    expect(screen.getByText('Test Key 2')).toBeInTheDocument();
+    expect(screen.getByText('February 29, 2024')).toBeInTheDocument();
+    expect(screen.getByText('February 28, 2024')).toBeInTheDocument();
+  });
 
-	it('handles copy to clipboard', () => {
-		const handleCopyToClipboard = jest.fn();
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={handleCopyToClipboard}
-				deleteKey={() => {}}
-			/>,
-		);
-		const buttons = screen.getAllByTestId('api-key-copy');
-		fireEvent.click(buttons[0]);
-		expect(handleCopyToClipboard).toHaveBeenCalledWith('123');
-	});
+  it('show confirmation modal when delete button is clicked', () => {
+    render(
+      <ApiKeyTable
+        keys={keys}
+        handleCloseKey={() => { }}
+        deleteKey={() => { }}
+      />,
+    );
+    const buttons = screen.getAllByTestId('api-key-delete');
+    fireEvent.click(buttons[0]);
+    expect(screen.getByText(/Are you sure?/i)).toBeInTheDocument();
+  });
 
-	it('shows copied icon when key is copied', () => {
-		const handleCopyToClipboard = jest.fn();
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey='123'
-				handleCopyToClipboard={handleCopyToClipboard}
-				deleteKey={() => {}}
-			/>,
-		);
+  it('close the confirmation modal when cancel button is clicked in modal', () => {
+    render(
+      <ApiKeyTable
+        keys={keys}
+        handleCloseKey={() => { }}
+        deleteKey={() => { }}
+      />,
+    );
 
-		const buttons = screen.getAllByTestId('api-key-copy');
-		fireEvent.click(buttons[0]);
-		expect(screen.getByTestId('api-key-copied')).toBeInTheDocument();
-	});
+    const buttons = screen.getAllByTestId('api-key-delete');
+    fireEvent.click(buttons[0]);
+    const modalTitle = screen.getByText(/Are you sure?/i);
+    const cancelButton = screen.getByText(/Cancel/i);
+    fireEvent.click(cancelButton);
+    expect(modalTitle).not.toBeInTheDocument();
+  });
 
-	it('show confirmation modal when delete button is clicked', () => {
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={() => {}}
-			/>,
-		);
-		const buttons = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(buttons[0]);
-		expect(screen.getByText(/Are you sure?/i)).toBeInTheDocument();
-	});
+  it('remove key when delete is confirmed', () => {
+    const deleteKey = jest.fn();
+    render(
+      <ApiKeyTable
+        keys={keys}
+        handleCloseKey={() => { }}
+        deleteKey={deleteKey}
+      />,
+    );
 
-	it('close the confirmation modal when cancel button is clicked in modal', () => {
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={() => {}}
-			/>,
-		);
+    const buttons = screen.getAllByTestId('api-key-delete');
+    fireEvent.click(buttons[0]);
+    const confirmButton = screen.getByText(/Okay/i);
 
-		const buttons = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(buttons[0]);
-		const modalTitle = screen.getByText(/Are you sure?/i);
-		const cancelButton = screen.getByText(/Cancel/i);
-		fireEvent.click(cancelButton);
-		expect(modalTitle).not.toBeInTheDocument();
-	});
+    fireEvent.click(confirmButton);
+    expect(deleteKey).toHaveBeenCalledWith('id1');
+    expect(deleteKey).toHaveBeenCalledTimes(1);
+  });
 
-	it('remove key when delete is confirmed', () => {
-		const deleteKey = jest.fn();
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={deleteKey}
-			/>,
-		);
+  it('does not remove key when delete is cancelled', () => {
+    const deleteKey = jest.fn();
+    render(
+      <ApiKeyTable
+        keys={keys}
+        handleCloseKey={() => { }}
+        deleteKey={deleteKey}
+      />,
+    );
 
-		const buttons = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(buttons[0]);
-		const confirmButton = screen.getByText(/Okay/i);
+    const buttons = screen.getAllByTestId('api-key-delete');
+    fireEvent.click(buttons[0]);
+    const cancelButton = screen.getByText(/Cancel/i);
 
-		fireEvent.click(confirmButton);
-		expect(deleteKey).toHaveBeenCalledWith('id1');
-		expect(deleteKey).toHaveBeenCalledTimes(1);
-	});
-
-	it('does not remove key when delete is cancelled', () => {
-		const deleteKey = jest.fn();
-		render(
-			<ApiKeyTable
-				keys={keys}
-				copiedKey=''
-				handleCopyToClipboard={() => {}}
-				deleteKey={deleteKey}
-			/>,
-		);
-
-		const buttons = screen.getAllByTestId('api-key-delete');
-		fireEvent.click(buttons[0]);
-		const cancelButton = screen.getByText(/Cancel/i);
-
-		fireEvent.click(cancelButton);
-		expect(deleteKey).not.toHaveBeenCalled();
-	});
+    fireEvent.click(cancelButton);
+    expect(deleteKey).not.toHaveBeenCalled();
+  });
 });
+

--- a/client/src/pages/dashboard/Dashboard.css
+++ b/client/src/pages/dashboard/Dashboard.css
@@ -77,13 +77,19 @@
 	font-size: var(--medium-text);
 	line-height: 20px;
 	font-weight: 400;
-	margin: 10px 0 30px 0;
+	margin: 20px 0 20px 0;
 }
 
 .api-key-div {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	border-radius: var(--bradius);
+	box-shadow: var(--shadow);
+	border: var(--border);
+	padding: 12px;
+	font-size: 16px;
+	font-weight: 500;
 }
 
 .api-key-buttons-div {
@@ -98,6 +104,38 @@
 	background: none;
 	font-size: larger;
 	cursor: pointer;
+}
+
+.api-key-header {
+	display: flex;
+	flex-direction: col-reverse;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 12px;
+	position: relative;
+}
+
+.close-btn-ak {
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+.api-key-container-main {
+	color: var(--description);
+	font-size: var(--medium-text);
+	line-height: 20px;
+	font-weight: 400;
+	margin-bottom: 30px;
+	padding: 12px;
+	font-size: 16px;
+	font-weight: 500;
+	width: 50%;
+	border-radius: var(--bradius);
+	box-shadow: var(--shadow);
+	border: var(--border);
+	margin: auto;
 }
 
 .hide {
@@ -368,6 +406,10 @@
 	.menu-dropdown-icon {
 		height: 18px;
 		width: 18px;
+	}
+
+	.api-key-container-main {
+		width: 100%;
 	}
 }
 

--- a/client/src/pages/dashboard/Dashboard.css
+++ b/client/src/pages/dashboard/Dashboard.css
@@ -72,6 +72,38 @@
 	margin-bottom: 30px;
 }
 
+.api-key-warning {
+	color: #eed202;
+	font-size: var(--medium-text);
+	line-height: 20px;
+	font-weight: 400;
+	margin: 10px 0 30px 0;
+}
+
+.api-key-div {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.api-key-buttons-div {
+	display: flex;
+	gap: 10px;
+}
+
+.api-key-buttons {
+	top: 1.5rem;
+	right: 1.5rem;
+	border: none;
+	background: none;
+	font-size: larger;
+	cursor: pointer;
+}
+
+.hide {
+	display: none;
+}
+
 .dashboard-content-item > button {
 	max-width: fit-content;
 }
@@ -344,3 +376,4 @@
 		display: none;
 	}
 }
+

--- a/client/src/pages/dashboard/Dashboard.css
+++ b/client/src/pages/dashboard/Dashboard.css
@@ -376,4 +376,3 @@
 		display: none;
 	}
 }
-

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -1,162 +1,161 @@
-import { useContext, useEffect, useState } from 'react';
+import {useContext, useEffect, useState} from 'react';
 import ApiKeyForm from '../../components/dashboard/ApiKeyForm';
 import ApiKeyTable from '../../components/dashboard/ApiKeyTable';
 import ApiKey from '../../components/dashboard/ApiKey';
 import CurrentPlan from '../../components/dashboard/CurrentPlan';
 import Usage from '../../components/dashboard/Usage';
-import { isLettersAndSpacesOnly } from '../../constants';
-import { UserContext } from '../../contexts/UserContext';
-import { useApi } from '../../hooks/useApi';
+import {isLettersAndSpacesOnly} from '../../constants';
+import {UserContext} from '../../contexts/UserContext';
+import {useApi} from '../../hooks/useApi';
 import './Dashboard.css';
 
 function getUsedCalls(keys) {
-  let result = 0;
-  keys?.forEach((key) => {
-    result += key.usageCount;
-  });
-  return result;
+	let result = 0;
+	keys?.forEach((key) => {
+		result += key.usageCount;
+	});
+	return result;
 }
 
 function Dashboard() {
-  const [inputValue, setInputValue] = useState('');
-  const [deletedKey, setDeletedKey] = useState(null);
-  const [errorMessage, setErrorMessage] = useState('');
-  const [copiedKey, setCopiedKey] = useState(null);
-  const [keys, setKeys] = useState([]);
-  const [showKey, setShowKey] = useState(false);
-  const { userData, fetchUserData } = useContext(UserContext);
-  const { data, errorMsg, makeRequest, isSuccess, loading } = useApi({
-    url: `api/user/generate`,
-    method: 'post',
-    data: { keyDescription: inputValue },
-  });
-  const {
-    errorMsg: errorDeleteMsg,
-    makeRequest: makeDeleteRequest,
-    isSuccess: isDeleteSuccess,
-  } = useApi({
-    url: `api/user/destroy`,
-    method: 'delete',
-    params: { keyId: deletedKey },
-  });
+	const [inputValue, setInputValue] = useState('');
+	const [deletedKey, setDeletedKey] = useState(null);
+	const [errorMessage, setErrorMessage] = useState('');
+	const [copiedKey, setCopiedKey] = useState(null);
+	const [keys, setKeys] = useState([]);
+	const [showKey, setShowKey] = useState(false);
+	const {userData, fetchUserData} = useContext(UserContext);
+	const {data, errorMsg, makeRequest, isSuccess, loading} = useApi({
+		url: `api/user/generate`,
+		method: 'post',
+		data: {keyDescription: inputValue},
+	});
+	const {
+		errorMsg: errorDeleteMsg,
+		makeRequest: makeDeleteRequest,
+		isSuccess: isDeleteSuccess,
+	} = useApi({
+		url: `api/user/destroy`,
+		method: 'delete',
+		params: {keyId: deletedKey},
+	});
 
-  useEffect(() => {
-    fetchUserData();
-  }, []);
+	useEffect(() => {
+		fetchUserData();
+	}, []);
 
-  useEffect(() => {
-    if (userData?.keys) {
-      setKeys(userData.keys);
-    }
-  }, [userData]);
+	useEffect(() => {
+		if (userData?.keys) {
+			setKeys(userData.keys);
+		}
+	}, [userData]);
 
-  useEffect(() => {
-    if (isSuccess) {
-      setShowKey(true);
-      const newKey = {
-        keyId: data.data.keyId,
-        keyDescription: data.data.keyDescription,
-        usageCount: data.data.usageCount,
-        createdAt: data.data.createdAt,
-        updatedAt: data.data.updatedAt,
-      };
-      setKeys([newKey, ...keys]);
-      setInputValue('');
-    } else if (errorMsg) {
-      setErrorMessage(errorMsg);
-      setInputValue('');
-    }
-  }, [isSuccess, errorMsg]);
+	useEffect(() => {
+		if (isSuccess) {
+			setShowKey(true);
+			const newKey = {
+				keyId: data.data.keyId,
+				keyDescription: data.data.keyDescription,
+				usageCount: data.data.usageCount,
+				createdAt: data.data.createdAt,
+				updatedAt: data.data.updatedAt,
+			};
+			setKeys([newKey, ...keys]);
+			setInputValue('');
+		} else if (errorMsg) {
+			setErrorMessage(errorMsg);
+			setInputValue('');
+		}
+	}, [isSuccess, errorMsg]);
 
-  useEffect(() => {
-    if (isDeleteSuccess) {
-      const updatedKeys = keys.filter((key) => key.keyId !== deletedKey);
-      setKeys(updatedKeys);
-      setDeletedKey(null);
-    }
-    if (errorDeleteMsg) {
-      setErrorMessage(errorDeleteMsg);
-    }
-  }, [errorDeleteMsg, isDeleteSuccess]);
+	useEffect(() => {
+		if (isDeleteSuccess) {
+			const updatedKeys = keys.filter((key) => key.keyId !== deletedKey);
+			setKeys(updatedKeys);
+			setDeletedKey(null);
+		}
+		if (errorDeleteMsg) {
+			setErrorMessage(errorDeleteMsg);
+		}
+	}, [errorDeleteMsg, isDeleteSuccess]);
 
-  useEffect(() => {
-    const deleteKeyFunction = async () => {
-      await makeDeleteRequest();
-    };
-    if (deletedKey) {
-      deleteKeyFunction();
-    }
-  }, [deletedKey]);
+	useEffect(() => {
+		const deleteKeyFunction = async () => {
+			await makeDeleteRequest();
+		};
+		if (deletedKey) {
+			deleteKeyFunction();
+		}
+	}, [deletedKey]);
 
-  async function handleGenerateKey(e) {
-    e.preventDefault();
-    if (inputValue.trim() === '') {
-      setErrorMessage('Description cannot be empty');
-      return;
-    }
-    if (inputValue.trim().length > 20) {
-      setErrorMessage('Description cannot be more than 20 characters');
-      return;
-    } else if (!isLettersAndSpacesOnly.test(inputValue)) {
-      setErrorMessage('Description must contain only alphabets and spaces');
-      return;
-    }
-    await makeRequest();
-  }
+	async function handleGenerateKey(e) {
+		e.preventDefault();
+		if (inputValue.trim() === '') {
+			setErrorMessage('Description cannot be empty');
+			return;
+		}
+		if (inputValue.trim().length > 20) {
+			setErrorMessage('Description cannot be more than 20 characters');
+			return;
+		} else if (!isLettersAndSpacesOnly.test(inputValue)) {
+			setErrorMessage('Description must contain only alphabets and spaces');
+			return;
+		}
+		await makeRequest();
+	}
 
-  const handleCopyToClipboard = async (apiKey) => {
-    await navigator.clipboard.writeText(apiKey);
-    setCopiedKey(apiKey);
-  };
+	const handleCopyToClipboard = async (apiKey) => {
+		await navigator.clipboard.writeText(apiKey);
+		setCopiedKey(apiKey);
+	};
 
-  const handleCloseKey = () => {
-    if (showKey) {
-      if (window.confirm('Are you sure you want to close the API key?')) {
-        setShowKey(false);
-      }
-    }
-  };
+	const handleCloseKey = () => {
+		if (showKey) {
+			if (window.confirm('Are you sure you want to close the API key?')) {
+				setShowKey(false);
+			}
+		}
+	};
 
-  return (
-    <div className='dashboard-container' data-testid='testid-dashboard'>
-      <div className='dashboard-content-container'>
-        <section className='dashboard-content-section'>
-          <CurrentPlan subscriptionData={userData?.subscription} />
-          <Usage
-            usedCalls={getUsedCalls(userData?.keys)}
-            totalCalls={userData?.subscription.usageLimit || 0}
-          />
-          <div className='generate-api'>
-            <h1 className='content-item-heading'>Generate your API key</h1>
-            <ApiKeyForm
-              inputValue={inputValue}
-              setInputValue={setInputValue}
-              errorMessage={errorMessage}
-              loading={loading}
-              setErrorMessage={setErrorMessage}
-              handleGenerateKey={handleGenerateKey}
-            />
-          </div>
-        </section>
-        {showKey && (
-          <ApiKey
-            Key={data?.data?.key}
-            handleCloseKey={handleCloseKey}
-            handleCopyToClipboard={handleCopyToClipboard}
-          />
-        )}
-        <div className='divider'></div>
-        <ApiKeyTable
-          keys={keys}
-          copiedKey={copiedKey}
-          handleCopyToClipboard={handleCopyToClipboard}
-          deleteKey={setDeletedKey}
-          handleCloseKey={handleCloseKey}
-        />
-      </div>
-    </div>
-  );
+	return (
+		<div className='dashboard-container' data-testid='testid-dashboard'>
+			<div className='dashboard-content-container'>
+				<section className='dashboard-content-section'>
+					<CurrentPlan subscriptionData={userData?.subscription} />
+					<Usage
+						usedCalls={getUsedCalls(userData?.keys)}
+						totalCalls={userData?.subscription.usageLimit || 0}
+					/>
+					<div className='generate-api'>
+						<h1 className='content-item-heading'>Generate your API key</h1>
+						<ApiKeyForm
+							inputValue={inputValue}
+							setInputValue={setInputValue}
+							errorMessage={errorMessage}
+							loading={loading}
+							setErrorMessage={setErrorMessage}
+							handleGenerateKey={handleGenerateKey}
+						/>
+					</div>
+				</section>
+				{showKey && (
+					<ApiKey
+						Key={data?.data?.key}
+						handleCloseKey={handleCloseKey}
+						handleCopyToClipboard={handleCopyToClipboard}
+					/>
+				)}
+				<div className='divider'></div>
+				<ApiKeyTable
+					keys={keys}
+					copiedKey={copiedKey}
+					handleCopyToClipboard={handleCopyToClipboard}
+					deleteKey={setDeletedKey}
+					handleCloseKey={handleCloseKey}
+				/>
+			</div>
+		</div>
+	);
 }
 
 export default Dashboard;
-

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -1,143 +1,162 @@
-import {useContext, useEffect, useState} from 'react';
+import { useContext, useEffect, useState } from 'react';
 import ApiKeyForm from '../../components/dashboard/ApiKeyForm';
 import ApiKeyTable from '../../components/dashboard/ApiKeyTable';
+import ApiKey from '../../components/dashboard/ApiKey';
 import CurrentPlan from '../../components/dashboard/CurrentPlan';
 import Usage from '../../components/dashboard/Usage';
-import {isLettersAndSpacesOnly} from '../../constants';
-import {UserContext} from '../../contexts/UserContext';
-import {useApi} from '../../hooks/useApi';
+import { isLettersAndSpacesOnly } from '../../constants';
+import { UserContext } from '../../contexts/UserContext';
+import { useApi } from '../../hooks/useApi';
 import './Dashboard.css';
 
 function getUsedCalls(keys) {
-	let result = 0;
-	keys?.forEach((key) => {
-		result += key.usageCount;
-	});
-	return result;
+  let result = 0;
+  keys?.forEach((key) => {
+    result += key.usageCount;
+  });
+  return result;
 }
 
 function Dashboard() {
-	const [inputValue, setInputValue] = useState('');
-	const [deletedKey, setDeletedKey] = useState(null);
-	const [errorMessage, setErrorMessage] = useState('');
-	const [copiedKey, setCopiedKey] = useState(null);
-	const [keys, setKeys] = useState([]);
-	const {userData, fetchUserData} = useContext(UserContext);
-	const {data, errorMsg, makeRequest, isSuccess, loading} = useApi({
-		url: `api/user/generate`,
-		method: 'post',
-		data: {keyDescription: inputValue},
-	});
-	const {
-		errorMsg: errorDeleteMsg,
-		makeRequest: makeDeleteRequest,
-		isSuccess: isDeleteSuccess,
-	} = useApi({
-		url: `api/user/destroy`,
-		method: 'delete',
-		params: {keyId: deletedKey},
-	});
+  const [inputValue, setInputValue] = useState('');
+  const [deletedKey, setDeletedKey] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [copiedKey, setCopiedKey] = useState(null);
+  const [keys, setKeys] = useState([]);
+  const [showKey, setShowKey] = useState(false);
+  const { userData, fetchUserData } = useContext(UserContext);
+  const { data, errorMsg, makeRequest, isSuccess, loading } = useApi({
+    url: `api/user/generate`,
+    method: 'post',
+    data: { keyDescription: inputValue },
+  });
+  const {
+    errorMsg: errorDeleteMsg,
+    makeRequest: makeDeleteRequest,
+    isSuccess: isDeleteSuccess,
+  } = useApi({
+    url: `api/user/destroy`,
+    method: 'delete',
+    params: { keyId: deletedKey },
+  });
 
-	useEffect(() => {
-		fetchUserData();
-	}, []);
+  useEffect(() => {
+    fetchUserData();
+  }, []);
 
-	useEffect(() => {
-		if (userData?.keys) {
-			setKeys(userData.keys);
-		}
-	}, [userData]);
+  useEffect(() => {
+    if (userData?.keys) {
+      setKeys(userData.keys);
+    }
+  }, [userData]);
 
-	useEffect(() => {
-		if (isSuccess) {
-			const newKey = {
-				keyId: data.data.keyId,
-				keyDescription: data.data.keyDescription,
-				key: data.data.key,
-				usageCount: data.data.usageCount,
-				createdAt: data.data.createdAt,
-				updatedAt: data.data.updatedAt,
-			};
-			setKeys([newKey, ...keys]);
-			setInputValue('');
-		} else if (errorMsg) {
-			setErrorMessage(errorMsg);
-			setInputValue('');
-		}
-	}, [isSuccess, errorMsg]);
+  useEffect(() => {
+    if (isSuccess) {
+      setShowKey(true);
+      const newKey = {
+        keyId: data.data.keyId,
+        keyDescription: data.data.keyDescription,
+        usageCount: data.data.usageCount,
+        createdAt: data.data.createdAt,
+        updatedAt: data.data.updatedAt,
+      };
+      setKeys([newKey, ...keys]);
+      setInputValue('');
+    } else if (errorMsg) {
+      setErrorMessage(errorMsg);
+      setInputValue('');
+    }
+  }, [isSuccess, errorMsg]);
 
-	useEffect(() => {
-		if (isDeleteSuccess) {
-			const updatedKeys = keys.filter((key) => key.keyId !== deletedKey);
-			setKeys(updatedKeys);
-			setDeletedKey(null);
-		}
-		if (errorDeleteMsg) {
-			setErrorMessage(errorDeleteMsg);
-		}
-	}, [errorDeleteMsg, isDeleteSuccess]);
+  useEffect(() => {
+    if (isDeleteSuccess) {
+      const updatedKeys = keys.filter((key) => key.keyId !== deletedKey);
+      setKeys(updatedKeys);
+      setDeletedKey(null);
+    }
+    if (errorDeleteMsg) {
+      setErrorMessage(errorDeleteMsg);
+    }
+  }, [errorDeleteMsg, isDeleteSuccess]);
 
-	useEffect(() => {
-		const deleteKeyFunction = async () => {
-			await makeDeleteRequest();
-		};
-		if (deletedKey) {
-			deleteKeyFunction();
-		}
-	}, [deletedKey]);
+  useEffect(() => {
+    const deleteKeyFunction = async () => {
+      await makeDeleteRequest();
+    };
+    if (deletedKey) {
+      deleteKeyFunction();
+    }
+  }, [deletedKey]);
 
-	async function handleGenerateKey(e) {
-		e.preventDefault();
-		if (inputValue.trim() === '') {
-			setErrorMessage('Description cannot be empty');
-			return;
-		}
-		if (inputValue.trim().length > 20) {
-			setErrorMessage('Description cannot be more than 20 characters');
-			return;
-		} else if (!isLettersAndSpacesOnly.test(inputValue)) {
-			setErrorMessage('Description must contain only alphabets and spaces');
-			return;
-		}
-		await makeRequest();
-	}
+  async function handleGenerateKey(e) {
+    e.preventDefault();
+    if (inputValue.trim() === '') {
+      setErrorMessage('Description cannot be empty');
+      return;
+    }
+    if (inputValue.trim().length > 20) {
+      setErrorMessage('Description cannot be more than 20 characters');
+      return;
+    } else if (!isLettersAndSpacesOnly.test(inputValue)) {
+      setErrorMessage('Description must contain only alphabets and spaces');
+      return;
+    }
+    await makeRequest();
+  }
 
-	const handleCopyToClipboard = async (apiKey) => {
-		await navigator.clipboard.writeText(apiKey);
-		setCopiedKey(apiKey);
-	};
+  const handleCopyToClipboard = async (apiKey) => {
+    await navigator.clipboard.writeText(apiKey);
+    setCopiedKey(apiKey);
+  };
 
-	return (
-		<div className='dashboard-container' data-testid='testid-dashboard'>
-			<div className='dashboard-content-container'>
-				<section className='dashboard-content-section'>
-					<CurrentPlan subscriptionData={userData?.subscription} />
-					<Usage
-						usedCalls={getUsedCalls(userData?.keys)}
-						totalCalls={userData?.subscription.usageLimit || 0}
-					/>
-					<div className='generate-api'>
-						<h1 className='content-item-heading'>Generate your API key</h1>
-						<ApiKeyForm
-							inputValue={inputValue}
-							setInputValue={setInputValue}
-							errorMessage={errorMessage}
-							loading={loading}
-							setErrorMessage={setErrorMessage}
-							handleGenerateKey={handleGenerateKey}
-						/>
-					</div>
-				</section>
-				<div className='divider'></div>
-				<ApiKeyTable
-					keys={keys}
-					copiedKey={copiedKey}
-					handleCopyToClipboard={handleCopyToClipboard}
-					deleteKey={setDeletedKey}
-				/>
-			</div>
-		</div>
-	);
+  const handleCloseKey = () => {
+    if (showKey) {
+      if (window.confirm('Are you sure you want to close the API key?')) {
+        setShowKey(false);
+      }
+    }
+  };
+
+  return (
+    <div className='dashboard-container' data-testid='testid-dashboard'>
+      <div className='dashboard-content-container'>
+        <section className='dashboard-content-section'>
+          <CurrentPlan subscriptionData={userData?.subscription} />
+          <Usage
+            usedCalls={getUsedCalls(userData?.keys)}
+            totalCalls={userData?.subscription.usageLimit || 0}
+          />
+          <div className='generate-api'>
+            <h1 className='content-item-heading'>Generate your API key</h1>
+            <ApiKeyForm
+              inputValue={inputValue}
+              setInputValue={setInputValue}
+              errorMessage={errorMessage}
+              loading={loading}
+              setErrorMessage={setErrorMessage}
+              handleGenerateKey={handleGenerateKey}
+            />
+          </div>
+        </section>
+        {showKey && (
+          <ApiKey
+            Key={data?.data?.key}
+            handleCloseKey={handleCloseKey}
+            handleCopyToClipboard={handleCopyToClipboard}
+          />
+        )}
+        <div className='divider'></div>
+        <ApiKeyTable
+          keys={keys}
+          copiedKey={copiedKey}
+          handleCopyToClipboard={handleCopyToClipboard}
+          deleteKey={setDeletedKey}
+          handleCloseKey={handleCloseKey}
+        />
+      </div>
+    </div>
+  );
 }
 
 export default Dashboard;
+

--- a/client/src/pages/dashboard/Dashboard.js
+++ b/client/src/pages/dashboard/Dashboard.js
@@ -109,9 +109,18 @@ function Dashboard() {
 		setCopiedKey(apiKey);
 	};
 
-	const handleCloseKey = () => {
+	const handleCloseKey = async (del) => {
 		if (showKey) {
-			if (window.confirm('Are you sure you want to close the API key?')) {
+			const nv = await navigator.clipboard.readText();
+			if (copiedKey !== nv && !del) {
+				if (
+					window.confirm(
+						'Are you sure you want to close the API key? ( You have not copied the key )',
+					)
+				) {
+					setShowKey(false);
+				}
+			} else {
 				setShowKey(false);
 			}
 		}

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -1,238 +1,237 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import Dashboard from './Dashboard';
-import { UserContext } from '../../contexts/UserContext';
-import { formatDate } from '../../utils/helpers';
+import {UserContext} from '../../contexts/UserContext';
+import {formatDate} from '../../utils/helpers';
 
 describe('Dashboard Component', () => {
-  const mockUserData = {
-    firstName: 'Anoop',
-    lastName: 'Singh',
-    email: 'aps08@gmail.com',
-    userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-    userType: 'CUSTOMER',
-    keys: [
-      {
-        keyId: '4d6544e38f5d4ad8bae546ea61e2b842',
-        usageCount: 0,
-        keyDescription: 'Demo Key',
-        updatedAt: formatDate(),
-        createdAt: formatDate(),
-      },
-    ],
-    subscription: {
-      subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-      subscriptionType: 'HOBBY',
-      keyLimit: 2,
-      usageLimit: 500,
-      isActive: false,
-      createdAt: '2024-04-11T10:24:38.501Z',
-      updatedAt: '2024-04-11T10:24:38.501Z',
-    },
-  };
-  const fetchUserData = jest.fn();
-  const renderDashboard = (userData = mockUserData) => {
-    render(
-      <UserContext.Provider value={{ userData, fetchUserData }}>
-        <Dashboard />
-      </UserContext.Provider>,
-    );
-  };
+	const mockUserData = {
+		firstName: 'Anoop',
+		lastName: 'Singh',
+		email: 'aps08@gmail.com',
+		userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+		userType: 'CUSTOMER',
+		keys: [
+			{
+				keyId: '4d6544e38f5d4ad8bae546ea61e2b842',
+				usageCount: 0,
+				keyDescription: 'Demo Key',
+				updatedAt: formatDate(),
+				createdAt: formatDate(),
+			},
+		],
+		subscription: {
+			subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+			subscriptionType: 'HOBBY',
+			keyLimit: 2,
+			usageLimit: 500,
+			isActive: false,
+			createdAt: '2024-04-11T10:24:38.501Z',
+			updatedAt: '2024-04-11T10:24:38.501Z',
+		},
+	};
+	const fetchUserData = jest.fn();
+	const renderDashboard = (userData = mockUserData) => {
+		render(
+			<UserContext.Provider value={{userData, fetchUserData}}>
+				<Dashboard />
+			</UserContext.Provider>,
+		);
+	};
 
-  it('renders Dashboard with all its components', () => {
-    renderDashboard();
-    const dashboardContainer = screen.getByTestId('testid-dashboard');
-    expect(dashboardContainer).toBeInTheDocument();
-    const currentPlanComponent = screen.getByText('Current Plan');
-    expect(currentPlanComponent).toBeInTheDocument();
-    const usageComponent = screen.getByText('Usage');
-    expect(usageComponent).toBeInTheDocument();
-    const apiKeyFormComponent = screen.getByText('Generate your API key');
-    expect(apiKeyFormComponent).toBeInTheDocument();
-    const apiKeyTableComponent = screen.getByText('DESCRIPTION');
-    expect(apiKeyTableComponent).toBeInTheDocument();
-  });
+	it('renders Dashboard with all its components', () => {
+		renderDashboard();
+		const dashboardContainer = screen.getByTestId('testid-dashboard');
+		expect(dashboardContainer).toBeInTheDocument();
+		const currentPlanComponent = screen.getByText('Current Plan');
+		expect(currentPlanComponent).toBeInTheDocument();
+		const usageComponent = screen.getByText('Usage');
+		expect(usageComponent).toBeInTheDocument();
+		const apiKeyFormComponent = screen.getByText('Generate your API key');
+		expect(apiKeyFormComponent).toBeInTheDocument();
+		const apiKeyTableComponent = screen.getByText('DESCRIPTION');
+		expect(apiKeyTableComponent).toBeInTheDocument();
+	});
 
-  it('Delete API key and removes it from the list', async () => {
-    renderDashboard();
-    const deleteButton = screen.getAllByTestId('api-key-delete');
-    const deletedApiKeyDescription = screen.queryByText('Demo Key');
-    fireEvent.click(deleteButton[0]);
-    const confirmButton = screen.getByText(/Okay/i);
-    fireEvent.click(confirmButton);
-    await waitFor(() => {
-      expect(deletedApiKeyDescription).not.toBeInTheDocument();
-    });
-  });
+	it('Delete API key and removes it from the list', async () => {
+		renderDashboard();
+		const deleteButton = screen.getAllByTestId('api-key-delete');
+		const deletedApiKeyDescription = screen.queryByText('Demo Key');
+		fireEvent.click(deleteButton[0]);
+		const confirmButton = screen.getByText(/Okay/i);
+		fireEvent.click(confirmButton);
+		await waitFor(() => {
+			expect(deletedApiKeyDescription).not.toBeInTheDocument();
+		});
+	});
 
-  it('Delete API Key fails on wrong keyId', async () => {
-    const wrongKeyData = {
-      firstName: 'Anoop',
-      lastName: 'Singh',
-      email: 'aps08@gmail.com',
-      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-      userType: 'CUSTOMER',
-      keys: [
-        {
-          keyId: 'LogoExecutive@007',
-          key: '4d6544e38f5d4ad8bae546ea61e2b842',
-          usageCount: '0',
-          keyDescription: 'Demo Key',
-          updatedAt: formatDate(),
-          createdAt: formatDate(),
-        },
-      ],
-      subscription: {
-        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-        subscriptionType: 'HOBBY',
-        keyLimit: 2,
-        usageLimit: 500,
-        isActive: false,
-        createdAt: '2024-04-11T10:24:38.501Z',
-        updatedAt: '2024-04-11T10:24:38.501Z',
-      },
-    };
-    renderDashboard(wrongKeyData);
-    const deleteButton = screen.getAllByTestId('api-key-delete');
-    const deletedApiKeyDescription = screen.queryByText('Demo Key');
-    fireEvent.click(deleteButton[0]);
-    const confirmButton = screen.getByText(/Okay/i);
-    fireEvent.click(confirmButton);
-    await waitFor(() => {
-      expect(screen.getByText('Key ID is required')).toBeInTheDocument();
-    });
-    expect(deletedApiKeyDescription).toBeInTheDocument();
-  });
+	it('Delete API Key fails on wrong keyId', async () => {
+		const wrongKeyData = {
+			firstName: 'Anoop',
+			lastName: 'Singh',
+			email: 'aps08@gmail.com',
+			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+			userType: 'CUSTOMER',
+			keys: [
+				{
+					keyId: 'LogoExecutive@007',
+					key: '4d6544e38f5d4ad8bae546ea61e2b842',
+					usageCount: '0',
+					keyDescription: 'Demo Key',
+					updatedAt: formatDate(),
+					createdAt: formatDate(),
+				},
+			],
+			subscription: {
+				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+				subscriptionType: 'HOBBY',
+				keyLimit: 2,
+				usageLimit: 500,
+				isActive: false,
+				createdAt: '2024-04-11T10:24:38.501Z',
+				updatedAt: '2024-04-11T10:24:38.501Z',
+			},
+		};
+		renderDashboard(wrongKeyData);
+		const deleteButton = screen.getAllByTestId('api-key-delete');
+		const deletedApiKeyDescription = screen.queryByText('Demo Key');
+		fireEvent.click(deleteButton[0]);
+		const confirmButton = screen.getByText(/Okay/i);
+		fireEvent.click(confirmButton);
+		await waitFor(() => {
+			expect(screen.getByText('Key ID is required')).toBeInTheDocument();
+		});
+		expect(deletedApiKeyDescription).toBeInTheDocument();
+	});
 
-  it('generates API key and adds to the list', async () => {
-    renderDashboard();
-    const descriptionInput = screen.getByLabelText('Description For API Key');
-    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
-    const generateButton = screen.getByText('Generate Key');
-    fireEvent.click(generateButton);
-    await waitFor(() => {
-      expect(screen.getByText('Test API Key')).toBeInTheDocument();
-    });
-    const tableElement = screen.getByRole('table');
-    const keyRows = screen.queryAllByRole('row', { container: tableElement });
-    expect(keyRows).toHaveLength(3);
-    expect(screen.getAllByText(formatDate())).toHaveLength(2);
-    expect(descriptionInput).toHaveValue('');
-  });
+	it('generates API key and adds to the list', async () => {
+		renderDashboard();
+		const descriptionInput = screen.getByLabelText('Description For API Key');
+		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
+		const generateButton = screen.getByText('Generate Key');
+		fireEvent.click(generateButton);
+		await waitFor(() => {
+			expect(screen.getByText('Test API Key')).toBeInTheDocument();
+		});
+		const tableElement = screen.getByRole('table');
+		const keyRows = screen.queryAllByRole('row', {container: tableElement});
+		expect(keyRows).toHaveLength(3);
+		expect(screen.getAllByText(formatDate())).toHaveLength(2);
+		expect(descriptionInput).toHaveValue('');
+	});
 
-  it('checks if no keys are displayed when there are no keys', async () => {
-    const mockNullData = {
-      firstName: 'Aasish',
-      lastName: 'M',
-      email: 'aasishnilambur@gmail.com',
-      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-      userType: 'CUSTOMER',
-      keys: null,
-      subscription: {
-        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-        subscriptionType: 'HOBBY',
-        keyLimit: 2,
-        usageLimit: 400,
-        isActive: false,
-        createdAt: '2024-04-11T10:24:38.501Z',
-        updatedAt: '2024-04-11T10:24:38.501Z',
-      },
-    };
-    renderDashboard(mockNullData);
-    await waitFor(() => {
-      expect(fetchUserData).toHaveBeenCalled();
-    });
-    expect(
-      screen.getByText(
-        'Your api keys will be visible here, click on generate key to add new api key',
-      ),
-    ).toBeInTheDocument();
-    const tableElement = screen.getByRole('table');
-    const keyRows = screen.queryAllByRole('row', { container: tableElement });
-    expect(keyRows).toHaveLength(2);
-  });
+	it('checks if no keys are displayed when there are no keys', async () => {
+		const mockNullData = {
+			firstName: 'Aasish',
+			lastName: 'M',
+			email: 'aasishnilambur@gmail.com',
+			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+			userType: 'CUSTOMER',
+			keys: null,
+			subscription: {
+				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+				subscriptionType: 'HOBBY',
+				keyLimit: 2,
+				usageLimit: 400,
+				isActive: false,
+				createdAt: '2024-04-11T10:24:38.501Z',
+				updatedAt: '2024-04-11T10:24:38.501Z',
+			},
+		};
+		renderDashboard(mockNullData);
+		await waitFor(() => {
+			expect(fetchUserData).toHaveBeenCalled();
+		});
+		expect(
+			screen.getByText(
+				'Your api keys will be visible here, click on generate key to add new api key',
+			),
+		).toBeInTheDocument();
+		const tableElement = screen.getByRole('table');
+		const keyRows = screen.queryAllByRole('row', {container: tableElement});
+		expect(keyRows).toHaveLength(2);
+	});
 
-  it('Check if used calls and total calls are being rendered', () => {
-    const mockNullData = {
-      firstName: 'Aasish',
-      lastName: 'M',
-      email: 'aasishnilambur@gmail.com',
-      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-      userType: 'CUSTOMER',
-      keys: null,
-      subscription: {
-        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-        subscriptionType: 'HOBBY',
-        keyLimit: 2,
-        usageLimit: 0,
-        isActive: false,
-        createdAt: '2024-04-11T10:24:38.501Z',
-        updatedAt: '2024-04-11T10:24:38.501Z',
-      },
-    };
-    renderDashboard(mockNullData);
-    const zeroCalls = screen.getAllByText('0 calls');
-    expect(zeroCalls).toHaveLength(2);
-  });
+	it('Check if used calls and total calls are being rendered', () => {
+		const mockNullData = {
+			firstName: 'Aasish',
+			lastName: 'M',
+			email: 'aasishnilambur@gmail.com',
+			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+			userType: 'CUSTOMER',
+			keys: null,
+			subscription: {
+				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+				subscriptionType: 'HOBBY',
+				keyLimit: 2,
+				usageLimit: 0,
+				isActive: false,
+				createdAt: '2024-04-11T10:24:38.501Z',
+				updatedAt: '2024-04-11T10:24:38.501Z',
+			},
+		};
+		renderDashboard(mockNullData);
+		const zeroCalls = screen.getAllByText('0 calls');
+		expect(zeroCalls).toHaveLength(2);
+	});
 
-  it('Throws error when same key description is given again', async () => {
-    renderDashboard();
-    const descriptionInput = screen.getByLabelText('Description For API Key');
-    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
-    const generateButton = screen.getByText('Generate Key');
-    fireEvent.click(generateButton);
-    await waitFor(() => {
-      expect(
-        screen.getByText('Please provide a different key description'),
-      ).toBeInTheDocument();
-    });
-  });
+	it('Throws error when same key description is given again', async () => {
+		renderDashboard();
+		const descriptionInput = screen.getByLabelText('Description For API Key');
+		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
+		const generateButton = screen.getByText('Generate Key');
+		fireEvent.click(generateButton);
+		await waitFor(() => {
+			expect(
+				screen.getByText('Please provide a different key description'),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('Throws limit error for keys more than 2', async () => {
-    renderDashboard();
-    const descriptionInput = screen.getByLabelText('Description For API Key');
-    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
-    const generateButton = screen.getByText('Generate Key');
-    fireEvent.click(generateButton);
-    await waitFor(() => {
-      expect(
-        screen.getByText('Limit reached. Consider upgrading your plan'),
-      ).toBeInTheDocument();
-    });
-  });
+	it('Throws limit error for keys more than 2', async () => {
+		renderDashboard();
+		const descriptionInput = screen.getByLabelText('Description For API Key');
+		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
+		const generateButton = screen.getByText('Generate Key');
+		fireEvent.click(generateButton);
+		await waitFor(() => {
+			expect(
+				screen.getByText('Limit reached. Consider upgrading your plan'),
+			).toBeInTheDocument();
+		});
+	});
 
-  it('shows an error message when trying to generate a key without a description', async () => {
-    renderDashboard();
-    const button = screen.getByText('Generate Key');
-    fireEvent.click(button);
-    const errordocument = screen.getByText('Description cannot be empty');
-    expect(errordocument).toBeInTheDocument();
-  });
+	it('shows an error message when trying to generate a key without a description', async () => {
+		renderDashboard();
+		const button = screen.getByText('Generate Key');
+		fireEvent.click(button);
+		const errordocument = screen.getByText('Description cannot be empty');
+		expect(errordocument).toBeInTheDocument();
+	});
 
-  it('shows an error message when trying to generate a key greater than 20 characters', () => {
-    renderDashboard();
-    const descriptionInput = screen.getByLabelText('Description For API Key');
-    fireEvent.change(descriptionInput, {
-      target: { value: 'Long string text more than twenty characters' },
-    });
-    const generateButton = screen.getByText('Generate Key');
-    fireEvent.click(generateButton);
-    const errordocument = screen.getByText(
-      'Description cannot be more than 20 characters',
-    );
-    expect(errordocument).toBeInTheDocument();
-  });
+	it('shows an error message when trying to generate a key greater than 20 characters', () => {
+		renderDashboard();
+		const descriptionInput = screen.getByLabelText('Description For API Key');
+		fireEvent.change(descriptionInput, {
+			target: {value: 'Long string text more than twenty characters'},
+		});
+		const generateButton = screen.getByText('Generate Key');
+		fireEvent.click(generateButton);
+		const errordocument = screen.getByText(
+			'Description cannot be more than 20 characters',
+		);
+		expect(errordocument).toBeInTheDocument();
+	});
 
-  it('shows an error message when trying to generate a key having numbers', () => {
-    renderDashboard();
-    const descriptionInput = screen.getByLabelText('Description For API Key');
-    fireEvent.change(descriptionInput, { target: { value: 'Test API 1222' } });
-    const generateButton = screen.getByText('Generate Key');
-    fireEvent.click(generateButton);
-    const errordocument = screen.getByText(
-      'Description must contain only alphabets and spaces',
-    );
-    expect(errordocument).toBeInTheDocument();
-  });
+	it('shows an error message when trying to generate a key having numbers', () => {
+		renderDashboard();
+		const descriptionInput = screen.getByLabelText('Description For API Key');
+		fireEvent.change(descriptionInput, {target: {value: 'Test API 1222'}});
+		const generateButton = screen.getByText('Generate Key');
+		fireEvent.click(generateButton);
+		const errordocument = screen.getByText(
+			'Description must contain only alphabets and spaces',
+		);
+		expect(errordocument).toBeInTheDocument();
+	});
 });
-

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -1,253 +1,238 @@
 import React from 'react';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Dashboard from './Dashboard';
-import {UserContext} from '../../contexts/UserContext';
-import {formatDate} from '../../utils/helpers';
+import { UserContext } from '../../contexts/UserContext';
+import { formatDate } from '../../utils/helpers';
 
 describe('Dashboard Component', () => {
-	const mockUserData = {
-		firstName: 'Anoop',
-		lastName: 'Singh',
-		email: 'aps08@gmail.com',
-		userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-		userType: 'CUSTOMER',
-		keys: [
-			{
-				keyId: '4d6544e38f5d4ad8bae546ea61e2b842',
-				key: '4d6544e38f5d4ad8bae546ea61e2b842',
-				usageCount: '0',
-				keyDescription: 'Demo Key',
-				updatedAt: formatDate(),
-				createdAt: formatDate(),
-			},
-		],
-		subscription: {
-			subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-			subscriptionType: 'HOBBY',
-			keyLimit: 2,
-			usageLimit: 500,
-			isActive: false,
-			createdAt: '2024-04-11T10:24:38.501Z',
-			updatedAt: '2024-04-11T10:24:38.501Z',
-		},
-	};
-	const fetchUserData = jest.fn();
-	const renderDashboard = (userData = mockUserData) => {
-		render(
-			<UserContext.Provider value={{userData, fetchUserData}}>
-				<Dashboard />
-			</UserContext.Provider>,
-		);
-	};
+  const mockUserData = {
+    firstName: 'Anoop',
+    lastName: 'Singh',
+    email: 'aps08@gmail.com',
+    userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+    userType: 'CUSTOMER',
+    keys: [
+      {
+        keyId: '4d6544e38f5d4ad8bae546ea61e2b842',
+        usageCount: 0,
+        keyDescription: 'Demo Key',
+        updatedAt: formatDate(),
+        createdAt: formatDate(),
+      },
+    ],
+    subscription: {
+      subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+      subscriptionType: 'HOBBY',
+      keyLimit: 2,
+      usageLimit: 500,
+      isActive: false,
+      createdAt: '2024-04-11T10:24:38.501Z',
+      updatedAt: '2024-04-11T10:24:38.501Z',
+    },
+  };
+  const fetchUserData = jest.fn();
+  const renderDashboard = (userData = mockUserData) => {
+    render(
+      <UserContext.Provider value={{ userData, fetchUserData }}>
+        <Dashboard />
+      </UserContext.Provider>,
+    );
+  };
 
-	it('renders Dashboard with all its components', () => {
-		renderDashboard();
-		const dashboardContainer = screen.getByTestId('testid-dashboard');
-		expect(dashboardContainer).toBeInTheDocument();
-		const currentPlanComponent = screen.getByText('Current Plan');
-		expect(currentPlanComponent).toBeInTheDocument();
-		const usageComponent = screen.getByText('Usage');
-		expect(usageComponent).toBeInTheDocument();
-		const apiKeyFormComponent = screen.getByText('Generate your API key');
-		expect(apiKeyFormComponent).toBeInTheDocument();
-		const apiKeyTableComponent = screen.getByText('DESCRIPTION');
-		expect(apiKeyTableComponent).toBeInTheDocument();
-	});
+  it('renders Dashboard with all its components', () => {
+    renderDashboard();
+    const dashboardContainer = screen.getByTestId('testid-dashboard');
+    expect(dashboardContainer).toBeInTheDocument();
+    const currentPlanComponent = screen.getByText('Current Plan');
+    expect(currentPlanComponent).toBeInTheDocument();
+    const usageComponent = screen.getByText('Usage');
+    expect(usageComponent).toBeInTheDocument();
+    const apiKeyFormComponent = screen.getByText('Generate your API key');
+    expect(apiKeyFormComponent).toBeInTheDocument();
+    const apiKeyTableComponent = screen.getByText('DESCRIPTION');
+    expect(apiKeyTableComponent).toBeInTheDocument();
+  });
 
-	it('Delete API key and removes it from the list', async () => {
-		renderDashboard();
-		const deleteButton = screen.getAllByTestId('api-key-delete');
-		const deletedApiKeyDescription = screen.queryByText('Demo Key');
-		fireEvent.click(deleteButton[0]);
-		const confirmButton = screen.getByText(/Okay/i);
-		fireEvent.click(confirmButton);
-		await waitFor(() => {
-			expect(deletedApiKeyDescription).not.toBeInTheDocument();
-		});
-	});
+  it('Delete API key and removes it from the list', async () => {
+    renderDashboard();
+    const deleteButton = screen.getAllByTestId('api-key-delete');
+    const deletedApiKeyDescription = screen.queryByText('Demo Key');
+    fireEvent.click(deleteButton[0]);
+    const confirmButton = screen.getByText(/Okay/i);
+    fireEvent.click(confirmButton);
+    await waitFor(() => {
+      expect(deletedApiKeyDescription).not.toBeInTheDocument();
+    });
+  });
 
-	it('Delete API Key fails on wrong keyId', async () => {
-		const wrongKeyData = {
-			firstName: 'Anoop',
-			lastName: 'Singh',
-			email: 'aps08@gmail.com',
-			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-			userType: 'CUSTOMER',
-			keys: [
-				{
-					keyId: 'LogoExecutive@007',
-					key: '4d6544e38f5d4ad8bae546ea61e2b842',
-					usageCount: '0',
-					keyDescription: 'Demo Key',
-					updatedAt: formatDate(),
-					createdAt: formatDate(),
-				},
-			],
-			subscription: {
-				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-				subscriptionType: 'HOBBY',
-				keyLimit: 2,
-				usageLimit: 500,
-				isActive: false,
-				createdAt: '2024-04-11T10:24:38.501Z',
-				updatedAt: '2024-04-11T10:24:38.501Z',
-			},
-		};
-		renderDashboard(wrongKeyData);
-		const deleteButton = screen.getAllByTestId('api-key-delete');
-		const deletedApiKeyDescription = screen.queryByText('Demo Key');
-		fireEvent.click(deleteButton[0]);
-		const confirmButton = screen.getByText(/Okay/i);
-		fireEvent.click(confirmButton);
-		await waitFor(() => {
-			expect(screen.getByText('Key ID is required')).toBeInTheDocument();
-		});
-		expect(deletedApiKeyDescription).toBeInTheDocument();
-	});
+  it('Delete API Key fails on wrong keyId', async () => {
+    const wrongKeyData = {
+      firstName: 'Anoop',
+      lastName: 'Singh',
+      email: 'aps08@gmail.com',
+      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+      userType: 'CUSTOMER',
+      keys: [
+        {
+          keyId: 'LogoExecutive@007',
+          key: '4d6544e38f5d4ad8bae546ea61e2b842',
+          usageCount: '0',
+          keyDescription: 'Demo Key',
+          updatedAt: formatDate(),
+          createdAt: formatDate(),
+        },
+      ],
+      subscription: {
+        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+        subscriptionType: 'HOBBY',
+        keyLimit: 2,
+        usageLimit: 500,
+        isActive: false,
+        createdAt: '2024-04-11T10:24:38.501Z',
+        updatedAt: '2024-04-11T10:24:38.501Z',
+      },
+    };
+    renderDashboard(wrongKeyData);
+    const deleteButton = screen.getAllByTestId('api-key-delete');
+    const deletedApiKeyDescription = screen.queryByText('Demo Key');
+    fireEvent.click(deleteButton[0]);
+    const confirmButton = screen.getByText(/Okay/i);
+    fireEvent.click(confirmButton);
+    await waitFor(() => {
+      expect(screen.getByText('Key ID is required')).toBeInTheDocument();
+    });
+    expect(deletedApiKeyDescription).toBeInTheDocument();
+  });
 
-	it('generates API key and adds to the list', async () => {
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		await waitFor(() => {
-			expect(screen.getByText('Test API Key')).toBeInTheDocument();
-		});
-		const tableElement = screen.getByRole('table');
-		const keyRows = screen.queryAllByRole('row', {container: tableElement});
-		expect(keyRows).toHaveLength(3);
-		expect(screen.getAllByText(formatDate())).toHaveLength(2);
-		expect(descriptionInput).toHaveValue('');
-	});
+  it('generates API key and adds to the list', async () => {
+    renderDashboard();
+    const descriptionInput = screen.getByLabelText('Description For API Key');
+    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
+    const generateButton = screen.getByText('Generate Key');
+    fireEvent.click(generateButton);
+    await waitFor(() => {
+      expect(screen.getByText('Test API Key')).toBeInTheDocument();
+    });
+    const tableElement = screen.getByRole('table');
+    const keyRows = screen.queryAllByRole('row', { container: tableElement });
+    expect(keyRows).toHaveLength(3);
+    expect(screen.getAllByText(formatDate())).toHaveLength(2);
+    expect(descriptionInput).toHaveValue('');
+  });
 
-	it('checks if no keys are displayed when there are no keys', async () => {
-		const mockNullData = {
-			firstName: 'Aasish',
-			lastName: 'M',
-			email: 'aasishnilambur@gmail.com',
-			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-			userType: 'CUSTOMER',
-			keys: null,
-			subscription: {
-				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-				subscriptionType: 'HOBBY',
-				keyLimit: 2,
-				usageLimit: 400,
-				isActive: false,
-				createdAt: '2024-04-11T10:24:38.501Z',
-				updatedAt: '2024-04-11T10:24:38.501Z',
-			},
-		};
-		renderDashboard(mockNullData);
-		await waitFor(() => {
-			expect(fetchUserData).toHaveBeenCalled();
-		});
-		expect(
-			screen.getByText(
-				'Your api keys will be visible here, click on generate key to add new api key',
-			),
-		).toBeInTheDocument();
-		const tableElement = screen.getByRole('table');
-		const keyRows = screen.queryAllByRole('row', {container: tableElement});
-		expect(keyRows).toHaveLength(2);
-	});
+  it('checks if no keys are displayed when there are no keys', async () => {
+    const mockNullData = {
+      firstName: 'Aasish',
+      lastName: 'M',
+      email: 'aasishnilambur@gmail.com',
+      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+      userType: 'CUSTOMER',
+      keys: null,
+      subscription: {
+        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+        subscriptionType: 'HOBBY',
+        keyLimit: 2,
+        usageLimit: 400,
+        isActive: false,
+        createdAt: '2024-04-11T10:24:38.501Z',
+        updatedAt: '2024-04-11T10:24:38.501Z',
+      },
+    };
+    renderDashboard(mockNullData);
+    await waitFor(() => {
+      expect(fetchUserData).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByText(
+        'Your api keys will be visible here, click on generate key to add new api key',
+      ),
+    ).toBeInTheDocument();
+    const tableElement = screen.getByRole('table');
+    const keyRows = screen.queryAllByRole('row', { container: tableElement });
+    expect(keyRows).toHaveLength(2);
+  });
 
-	it('Check if used calls and total calls are being rendered', () => {
-		const mockNullData = {
-			firstName: 'Aasish',
-			lastName: 'M',
-			email: 'aasishnilambur@gmail.com',
-			userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
-			userType: 'CUSTOMER',
-			keys: null,
-			subscription: {
-				subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
-				subscriptionType: 'HOBBY',
-				keyLimit: 2,
-				usageLimit: 0,
-				isActive: false,
-				createdAt: '2024-04-11T10:24:38.501Z',
-				updatedAt: '2024-04-11T10:24:38.501Z',
-			},
-		};
-		renderDashboard(mockNullData);
-		const zeroCalls = screen.getAllByText('0 calls');
-		expect(zeroCalls).toHaveLength(2);
-	});
+  it('Check if used calls and total calls are being rendered', () => {
+    const mockNullData = {
+      firstName: 'Aasish',
+      lastName: 'M',
+      email: 'aasishnilambur@gmail.com',
+      userId: '99234290-a33b-40d1-a5d4-888e86d06cd1',
+      userType: 'CUSTOMER',
+      keys: null,
+      subscription: {
+        subscriptionId: '4d6544e3-8f5d-4ad8-bae5-46ea61e2b842',
+        subscriptionType: 'HOBBY',
+        keyLimit: 2,
+        usageLimit: 0,
+        isActive: false,
+        createdAt: '2024-04-11T10:24:38.501Z',
+        updatedAt: '2024-04-11T10:24:38.501Z',
+      },
+    };
+    renderDashboard(mockNullData);
+    const zeroCalls = screen.getAllByText('0 calls');
+    expect(zeroCalls).toHaveLength(2);
+  });
 
-	it('Throws error when same key description is given again', async () => {
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		await waitFor(() => {
-			expect(
-				screen.getByText('Please provide a different key description'),
-			).toBeInTheDocument();
-		});
-	});
+  it('Throws error when same key description is given again', async () => {
+    renderDashboard();
+    const descriptionInput = screen.getByLabelText('Description For API Key');
+    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
+    const generateButton = screen.getByText('Generate Key');
+    fireEvent.click(generateButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText('Please provide a different key description'),
+      ).toBeInTheDocument();
+    });
+  });
 
-	it('Throws limit error for keys more than 2', async () => {
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		await waitFor(() => {
-			expect(
-				screen.getByText('Limit reached. Consider upgrading your plan'),
-			).toBeInTheDocument();
-		});
-	});
+  it('Throws limit error for keys more than 2', async () => {
+    renderDashboard();
+    const descriptionInput = screen.getByLabelText('Description For API Key');
+    fireEvent.change(descriptionInput, { target: { value: 'Test API Key' } });
+    const generateButton = screen.getByText('Generate Key');
+    fireEvent.click(generateButton);
+    await waitFor(() => {
+      expect(
+        screen.getByText('Limit reached. Consider upgrading your plan'),
+      ).toBeInTheDocument();
+    });
+  });
 
-	it('shows an error message when trying to generate a key without a description', async () => {
-		renderDashboard();
-		const button = screen.getByText('Generate Key');
-		fireEvent.click(button);
-		const errordocument = screen.getByText('Description cannot be empty');
-		expect(errordocument).toBeInTheDocument();
-	});
+  it('shows an error message when trying to generate a key without a description', async () => {
+    renderDashboard();
+    const button = screen.getByText('Generate Key');
+    fireEvent.click(button);
+    const errordocument = screen.getByText('Description cannot be empty');
+    expect(errordocument).toBeInTheDocument();
+  });
 
-	it('shows an error message when trying to generate a key greater than 20 characters', () => {
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {
-			target: {value: 'Long string text more than twenty characters'},
-		});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		const errordocument = screen.getByText(
-			'Description cannot be more than 20 characters',
-		);
-		expect(errordocument).toBeInTheDocument();
-	});
+  it('shows an error message when trying to generate a key greater than 20 characters', () => {
+    renderDashboard();
+    const descriptionInput = screen.getByLabelText('Description For API Key');
+    fireEvent.change(descriptionInput, {
+      target: { value: 'Long string text more than twenty characters' },
+    });
+    const generateButton = screen.getByText('Generate Key');
+    fireEvent.click(generateButton);
+    const errordocument = screen.getByText(
+      'Description cannot be more than 20 characters',
+    );
+    expect(errordocument).toBeInTheDocument();
+  });
 
-	it('shows an error message when trying to generate a key having numbers', () => {
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {target: {value: 'Test API 1222'}});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		const errordocument = screen.getByText(
-			'Description must contain only alphabets and spaces',
-		);
-		expect(errordocument).toBeInTheDocument();
-	});
-
-	it('copies API key to clipboard', async () => {
-		global.navigator.clipboard = {
-			writeText: jest.fn(),
-		};
-		renderDashboard();
-		const descriptionInput = screen.getByLabelText('Description For API Key');
-		fireEvent.change(descriptionInput, {target: {value: 'Test API Key'}});
-		const generateButton = screen.getByText('Generate Key');
-		fireEvent.click(generateButton);
-		const buttons = screen.getAllByTestId('api-key-copy');
-		fireEvent.click(buttons[0]);
-		const inscreenirem = await screen.findByTestId('api-key-copied');
-		expect(inscreenirem).toBeInTheDocument();
-	});
+  it('shows an error message when trying to generate a key having numbers', () => {
+    renderDashboard();
+    const descriptionInput = screen.getByLabelText('Description For API Key');
+    fireEvent.change(descriptionInput, { target: { value: 'Test API 1222' } });
+    const generateButton = screen.getByText('Generate Key');
+    fireEvent.click(generateButton);
+    const errordocument = screen.getByText(
+      'Description must contain only alphabets and spaces',
+    );
+    expect(errordocument).toBeInTheDocument();
+  });
 });
+

--- a/server/__tests__/unit/services/Keys.js
+++ b/server/__tests__/unit/services/Keys.js
@@ -1,9 +1,4 @@
-const {
-  createKey,
-  fetchKeysByuserid,
-  isAPIKeyPresent,
-  destroyKey,
-} = require("../../../services");
+const { createKey, fetchKeysByuserid, isAPIKeyPresent, destroyKey } = require("../../../services");
 const Keys = require("../../../models/Keys");
 const { mockKeys } = require("../../../utils/mocks/Keys");
 const mongoose = require("mongoose");
@@ -67,9 +62,7 @@ describe("fetchKeysByUserId", () => {
   });
 
   test("should return null if no keys are found for the provided userId", async () => {
-    const nonExistingUser = new mongoose.Types.ObjectId(
-      "21FB95E0E988B2F5883106C0",
-    );
+    const nonExistingUser = new mongoose.Types.ObjectId();
     const result = await fetchKeysByuserid(nonExistingUser);
     expect(result).toBeNull();
   });

--- a/server/__tests__/unit/services/Keys.js
+++ b/server/__tests__/unit/services/Keys.js
@@ -1,4 +1,9 @@
-const { createKey, fetchKeysByuserid, isAPIKeyPresent, destroyKey } = require("../../../services");
+const {
+  createKey,
+  fetchKeysByuserid,
+  isAPIKeyPresent,
+  destroyKey,
+} = require("../../../services");
 const Keys = require("../../../models/Keys");
 const { mockKeys } = require("../../../utils/mocks/Keys");
 const mongoose = require("mongoose");
@@ -58,11 +63,13 @@ describe("fetchKeysByUserId", () => {
   test("should not include 'key' property in returned keys", async () => {
     const result = await fetchKeysByuserid(mockKeys[0].user);
     // Assert that 'key' property is absent in each object of the result
-    expect(result.every(keyObj => !keyObj.hasOwnProperty('key'))).toBe(true);
+    expect(result.every((keyObj) => !keyObj.hasOwnProperty("key"))).toBe(true);
   });
 
   test("should return null if no keys are found for the provided userId", async () => {
-    const nonExistingUser = new mongoose.Types.ObjectId("21FB95E0E988B2F5883106C0");
+    const nonExistingUser = new mongoose.Types.ObjectId(
+      "21FB95E0E988B2F5883106C0",
+    );
     const result = await fetchKeysByuserid(nonExistingUser);
     expect(result).toBeNull();
   });
@@ -71,7 +78,9 @@ describe("fetchKeysByUserId", () => {
     const errorMessage = "Database operation failed";
 
     jest.spyOn(Keys, "find").mockRejectedValueOnce(new Error(errorMessage));
-    await expect(fetchKeysByuserid(mockKeys[0].user)).rejects.toThrow(errorMessage);
+    await expect(fetchKeysByuserid(mockKeys[0].user)).rejects.toThrow(
+      errorMessage,
+    );
   });
 });
 
@@ -119,7 +128,9 @@ describe("destroyKey", () => {
   test("should throw an error if the delete operation fails", async () => {
     const errorMessage = "Database operation failed";
 
-    jest.spyOn(Keys, "deleteOne").mockRejectedValueOnce(new Error(errorMessage));
+    jest
+      .spyOn(Keys, "deleteOne")
+      .mockRejectedValueOnce(new Error(errorMessage));
 
     await expect(destroyKey(createdKey._id)).rejects.toThrow(errorMessage);
   });

--- a/server/__tests__/unit/services/Keys.js
+++ b/server/__tests__/unit/services/Keys.js
@@ -34,7 +34,7 @@ describe("createKey", () => {
     jest.spyOn(Keys.prototype, "save").mockImplementationOnce(() => {
       throw new Error(errorMessage);
     });
-    
+
     await expect(createKey(mockKeys[0])).rejects.toThrow(errorMessage);
   });
 });
@@ -53,6 +53,12 @@ describe("fetchKeysByUserId", () => {
     const result = await fetchKeysByuserid(mockKeys[0].user);
     expect(result.length).toBe(mockKeys.length);
     // expect(result[0]).toBeInstanceOf(Keys);
+  });
+
+  test("should not include 'key' property in returned keys", async () => {
+    const result = await fetchKeysByuserid(mockKeys[0].user);
+    // Assert that 'key' property is absent in each object of the result
+    expect(result.every(keyObj => !keyObj.hasOwnProperty('key'))).toBe(true);
   });
 
   test("should return null if no keys are found for the provided userId", async () => {

--- a/server/services/Keys.js
+++ b/server/services/Keys.js
@@ -81,4 +81,3 @@ module.exports = {
   destroyKey,
   isAPIKeyPresent,
 };
-

--- a/server/services/Keys.js
+++ b/server/services/Keys.js
@@ -21,7 +21,7 @@ async function createKey(data) {
 
     const UserKey = new Keys(keyData);
     const result = await UserKey.save();
-    if(!result) return null;
+    if (!result) return null;
     const { _id, ...restKeyData } = result._doc;
     const key = { keyId: _id, ...restKeyData };
     return key;
@@ -36,11 +36,11 @@ async function createKey(data) {
  **/
 async function fetchKeysByuserid(user) {
   try {
-    const keys = await Keys.find({"user": user});
+    const keys = await Keys.find({ user: user });
     if (!keys.length) return null;
-    const filteredKeys = keys.map(( {_doc: { _id, ...restKeyData }})=>({
-      keyId:_id,
-      ...restKeyData
+    const filteredKeys = keys.map(({ _doc: { _id, key, ...restKeyData } }) => ({
+      keyId: _id,
+      ...restKeyData,
     }));
     return filteredKeys;
   } catch (err) {
@@ -54,7 +54,7 @@ async function fetchKeysByuserid(user) {
  **/
 async function isAPIKeyPresent(apiKey) {
   try {
-    const keyRef = await Keys.find({"key": apiKey});
+    const keyRef = await Keys.find({ key: apiKey });
     return keyRef.length > 0;
   } catch (err) {
     throw err;
@@ -67,8 +67,8 @@ async function isAPIKeyPresent(apiKey) {
  **/
 async function destroyKey(_id) {
   try {
-    const keyRef = await Keys.deleteOne({"_id": _id});
-    if(keyRef.deletedCount === 0) throw new Error("Database operation failed");
+    const keyRef = await Keys.deleteOne({ _id: _id });
+    if (keyRef.deletedCount === 0) throw new Error("Database operation failed");
     return true;
   } catch (err) {
     throw err;
@@ -81,3 +81,4 @@ module.exports = {
   destroyKey,
   isAPIKeyPresent,
 };
+


### PR DESCRIPTION
### Summary
This PR adds more abstraction to API Key where users can retrieve or access their API Key only once which is at generation. as mentioned in #343 .

### Description
Changed UI components/Dashboard:
-ApiKey.js (New Component to show api key)
-ApikeyTable.js (Removed API key column)
-Dashboard.js 
Changed backend controllers:
-fetchKeysByuserid (Modified to not respond with api keys ) 

### How to Test the Changes
Login and generate a new API key 

### Screenshots or Recordings (Optional)
![screenshot_000](https://github.com/user-attachments/assets/5526bb29-42fd-4a3b-9958-f3889a9ee668)

https://github.com/user-attachments/assets/a3ca6a2f-e11e-4b84-8279-d06e7c26fbe9

## Checklist
- [✅] I have tested the changes locally and they work as expected.
- [✅] I have added/updated tests that cover the changes.
- [✅] I have updated the documentation to reflect the changes.
- [✅] This pull request follows the project's coding guidelines.
