### PR TITLE
Add Automated Script to Reset Subscription Usage Count Every 30 Days

### DIFF
--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -8,7 +8,14 @@ on:
 jobs:
   refresh_usage_count:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
+      - name: set timezone
+        run: |
+          sudo timedatectl set-timezone Asia/Kolkata
+          sudo timedatectl set-ntp true
+          timedatectl
+      
       - name: Checkout code
         uses: actions/checkout@v3
 

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -16,18 +16,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-      
-      - name: Create temp directory for mongoose
-        run: mkdir -p temp-dir
 
-      - name: Install mongoose
-        run: |
-          cd temp-dir
-          npm init -y
-          npm install mongoose
+      - name: Install Mongoose
+        run: npm install mongoose --legacy-peer-deps
 
       - name: Run refreshUsageCount script
         env:
           MONGO_URL: ${{ secrets.MONGO_URL }}
-          NODE_PATH: temp-dir/node_modules
         run: node ./server/scripts/refreshUsageCount.js

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '20'
 
       - name: Install Mongoose
-        run: npm install mongoose
+        run: npm install mongoose --legacy-peer-deps
 
       - name: Run refreshUsageCount script
         env:

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install Mongoose
+        run: npm install mongoose
 
       - name: Run refreshUsageCount script
         env:

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -1,0 +1,26 @@
+name: Refresh Usage Count
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh_usage_count:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run refreshUsageCount script
+        env:
+          MONGO_URL: ${{ secrets.MONGO_URL }}
+        run: node ./server/scripts/refreshUsageCount.js

--- a/.github/workflows/refresh-usage-count.yml
+++ b/.github/workflows/refresh-usage-count.yml
@@ -16,11 +16,18 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
+      
+      - name: Create temp directory for mongoose
+        run: mkdir -p temp-dir
 
-      - name: Install Mongoose
-        run: npm install mongoose --legacy-peer-deps
+      - name: Install mongoose
+        run: |
+          cd temp-dir
+          npm init -y
+          npm install mongoose
 
       - name: Run refreshUsageCount script
         env:
           MONGO_URL: ${{ secrets.MONGO_URL }}
+          NODE_PATH: temp-dir/node_modules
         run: node ./server/scripts/refreshUsageCount.js

--- a/server/scripts/refreshUsageCount.js
+++ b/server/scripts/refreshUsageCount.js
@@ -1,0 +1,34 @@
+const { Subscriptions } = require("../models");
+const mongoose = require("mongoose");
+require("dotenv").config();
+
+async function refreshUsageCount() {
+  try {
+    await mongoose.connect(process.env.MONGO_URL);
+
+    const allSubscriptions = await Subscriptions.find();
+    
+    const refreshSubscriptionData = allSubscriptions.map(async (subscription) => {
+      const currentDate = Date.now();
+      const daysSinceLastUpdated = (currentDate - subscription.updatedAt) / (1000 * 3600 * 24);
+
+      if (subscription.usageCount >= subscription.usageLimit || daysSinceLastUpdated >= 31) {
+        subscription.usageCount = 0;
+        subscription.updatedAt = Date.now();
+        await subscription.save();
+      }
+    });
+
+    await Promise.all(refreshSubscriptionData);
+  } catch(err) {
+    console.log(err);
+  } finally {
+    await mongoose.connection.close();
+  }
+}
+
+refreshUsageCount().then(() => {
+  console.log("Refresh usage count process completed successfully.");
+}).catch(error => {
+  console.error("An error occurred during the refresh usage count process:", error);
+});

--- a/server/scripts/refreshUsageCount.js
+++ b/server/scripts/refreshUsageCount.js
@@ -7,12 +7,14 @@ async function refreshUsageCount() {
     await mongoose.connect(process.env.MONGO_URL);
 
     const allSubscriptions = await Subscriptions.find();
-    
+
     const refreshSubscriptionData = allSubscriptions.map(async (subscription) => {
       const currentDate = Date.now();
-      const daysSinceLastUpdated = (currentDate - subscription.updatedAt) / (1000 * 3600 * 24);
+      const daysSinceCreation = Math.round((currentDate - subscription.createdAt) / (1000 * 3600 * 24));
+      const daysInAMonth = 30;
 
-      if (subscription.usageCount >= subscription.usageLimit || daysSinceLastUpdated >= 31) {
+      //Every time 30 days i.e a month has passed, usageCount gets reset to zero
+      if (daysSinceCreation % daysInAMonth === 0) {
         subscription.usageCount = 0;
         subscription.updatedAt = Date.now();
         await subscription.save();
@@ -28,7 +30,8 @@ async function refreshUsageCount() {
 }
 
 refreshUsageCount().then(() => {
-  console.log("Refresh usage count process completed successfully.");
+  const currentDateTime = new Date().toLocaleString();
+  console.log(`Refresh usage count process completed successfully on ${currentDateTime}.`);
 }).catch(error => {
   console.error("An error occurred during the refresh usage count process:", error);
 });

--- a/server/scripts/refreshUsageCount.js
+++ b/server/scripts/refreshUsageCount.js
@@ -11,13 +11,14 @@ async function refreshUsageCount() {
     const refreshSubscriptionData = allSubscriptions.map(async (subscription) => {
       const currentDate = Date.now();
       const daysSinceCreation = Math.round((currentDate - subscription.createdAt) / (1000 * 3600 * 24));
-      const daysInAMonth = 30;
 
       //Every time 30 days i.e a month has passed, usageCount gets reset to zero
-      if (daysSinceCreation % daysInAMonth === 0) {
-        subscription.usageCount = 0;
-        subscription.updatedAt = Date.now();
-        await subscription.save();
+      if (daysSinceCreation > 0 && daysSinceCreation % 30 === 0) {
+        if(subscription.usageCount > 0) {
+          subscription.usageCount = 0;
+          subscription.updatedAt = Date.now();
+          await subscription.save();
+        }
       }
     });
 
@@ -30,8 +31,7 @@ async function refreshUsageCount() {
 }
 
 refreshUsageCount().then(() => {
-  const currentDateTime = new Date().toLocaleString();
-  console.log(`Refresh usage count process completed successfully on ${currentDateTime}.`);
+  console.log("Refresh usage count process completed successfully!");
 }).catch(error => {
   console.error("An error occurred during the refresh usage count process:", error);
 });

--- a/server/scripts/refreshUsageCount.js
+++ b/server/scripts/refreshUsageCount.js
@@ -9,8 +9,6 @@ async function refreshUsageCount() {
     const allSubscriptions = await Subscriptions.find({ usageCount: { $gt: 0 }});
     const recordsToUpdate = [];
 
-    console.log(allSubscriptions);
-
     const refreshSubscriptionData = allSubscriptions.map((subscription) => {
       const currentDate = Date.now();
       const daysSinceCreation = Math.round((currentDate - subscription.createdAt) / (1000 * 3600 * 24));


### PR DESCRIPTION
### Summary

This pull request introduces a new script that is scheduled to run automatically at midnight to refresh the usage count of subscriptions. 

### Description

The script performs the following actions:
- Connects to the MongoDB database and retrieves all subscriptions.
- Calculates the number of days since each subscription was created.
- Resets the usage count to zero for subscriptions after every 30 consecutive days starting from the time of creation and only if the current usage count is greater than zero.
- Updates the `updatedAt` field to reflect the reset action.

This PR resolves [Issue #355](https://github.com/TeamShiksha/logoexecutive/issues/355)

### How to Test the Changes

<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Context (Optional)

<!-- Provide any additional context about the problem or feature here. -->

### Screenshots or Recordings (Optional)

![Screenshot 2024-08-23 234213](https://github.com/user-attachments/assets/5506a7e6-ac8e-4d7d-b83d-94e2a9ee069d)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->

- [X] I have tested the changes locally and they work as expected.
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
- [X] This pull request follows the project's coding guidelines.
