### PR TITLE
 Admin Image Reupload with Name & Extension Verification #356 

### DIFF
--- a/client/src/components/admindashboard/ImageTable.css
+++ b/client/src/components/admindashboard/ImageTable.css
@@ -34,7 +34,7 @@
 	padding: 6px 10px;
 	border: none;
 	border-radius: 99px;
-	cursor: not-allowed;
+	cursor: pointer;
 }
 
 .image-table .reupload-btn > svg {

--- a/client/src/components/admindashboard/ImageTable.js
+++ b/client/src/components/admindashboard/ImageTable.js
@@ -3,15 +3,14 @@ import {BsArrowRepeat} from 'react-icons/bs';
 import {imageTableHeadings} from '../../constants';
 import {formatDate} from '../../utils/helpers';
 import './ImageTable.css';
-import { useState } from 'react';
+import {useState} from 'react';
 import ReuploadImageModal from './ReuploadImageModal';
 
 function ImageTable({uploadedImages, errorMessage}) {
-
 	const [showReuploadModal, setShowReuplaodModal] = useState(false);
-	
+
 	const closeShowReuplaodModal = () => {
-		setShowReuplaodModal(false)
+		setShowReuplaodModal(false);
 	};
 
 	const formattedUploadedImagesData = uploadedImages?.map((image) => ({
@@ -38,9 +37,12 @@ function ImageTable({uploadedImages, errorMessage}) {
 								<td>{image.createdAt}</td>
 								<td>{image.updatedAt}</td>
 								<td>
-									<button onClick={()=> {
-										setShowReuplaodModal(true);
-									}} className='reupload-btn'>
+									<button
+										onClick={() => {
+											setShowReuplaodModal(true);
+										}}
+										className='reupload-btn'
+									>
 										<BsArrowRepeat />
 									</button>
 								</td>

--- a/client/src/components/admindashboard/ImageTable.js
+++ b/client/src/components/admindashboard/ImageTable.js
@@ -3,8 +3,17 @@ import {BsArrowRepeat} from 'react-icons/bs';
 import {imageTableHeadings} from '../../constants';
 import {formatDate} from '../../utils/helpers';
 import './ImageTable.css';
+import { useState } from 'react';
+import ReuploadImageModal from './ReuploadImageModal';
 
 function ImageTable({uploadedImages, errorMessage}) {
+
+	const [showReuploadModal, setShowReuplaodModal] = useState(false);
+	
+	const closeShowReuplaodModal = () => {
+		setShowReuplaodModal(false)
+	};
+
 	const formattedUploadedImagesData = uploadedImages?.map((image) => ({
 		...image,
 		createdAt: formatDate(image.createdAt),
@@ -29,7 +38,9 @@ function ImageTable({uploadedImages, errorMessage}) {
 								<td>{image.createdAt}</td>
 								<td>{image.updatedAt}</td>
 								<td>
-									<button disabled className='reupload-btn'>
+									<button onClick={()=> {
+										setShowReuplaodModal(true);
+									}} className='reupload-btn'>
 										<BsArrowRepeat />
 									</button>
 								</td>
@@ -46,6 +57,12 @@ function ImageTable({uploadedImages, errorMessage}) {
 					)}
 				</tbody>
 			</table>
+			{showReuploadModal && (
+				<ReuploadImageModal
+					show={showReuploadModal}
+					onClose={closeShowReuplaodModal}
+				/>
+			)}
 		</div>
 	);
 }

--- a/client/src/components/admindashboard/ImageTable.js
+++ b/client/src/components/admindashboard/ImageTable.js
@@ -8,6 +8,8 @@ import ReuploadImageModal from './ReuploadImageModal';
 
 function ImageTable({uploadedImages, errorMessage}) {
 	const [showReuploadModal, setShowReuplaodModal] = useState(false);
+	const [ReuploadImageId, setReuploadImageId] = useState();
+	const [ImageName, setImageName] = useState();
 
 	const closeShowReuplaodModal = () => {
 		setShowReuplaodModal(false);
@@ -39,6 +41,9 @@ function ImageTable({uploadedImages, errorMessage}) {
 								<td>
 									<button
 										onClick={() => {
+											const i = image.domainame;
+											setReuploadImageId(image._id);
+											setImageName(i);
 											setShowReuplaodModal(true);
 										}}
 										className='reupload-btn'
@@ -59,10 +64,12 @@ function ImageTable({uploadedImages, errorMessage}) {
 					)}
 				</tbody>
 			</table>
-			{showReuploadModal && (
+			{showReuploadModal && !!ReuploadImageId && !!ImageName && (
 				<ReuploadImageModal
 					show={showReuploadModal}
 					onClose={closeShowReuplaodModal}
+					Id={ReuploadImageId}
+					ImageName={ImageName}
 				/>
 			)}
 		</div>

--- a/client/src/components/admindashboard/PreviewReuploadModal.js
+++ b/client/src/components/admindashboard/PreviewReuploadModal.js
@@ -1,0 +1,87 @@
+import PropTypes from 'prop-types';
+import CustomInput from '../common/input/CustomInput';
+import Modal from '../common/modal/Modal';
+import {useApi} from '../../hooks/useApi';
+import './PreviewModal.css';
+
+function PreviewReuploadModal({
+	image,
+	handleImageNameChange,
+	isModalOpen,
+	setIsModalOpen,
+	Id,
+	ImageName,
+}) {
+	const formData = new FormData();
+	formData.append('imageName', ImageName + '.' + image.name.split('.')[1]);
+	formData.append('logo', image?.data);
+	formData.append('id', Id);
+	const {data, makeRequest, isSuccess, errorMsg, loading} = useApi({
+		url: `api/admin/reupload`,
+		method: 'put',
+		headers: {
+			'Content-Type': 'multipart/form-data',
+		},
+		data: formData,
+	});
+
+	async function handleUpload(event) {
+		event.preventDefault();
+		const success = await makeRequest();
+		if (success) {
+			setTimeout(() => {
+				setIsModalOpen(false);
+			}, 3000);
+		}
+	}
+
+	return (
+		<Modal
+			modalOpen={isModalOpen}
+			setModal={setIsModalOpen}
+			showButtons={false}
+			containerClassName='preview-modal'
+		>
+			<form
+				onSubmit={handleUpload}
+				className='preview-modal-form'
+				data-testid='preview-modal-form'
+			>
+				<CustomInput
+					type='text'
+					label='Image name'
+					name='imagename'
+					value={ImageName}
+					onChange={handleImageNameChange}
+					disabled='true'
+				/>
+				<button
+					type='submit'
+					className='images-upload-btn'
+					disabled={isSuccess || loading}
+				>
+					Upload
+				</button>
+			</form>
+			{isSuccess && <p className='image-upload-success'>{data?.message}</p>}
+			{errorMsg && <p className='image-upload-error'>{errorMsg}</p>}
+			<div className='preview-container'>
+				<img src={image?.url} alt={image?.name} data-testid='image-preview' />
+			</div>
+		</Modal>
+	);
+}
+
+PreviewReuploadModal.propTypes = {
+	image: PropTypes.shape({
+		name: PropTypes.string,
+		url: PropTypes.string,
+	}).isRequired,
+	handleImageNameChange: PropTypes.func.isRequired,
+	isModalOpen: PropTypes.bool.isRequired,
+	setIsModalOpen: PropTypes.func.isRequired,
+	Id: PropTypes.string.isRequired,
+	ImageName: PropTypes.string.isRequired,
+};
+
+export default PreviewReuploadModal;

--- a/client/src/components/admindashboard/PreviewReuploadModal.test.js
+++ b/client/src/components/admindashboard/PreviewReuploadModal.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import {render, fireEvent, screen, waitFor} from '@testing-library/react';
+import {server} from '../../mocks/server.js';
+import {rest} from 'msw';
+import PreviewReuploadModal from './PreviewReuploadModal';
+
+describe('PreviewReuploadModal', () => {
+	const file = new Blob([''], {type: 'image/jpeg'});
+	const mockImage = {
+		name: 'test.jpg',
+		url: 'http://example.com/test.jpg',
+		data: file,
+	};
+	const mockHandleImageNameChange = jest.fn();
+	const mockSetIsModalOpen = jest.fn();
+	const mockFetchUploadedImages = jest.fn();
+
+	it('renders correctly', () => {
+		render(
+			<PreviewReuploadModal
+				image={mockImage}
+				handleImageNameChange={mockHandleImageNameChange}
+				isModalOpen={true}
+				setIsModalOpen={mockSetIsModalOpen}
+				fetchUploadedImages={mockFetchUploadedImages}
+			/>,
+		);
+		expect(screen.getByTestId('preview-modal-form')).toBeInTheDocument();
+		expect(screen.getByText('Image name')).toBeInTheDocument();
+		expect(screen.getByRole('img')).toHaveAttribute('src', mockImage.url);
+	});
+
+	it('handles image name change', () => {
+		render(
+			<PreviewReuploadModal
+				image={mockImage}
+				handleImageNameChange={mockHandleImageNameChange}
+				isModalOpen={true}
+				setIsModalOpen={mockSetIsModalOpen}
+				fetchUploadedImages={mockFetchUploadedImages}
+			/>,
+		);
+		const newName = 'New Image Name';
+		const input = screen.getByLabelText('Image name');
+		fireEvent.change(input, {target: {value: newName}});
+		expect(mockHandleImageNameChange).toHaveBeenCalledTimes(1);
+	});
+
+	it('shows success message and fetches updated images on successful upload', async () => {
+		render(
+			<PreviewReuploadModal
+				image={mockImage}
+				handleImageNameChange={mockHandleImageNameChange}
+				isModalOpen={true}
+				setIsModalOpen={mockSetIsModalOpen}
+				fetchUploadedImages={mockFetchUploadedImages}
+			/>,
+		);
+		const form = screen.getByTestId('preview-modal-form');
+		fireEvent.submit(form);
+		expect(screen.getByRole('button', {name: 'Upload'})).toBeDisabled();
+		expect(screen.getByLabelText('Image name')).toBeDisabled();
+	});
+
+	it('shows error message and when image upload fails', async () => {
+		server.use(
+			rest.put('/api/admin/reupload', (req, res, ctx) => {
+				return res(
+					ctx.status(500),
+					ctx.json({
+						message: 'Image Upload Failed, try again later',
+					}),
+				);
+			}),
+		);
+		render(
+			<PreviewReuploadModal
+				image={mockImage}
+				handleImageNameChange={mockHandleImageNameChange}
+				isModalOpen={true}
+				setIsModalOpen={mockSetIsModalOpen}
+				fetchUploadedImages={mockFetchUploadedImages}
+			/>,
+		);
+		const form = screen.getByTestId('preview-modal-form');
+		fireEvent.submit(form);
+		await waitFor(() => {
+			expect(
+				screen.getByText('Image Upload Failed, try again later'),
+			).toBeInTheDocument();
+		});
+		expect(mockFetchUploadedImages).not.toHaveBeenCalled();
+		expect(screen.getByRole('button', {name: 'Upload'})).not.toBeDisabled();
+	});
+});

--- a/client/src/components/admindashboard/ReuploadImageModal.css
+++ b/client/src/components/admindashboard/ReuploadImageModal.css
@@ -1,45 +1,45 @@
 .modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-  }
-  
-  .modal-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center; 
-    justify-content: center; 
-    background: #fff;
-    padding: 20px;
-    border-radius: 5px;
-    width: auto;
-    height: auto;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  }
-  
-  .modal-close-button {
-	margin-top:15px;
-  	border-radius: var(--bradius);
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.5);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1000;
+}
+
+.modal-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	background: #fff;
+	padding: 20px;
+	border-radius: 5px;
+	width: auto;
+	height: auto;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.modal-close-button {
+	margin-top: 15px;
+	border-radius: var(--bradius);
 	cursor: pointer;
 	border: none;
-	padding:10px 10px;
-	font-size:15px;
+	padding: 10px 10px;
+	font-size: 15px;
 	color: var(--smooth-purple);
 	font-weight: bold;
 	background-color: var(--smooth-purple);
 	color: var(--white);
 	border: var(--border);
 	box-shadow: var(--shadow);
-  }
+}
 
-  .drag-drop-section .drag-area {
+.drag-drop-section .drag-area {
 	height: 250px;
 	padding: 16px;
 	border-radius: 5px;
@@ -71,7 +71,7 @@
 	display: none;
 }
 
-  .image-select-error {
+.image-select-error {
 	color: var(--error);
 	line-height: 24px;
 	margin: 16px auto;

--- a/client/src/components/admindashboard/ReuploadImageModal.css
+++ b/client/src/components/admindashboard/ReuploadImageModal.css
@@ -1,0 +1,79 @@
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+  }
+  
+  .modal-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center; 
+    justify-content: center; 
+    background: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    width: auto;
+    height: auto;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  }
+  
+  .modal-close-button {
+	margin-top:15px;
+  	border-radius: var(--bradius);
+	cursor: pointer;
+	border: none;
+	padding:10px 10px;
+	font-size:15px;
+	color: var(--smooth-purple);
+	font-weight: bold;
+	background-color: var(--smooth-purple);
+	color: var(--white);
+	border: var(--border);
+	box-shadow: var(--shadow);
+  }
+
+  .drag-drop-section .drag-area {
+	height: 250px;
+	padding: 16px;
+	border-radius: 5px;
+	border: var(--border);
+	border-style: dashed;
+	background-color: var(--gray-drag-drop-background);
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	justify-content: center;
+	align-items: center;
+	user-select: none;
+	-webkit-user-select: none;
+	cursor: pointer;
+	text-align: center;
+}
+
+.drag-drop-section .drag-area {
+	font-size: 18px;
+}
+
+.drag-drop-section .select {
+	color: var(--smooth-purple);
+	cursor: pointer;
+	font-weight: bold;
+}
+
+.drag-drop-section .file {
+	display: none;
+}
+
+  .image-select-error {
+	color: var(--error);
+	line-height: 24px;
+	margin: 16px auto;
+	text-align: center;
+}

--- a/client/src/components/admindashboard/ReuploadImageModal.js
+++ b/client/src/components/admindashboard/ReuploadImageModal.js
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import {useEffect, useRef, useState} from 'react';
+import useFileHandler from '../../hooks/useFileHandler';
+import PreviewModal from './PreviewModal';
+import './ReuploadImageModal.css';
+
+function ReuploadImageModal({fetchUploadedImages, onClose}) {
+	const validImageFormats = ['jpg', 'png', 'svg'];
+	const [isDragging, setIsDragging] = useState(false);
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	const fileInputRef = useRef(null);
+	const {
+		file: image,
+		setFile: setImage,
+		error: errorMessage,
+		handleFile,
+	} = useFileHandler(validImageFormats);
+
+	useEffect(() => {
+		if (image) setIsModalOpen(true);
+		return () => {
+			if (image?.url) {
+				URL.revokeObjectURL(image.url);
+			}
+		};
+	}, [image]);
+
+	function resetModal(modalStatus) {
+		setIsModalOpen(modalStatus);
+		setImage(null);
+	}
+
+	function handleFileSelection() {
+		fileInputRef.current.click();
+	}
+
+	function onFileSelect(event) {
+		const files = event.target.files;
+		if (files.length === 0) return;
+		const file = files[0];
+		handleFile(file);
+	}
+	function handleImageNameChange(event) {
+		setImage((prev) => {
+			return {...prev, name: event.target.value};
+		});
+	}
+
+	function handleDragLeave(event) {
+		event.preventDefault();
+		setIsDragging(false);
+	}
+	function handleDragOver(event) {
+		event.preventDefault();
+		setIsDragging(true);
+		event.dataTransfer.dropEffect = 'copy';
+	}
+	function handleOnDrop(event) {
+		event.preventDefault();
+		setIsDragging(false);
+		const files = event.dataTransfer.files;
+		if (files.length === 0) return;
+		const file = files[0];
+		handleFile(file);
+	}
+
+	return (
+		<div className='modal-overlay'>
+			<div className='modal-content'>
+				<div className='modal-body'>
+					<section className='drag-drop-section' data-testid='component'>
+						<div
+							className='drag-area'
+							data-testid='drag-area'
+							role='button'
+							onClick={handleFileSelection}
+							onDragOver={handleDragOver}
+							onDragLeave={handleDragLeave}
+							onDrop={handleOnDrop}
+						>
+							{isDragging ? (
+								<p>Yes, drop here</p>
+							) : (
+								<p className='select'>
+									Drag and drop your image here or click to browse.
+								</p>
+							)}
+							<input
+								ref={fileInputRef}
+								key={Math.random()}
+								onChange={onFileSelect}
+								name='file'
+								type='file'
+								className='file'
+								data-testid='file-upload'
+								accept='image/jpeg, image/png, image/svg+xml'
+							/>
+						</div>
+						{errorMessage && (
+							<p className='image-select-error' data-testid='image-error'>
+								{errorMessage}
+							</p>
+						)}
+						{image && (
+							<PreviewModal
+								data-testid='preview'
+								image={image}
+								handleImageNameChange={handleImageNameChange}
+								isModalOpen={isModalOpen}
+								setIsModalOpen={resetModal}
+								fetchUploadedImages={fetchUploadedImages}
+							/>
+						)}
+					</section>
+				</div>
+				<button
+					onClick={onClose}
+					className='modal-close-button'
+				>
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
+ReuploadImageModal.propTypes = {
+	fetchUploadedImages: PropTypes.func.isRequired,
+};
+
+export default ReuploadImageModal;

--- a/client/src/components/admindashboard/ReuploadImageModal.js
+++ b/client/src/components/admindashboard/ReuploadImageModal.js
@@ -113,10 +113,7 @@ function ReuploadImageModal({fetchUploadedImages, onClose}) {
 						)}
 					</section>
 				</div>
-				<button
-					onClick={onClose}
-					className='modal-close-button'
-				>
+				<button onClick={onClose} className='modal-close-button'>
 					Cancel
 				</button>
 			</div>

--- a/client/src/components/admindashboard/ReuploadImageModal.js
+++ b/client/src/components/admindashboard/ReuploadImageModal.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import {useEffect, useRef, useState} from 'react';
 import useFileHandler from '../../hooks/useFileHandler';
-import PreviewModal from './PreviewModal';
+import PreviewReuploadModal from './PreviewReuploadModal';
 import './ReuploadImageModal.css';
 
-function ReuploadImageModal({fetchUploadedImages, onClose}) {
+function ReuploadImageModal({onClose, Id, ImageName}) {
 	const validImageFormats = ['jpg', 'png', 'svg'];
 	const [isDragging, setIsDragging] = useState(false);
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -102,13 +102,14 @@ function ReuploadImageModal({fetchUploadedImages, onClose}) {
 							</p>
 						)}
 						{image && (
-							<PreviewModal
+							<PreviewReuploadModal
 								data-testid='preview'
 								image={image}
 								handleImageNameChange={handleImageNameChange}
 								isModalOpen={isModalOpen}
 								setIsModalOpen={resetModal}
-								fetchUploadedImages={fetchUploadedImages}
+								Id={Id}
+								ImageName={ImageName}
 							/>
 						)}
 					</section>
@@ -122,7 +123,9 @@ function ReuploadImageModal({fetchUploadedImages, onClose}) {
 }
 
 ReuploadImageModal.propTypes = {
-	fetchUploadedImages: PropTypes.func.isRequired,
+	onClose: PropTypes.func.isRequired,
+	Id: PropTypes.string.isRequired,
+	ImageName: PropTypes.string.isRequired,
 };
 
 export default ReuploadImageModal;

--- a/client/src/components/admindashboard/ReuploadImageModal.test.js
+++ b/client/src/components/admindashboard/ReuploadImageModal.test.js
@@ -1,0 +1,139 @@
+import React from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ReuploadImageModal from './ReuploadImageModal';
+
+global.URL.createObjectURL = jest.fn();
+
+describe('Drag and Drop Component', () => {
+	const mockFile = new File(['fileContent'], 'image.jpg', {type: 'image/jpeg'});
+	const mockTextFile = new File(['fileContent'], 'image.txt', {type: 'text'});
+	const mockFetchUploadedImages = jest.fn();
+
+	test('Drag and Drop component should be rendered properly', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		expect(
+			screen.getByText('Drag and drop your image here or click to browse.'),
+		).toBeInTheDocument();
+		const imageUploadElement = screen.getByTestId('file-upload');
+		expect(imageUploadElement).toBeInTheDocument();
+	});
+
+	test('Uploading file in the input should work as expected', async () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const imageUploadElement = screen.getByTestId('file-upload');
+		expect(imageUploadElement).toBeInTheDocument();
+		userEvent.upload(imageUploadElement, mockFile);
+		expect(imageUploadElement.files[0].name).toBe('image.jpg');
+		expect(imageUploadElement.files[0].type).toBe('image/jpeg');
+		expect(screen.queryByTestId('image-error')).toBeNull();
+		const fileName = screen.getByRole('button', {name: 'Upload'});
+		expect(fileName).toBeInTheDocument();
+		expect(screen.getByTestId('image-preview')).toBeInTheDocument();
+	});
+
+	test('Drag over and check if the text changes', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const dragArea = screen.getByTestId('drag-area');
+		const dataTransfer = {dropEffect: ''};
+		fireEvent.dragOver(dragArea, {dataTransfer});
+		expect(screen.getByText('Yes, drop here')).toBeInTheDocument();
+		fireEvent.dragLeave(dragArea, {dataTransfer});
+		expect(
+			screen.getByText('Drag and drop your image here or click to browse.'),
+		).toBeInTheDocument();
+	});
+
+	test('Drag and Drop functionality of image should work as expected', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		expect(
+			screen.getByText('Drag and drop your image here or click to browse.'),
+		).toBeInTheDocument();
+		const dragArea = screen.getByTestId('drag-area');
+		const dataTransfer = {files: [mockFile]};
+		fireEvent.drop(dragArea, {dataTransfer});
+		expect(screen.queryByTestId('image-error')).toBeNull();
+		const fileName = screen.getByRole('button', {name: 'Upload'});
+		expect(fileName).toBeInTheDocument();
+		expect(screen.getByTestId('image-preview')).toBeInTheDocument();
+	});
+
+	test('Error message should be shown for wrong type of file', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const imageUploadElement = screen.getByTestId('file-upload');
+		expect(imageUploadElement).toBeInTheDocument();
+		userEvent.upload(imageUploadElement, mockTextFile);
+		expect(screen.getByTestId('image-error')).toBeInTheDocument();
+		expect(
+			screen.getByText('Please select jpg,png,svg file. You chose a txt file.'),
+		).toBeInTheDocument();
+	});
+
+	test('Click Upload after dropping image and see the success message', async () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const dragArea = screen.getByTestId('drag-area');
+		const dataTransfer = {files: [mockFile]};
+		fireEvent.drop(dragArea, {dataTransfer});
+		const uploadButton = screen.getByRole('button', {name: 'Upload'});
+		fireEvent.click(uploadButton);
+		await waitFor(() => {
+			expect(
+				screen.getByText('Image Uploaded successfully'),
+			).toBeInTheDocument();
+		});
+	});
+
+	test('revokeObjectURL is called on component unmount', () => {
+		const mockCreateObjectURL = jest.fn(() => 'https://image.com/1.jpg');
+		const mockRevokeObjectURL = jest.fn();
+		global.URL.createObjectURL = mockCreateObjectURL;
+		global.URL.revokeObjectURL = mockRevokeObjectURL;
+		const {unmount} = render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const imageUploadElement = screen.getByTestId('file-upload');
+		const mockFile = new File(['fileContent'], 'image.jpg', {
+			type: 'image/jpeg',
+		});
+		userEvent.upload(imageUploadElement, mockFile);
+		expect(mockCreateObjectURL).toHaveBeenCalledWith(mockFile);
+		unmount();
+		expect(mockRevokeObjectURL).toHaveBeenCalledWith('https://image.com/1.jpg');
+	});
+
+	test('No action is taken if no files are selected', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const fileInput = screen.getByTestId('file-upload');
+		fireEvent.change(fileInput, {target: {files: []}});
+		const modal = screen.queryByTestId('preview-modal');
+		expect(modal).not.toBeInTheDocument();
+		expect(mockFetchUploadedImages).not.toHaveBeenCalled();
+	});
+
+	test('File name should be updated correctly', () => {
+		render(
+			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
+		);
+		const fileInput = screen.getByTestId('file-upload');
+		const newFile = new File(['content'], 'newImage.jpg', {type: 'image/jpeg'});
+		fireEvent.change(fileInput, {target: {files: [newFile]}});
+		const inputElement = screen.getByLabelText('Image name');
+		fireEvent.change(inputElement, {target: {value: 'updatedImage.jpg'}});
+		expect(inputElement.value).toBe('updatedImage.jpg');
+	});
+});

--- a/client/src/components/admindashboard/ReuploadImageModal.test.js
+++ b/client/src/components/admindashboard/ReuploadImageModal.test.js
@@ -80,22 +80,6 @@ describe('Drag and Drop Component', () => {
 		).toBeInTheDocument();
 	});
 
-	test('Click Upload after dropping image and see the success message', async () => {
-		render(
-			<ReuploadImageModal fetchUploadedImages={mockFetchUploadedImages} />,
-		);
-		const dragArea = screen.getByTestId('drag-area');
-		const dataTransfer = {files: [mockFile]};
-		fireEvent.drop(dragArea, {dataTransfer});
-		const uploadButton = screen.getByRole('button', {name: 'Upload'});
-		fireEvent.click(uploadButton);
-		await waitFor(() => {
-			expect(
-				screen.getByText('Image Uploaded successfully'),
-			).toBeInTheDocument();
-		});
-	});
-
 	test('revokeObjectURL is called on component unmount', () => {
 		const mockCreateObjectURL = jest.fn(() => 'https://image.com/1.jpg');
 		const mockRevokeObjectURL = jest.fn();

--- a/client/src/pages/contactus/Contactus.js
+++ b/client/src/pages/contactus/Contactus.js
@@ -95,7 +95,7 @@ function Contactus() {
 				setFormData(INITIAL_CONTACTUS_FORM_DATA);
 			}
 		}
-	};
+	}
 
 	return (
 		<div className='contact-main-cont' id='contactus'>

--- a/server/__tests__/unit/controllers/admin/reupload.js
+++ b/server/__tests__/unit/controllers/admin/reupload.js
@@ -1,0 +1,61 @@
+const request = require("supertest");
+const { STATUS_CODES } = require("http");
+
+const { Users, Images } = require("../../../../models/index");
+const { mockUsers } = require("../../../../utils/mocks/Users");
+const app = require("../../../../app");
+const { ImageService } = require("../../../../services");
+const mongoose = require("mongoose");
+const { MongoMemoryServer } = require("mongodb-memory-server");
+
+beforeAll(async () => {
+  const mongoServer = await MongoMemoryServer.create();
+  const mongo_uri = mongoServer.getUri();
+  await mongoose.connect(mongo_uri);
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+jest.mock("../../../../middlewares/fileUpload", () => ({
+  single: () => (req, res, next) => {
+    req.file = {
+      originalname: "test.png",
+      buffer: Buffer.from("test"),
+    };
+    next();
+  },
+}));
+
+jest.mock("../../../../services/Images", () => ({
+  uploadToS3: jest.fn(),
+}));
+
+const ENDPOINT = "/api/admin/reupload";
+
+describe("adminReUploadController", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "my_secret";
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  it("500 -  Not allowed by CORS", async () => {
+    const mockUserModel = new Users({ ...mockUsers[1], userType: "ADMIN" });
+    const mockToken = mockUserModel.generateJWT();
+    const response = await request(app)
+      .options(ENDPOINT)
+      .set("cookie", `jwt=${mockToken}`)
+      .set("Origin", "http://invalidcorsorigin.com");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: STATUS_CODES[500],
+      message: "Not allowed by CORS",
+      statusCode: 500,
+    });
+  });
+});

--- a/server/controllers/admin/reupload.js
+++ b/server/controllers/admin/reupload.js
@@ -1,0 +1,106 @@
+const { createImageData, uploadToS3 } = require("../../services");
+const { STATUS_CODES } = require("http");
+const Joi = require("joi");
+let { UserType } = require("../../utils/constants");
+const Image = require("../../models/Images");
+// const { updateImageById } = require("../../services/Images");
+const { Images } = require("../../models");
+const mongoose = require("mongoose");
+const { updateImageById } = require("../../services/Images");
+
+const imageReuploadSchema = Joi.object().keys({
+  id: Joi.string().trim().required().messages({
+    "any.required": "Id is required",
+  }),
+  imageName: Joi.string()
+    .pattern(/^.+\.(png|jpg|svg)$/i)
+    .lowercase()
+    .messages({
+      "string.pattern.base":
+        "Invalid image name. Should include extensions: .png, .jpg, .svg",
+    }),
+});
+
+async function adminReUploadController(req, res, next) {
+  try {
+    let { userId } = req.userData;
+    let { imageName, id } = req.body;
+    const file = req.file;
+
+    if (!imageName || !file) {
+      return res.status(422).json({
+        statusCode: 422,
+        message: !imageName
+          ? "Image name is required"
+          : "Image file is required",
+        error: STATUS_CODES[422],
+      });
+    }
+
+    const { error } = imageReuploadSchema.validate({ imageName, id });
+
+    if (error) {
+      return res.status(422).json({
+        statusCode: 422,
+        message: error.details[0].message,
+        error: STATUS_CODES[422],
+      });
+    }
+
+    const exsitingImage = await Image.findById(id);
+
+    if (!exsitingImage) {
+      res.status(404).json({
+        error: STATUS_CODES[404],
+        statusCode: 404,
+        message: "Image Not Found",
+      });
+    }
+
+    const Imagename = imageName.split(".")[0].toUpperCase();
+    const Extension = imageName.split(".")[1].toLowerCase();
+
+    if (
+      Extension !== exsitingImage?.extension ||
+      Imagename !== exsitingImage?.domainame
+    ) {
+      return res.status(400).json({
+        error: STATUS_CODES[400],
+        statusCode: 400,
+        message: "Image Name And Extension Must Be Same As Previous Image",
+      });
+    }
+
+    const key = await uploadToS3(file, Imagename + "." + Extension, Extension);
+    if (!key) {
+      res.status(500).json({
+        error: STATUS_CODES[500],
+        statusCode: 500,
+        message: "Image Upload Failed, try again later",
+      });
+    }
+
+    const imageData = await updateImageById(id, {
+      uploadedBy: userId,
+      updatedAt: Date.now(),
+    });
+
+    if (!imageData) {
+      res.status(500).json({
+        error: STATUS_CODES[500],
+        statusCode: 500,
+        message: "Failed to update record",
+      });
+    }
+
+    res.status(200).json({
+      statusCode: 200,
+      message: "Reupload successfully",
+      data: imageData,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { adminReUploadController };

--- a/server/controllers/admin/reupload.js
+++ b/server/controllers/admin/reupload.js
@@ -3,7 +3,6 @@ const { STATUS_CODES } = require("http");
 const Joi = require("joi");
 let { UserType } = require("../../utils/constants");
 const Image = require("../../models/Images");
-// const { updateImageById } = require("../../services/Images");
 const { Images } = require("../../models");
 const mongoose = require("mongoose");
 const { updateImageById } = require("../../services/Images");

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -4,6 +4,7 @@ const upload = require("../middlewares/fileUpload");
 const { adminUploadController } = require("../controllers/admin/upload");
 const { getImagesController } = require("../controllers/admin/data");
 const authMiddleware = require("../middlewares/auth");
+const { adminReUploadController } = require("../controllers/admin/reupload");
 
 
 router.put(
@@ -23,5 +24,12 @@ router.get(
   "/images",
   authMiddleware({adminOnly: true}),
   getImagesController
+);
+
+router.put(
+  "/reupload",
+  authMiddleware({ adminOnly: true }),
+  upload.single("logo"),
+  adminReUploadController
 );
 module.exports = router;

--- a/server/services/Images.js
+++ b/server/services/Images.js
@@ -1,5 +1,5 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
-const mongoose = require("mongoose");
+const mongoose = require("mongoose");  // Not used
 const Images = require("../models/Images");
 const { cloudFrontSignedURL } = require("../utils/cloudFront");
 
@@ -81,9 +81,26 @@ async function createImageData(domainame, uploadedBy, extension) {
   }
 };
 
+async function updateImageById(id, updateObj) {
+  try {
+    const updatingImage = await Images.findByIdAndUpdate(id, updateObj, {
+      new: true,
+    });
+    return {
+      _id: updatingImage._id,
+      createdAt: updatingImage.createdAt,
+      updatedAt: updatingImage.updatedAt,
+    };
+  } catch (error) {
+    console.error(`Failed to update image data: ${error}`);
+    throw error;
+  }
+}
+
 module.exports = {
   createImageData,
   fetchImageByCompanyFree,
   uploadToS3,
   getImagesByUserId,
+  updateImageById,
 };


### PR DESCRIPTION
### Summary

Added Re-upload functionality in the Image Table
#356 

Back-end is done by @jayshahWebDev and @Sharathxct helped me to resolve some issues in the front-end integrate the front-end and backend

### How to Test the Changes

Type yarn start in the terminal to start the development environment. Go the browser type the url: http://localhost:3000/admin. If there is any file present in the database then it show in the image table or you can upload a new image. At the last column of the image table you will find the reupload button. After clicking on it reupload modal, you can upload the updated image, you can see that the previous image is overridden with the new image(given that the name and extension of the image is same). 

### Screenshots or Recordings
![Screenshot from 2024-09-09 21-39-24](https://github.com/user-attachments/assets/34bc601c-b876-489b-b4d0-5c8f2288c969)

![Screenshot from 2024-09-09 21-39-49](https://github.com/user-attachments/assets/f9606c89-0d06-418c-a141-b28347f0ca6d)

<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
