### PR TITLE
Feature : Logo Search API

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -27,29 +27,27 @@ https://api-logoexecutive.vercel.app/api/business/logo?domain=https://google.com
 https://api-logoexecutive.vercel.app/api/business/logo?domain=www.google.com&API_KEY=YOUR_API_KEY
 ```
 
-## 2. Search (Comming soon)
+## 2. Search (Now Available)
 
 ### Basic
 
-The Basic Logo Search API fetches a list of logo URLs that start with the
-specified characters. This is useful for displaying a variety of logos that
-share a common theme.
+The Basic Logo Search API allows users to fetch a list of logo URLs that start with the specified characters. This is particularly useful for identifying logos based on a domain name's prefix.
 
-**Endpoint:** `/api/logo/search?key={KEY}&API_KEY={YOUR_API_KEY}`
+**Endpoint:** `api/business/search?domainKey={KEY}&API_KEY={YOUR_API_KEY}` 
 
 **Method:** GET
 
 **Access:** Paid
 
-| Parameter | Type   | Description                                                    | Required |
-| --------- | ------ | -------------------------------------------------------------- | -------- |
-| key       | string | The initial character(s) that the logo URLs should begin with. | Yes      |
-| API_KEY   | string | The API Key generated from the dashboard.                      | Yes      |
+| Parameter  | Type   | Description                                                  | Required |
+| ---------- | ------ | ------------------------------------------------------------ | -------- |
+| domainKey  | string | The starting prefix of the domain name to filter logo URLs.   | Yes      | 
+| API_KEY    | string | The API Key generated from the dashboard.                     | Yes      |
 
 **Example Call:**
 
 ```sh
-https://api-logoexecutive.vercel.app/api/business/logo/search?key=g&API_KEY=YOUR_API_KEY
+https://api-logoexecutive.vercel.app/api/business/search?domainKey=google&API_KEY=YOUR_API_KEY
 ```
 
 We encourage you to explore and integrate these endpoints into your

--- a/server/__tests__/unit/controllers/business/search.js
+++ b/server/__tests__/unit/controllers/business/search.js
@@ -1,0 +1,185 @@
+const request = require("supertest");
+const { STATUS_CODES } = require("http");
+const app = require("../../../../app");
+const { KeyService, ImageService, SubscriptionService } = require("../../../../services");
+const Images = require("../../../../models/Images");
+const { mockImages } = require("../../../../utils/mocks/Images");
+
+jest.mock("../../../../services/Keys", () => ({
+  isAPIKeyPresent: jest.fn(),
+  fetchUserByApiKey: jest.fn(),
+}));
+
+jest.mock("../../../../services/Subscriptions", () => ({
+  isApiUsageLimitExceed: jest.fn(),
+  updateApiUsageCount: jest.fn(),
+}));
+
+jest.mock("../../../../services/Images", () => ({
+  fetchImageByCompanyFree: jest.fn(),
+}));
+
+jest.mock("../../../../models/Images");
+
+const mockCDNLink = "https://du4goljobz66l.cloudfront.net/meta.png?Expires=1706882374&Key-Pair-Id=K1CBTPCVEWK03E&Signature=l6ZpbQ-Z3WtJQ8inaDomAAAhcnnC0U2R~5Su7HWjC8fbbeQI4e4JBK368guQFYtc8rQAJMur446ozoXJE-9Hcj125NlZFSMqpeUsjam-nk9Wb2d8XGR6UjyxYLqGbhca8WYwl~h0CzHbe20PJXZbyuFPTufCrBTkIoh4o3Mg3MQDe2fPf5z6L9xLgVtbOrpJQoHZ0YlWTNvWJWutL-AFX8KbisrBaMi8zRa6h-mSfXuIoUyjziMRA5gPA0T8QSUJ8iLdbURwxvRpRpM0Ohrjk06sWDSTkNzLL~pVNyL7LwO04mAHVK4XYgK5179xcZ-BjMMW1qJD3YF7G~xdcsXJw__";
+const mockUser = "66a1c92b2ea4a39a015a9d14";
+const mockApiKey = "2B1B1BF5F9914BCD85A0B1122C71EDDB";
+const ENDPOINT = "/api/business/search";
+
+describe("searchLogoController", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "my_secret";
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("422 - Domain Key is required", async () => {
+    const mockQuery = { API_KEY: mockApiKey };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({
+      message: "domainKey is required",
+      statusCode: 422,
+      error: STATUS_CODES[422],
+    });
+  });
+
+  it("422 - API key is required", async () => {
+    const mockQuery = { domainKey: "dummy" };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({
+      message: "API key is required",
+      statusCode: 422,
+      error: STATUS_CODES[422],
+    });
+  });
+
+  it("403 - Invalid API key", async () => {
+    const mockQuery = {
+      domainKey: "dummy",
+      API_KEY: "2B1B1BF5F9914BCD85A0B1122C71EDDC",
+    };
+    jest.spyOn(KeyService, "isAPIKeyPresent").mockResolvedValue(false);
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: "Invalid API key",
+      statusCode: 403,
+      error: STATUS_CODES[403],
+    });
+  });
+
+  it("403 - API Key Limit reached. Consider upgrading your plan", async () => {
+    jest.spyOn(KeyService, "isAPIKeyPresent").mockResolvedValue(true);
+    jest.spyOn(KeyService, "fetchUserByApiKey").mockResolvedValue(mockUser);
+    jest.spyOn(SubscriptionService, "isApiUsageLimitExceed").mockResolvedValue(true);
+    const mockQuery = {
+      domainKey: "dummy",
+      API_KEY: "2B1B1BF5F9914BCD85A0B1122C71EDDB",
+    };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: "Limit reached. Consider upgrading your plan",
+      statusCode: 403,
+      error: STATUS_CODES[403],
+    });
+  });
+
+  it("500 - Unexpected error", async () => {
+    jest.spyOn(KeyService, "isAPIKeyPresent").mockImplementation(() => {
+      throw new Error("Unexpected error");
+    });
+    const mockQuery = {
+      domainKey: "dummy",
+      API_KEY: "2B1B1BF5F9914BCD85A0B1122C71EDDB",
+    };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: "Unexpected error",
+      error: STATUS_CODES[500],
+      statusCode: 500,
+    });
+  });
+
+  it("200 - Success response when domainKey is given", async () => {
+    jest.spyOn(KeyService, "isAPIKeyPresent").mockResolvedValue(true);
+    jest.spyOn(KeyService, "fetchUserByApiKey").mockResolvedValue(mockUser);
+    jest.spyOn(SubscriptionService, "updateApiUsageCount").mockResolvedValue(mockUser);
+    jest.spyOn(SubscriptionService, "isApiUsageLimitExceed").mockResolvedValue(false);
+    jest.spyOn(ImageService, "fetchImageByCompanyFree").mockResolvedValue(mockCDNLink);
+    jest.spyOn(Images, "find").mockImplementation((query) => {
+      const regex = query.domainame.$regex;
+      const filteredImages = mockImages.filter((company) => regex.test(company.domainame));
+      return filteredImages;
+    });
+
+    const mockQuery = {
+      domainKey: "go",
+      API_KEY: "2B1B1BF5F9914BCD85A0B1122C71EDDB",
+    };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    const expectedData = [
+      {
+        companyName: "GODADDY",
+        image: mockCDNLink
+      },
+      {
+        companyName: "GOOGLE",
+        image: mockCDNLink  
+      }
+    ];
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      statusCode: 200,
+      data: expectedData,
+    });
+  });
+
+  it("200 - Success response when domain URL is given", async () => {
+    jest.spyOn(KeyService, "isAPIKeyPresent").mockResolvedValue(true);
+    jest.spyOn(KeyService, "fetchUserByApiKey").mockResolvedValue(mockUser);
+    jest.spyOn(SubscriptionService, "updateApiUsageCount").mockResolvedValue(mockUser);
+    jest.spyOn(SubscriptionService, "isApiUsageLimitExceed").mockResolvedValue(false);
+    jest.spyOn(ImageService, "fetchImageByCompanyFree").mockResolvedValue(mockCDNLink);
+    jest.spyOn(Images, "find").mockImplementation((query) => {
+      const regex = query.domainame.$regex;
+      const filteredImages = mockImages.filter((company) => regex.test(company.domainame));
+      return filteredImages;
+    });
+
+    const mockQuery = {
+      domainKey: "https://www.aircon.com",
+      API_KEY: "2B1B1BF5F9914BCD85A0B1122C71EDDB",
+    };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    const expectedData = [
+      {
+        companyName: "AIRCON",
+        image: mockCDNLink
+      }
+    ];
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      statusCode: 200,
+      data: expectedData,
+    });
+  });
+});

--- a/server/__tests__/unit/controllers/public/search.js
+++ b/server/__tests__/unit/controllers/public/search.js
@@ -1,0 +1,129 @@
+const request = require("supertest");
+const { STATUS_CODES } = require("http");
+const app = require("../../../../app");
+const { ImageService } = require("../../../../services");
+const Images = require("../../../../models/Images");
+const { mockImages } = require("../../../../utils/mocks/Images");
+
+jest.mock("../../../../services/Images", () => ({
+  fetchImageByCompanyFree: jest.fn(),
+}));
+
+jest.mock("../../../../models/Images");
+
+const mockCDNLink = "https://du4goljobz66l.cloudfront.net/meta.png?Expires=1706882374&Key-Pair-Id=K1CBTPCVEWK03E&Signature=l6ZpbQ-Z3WtJQ8inaDomAAAhcnnC0U2R~5Su7HWjC8fbbeQI4e4JBK368guQFYtc8rQAJMur446ozoXJE-9Hcj125NlZFSMqpeUsjam-nk9Wb2d8XGR6UjyxYLqGbhca8WYwl~h0CzHbe20PJXZbyuFPTufCrBTkIoh4o3Mg3MQDe2fPf5z6L9xLgVtbOrpJQoHZ0YlWTNvWJWutL-AFX8KbisrBaMi8zRa6h-mSfXuIoUyjziMRA5gPA0T8QSUJ8iLdbURwxvRpRpM0Ohrjk06sWDSTkNzLL~pVNyL7LwO04mAHVK4XYgK5179xcZ-BjMMW1qJD3YF7G~xdcsXJw__";
+const ENDPOINT = "/api/public/search";
+
+describe("demoSearchLogoController", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "my_secret";
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("422 - Domain Key is required", async () => {
+    const mockQuery = { };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({
+      message: "domainKey is required",
+      statusCode: 422,
+      error: STATUS_CODES[422],
+    });
+  });
+
+  it("500 - Not allowed by CORS", async () => {
+    const mockQuery = { domainKey: "dummy" };
+    const response = await request(app)
+      .get(ENDPOINT)
+      .set("Origin", "http://invalidcorsorigin.com")
+      .query(mockQuery);
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: STATUS_CODES[500],
+      message: "Not allowed by CORS",
+      statusCode: 500,
+    });
+  });
+
+  it("500 - Unexpected error", async () => {
+    jest.spyOn(ImageService, "fetchImageByCompanyFree").mockImplementation(() => {
+      throw new Error("Unexpected error");
+    });
+    jest.spyOn(Images, "find").mockImplementation((query) => {
+      const regex = query.domainame.$regex;
+      const filteredImages = mockImages.filter((company) => regex.test(company.domainame));
+      return filteredImages;
+    });
+    const mockQuery = { domainKey: "go" };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: "Unexpected error",
+      error: STATUS_CODES[500],
+      statusCode: 500,
+    });
+  });
+
+  it("200 - Success response when domainKey is given", async () => {
+    jest.spyOn(ImageService, "fetchImageByCompanyFree").mockResolvedValue(mockCDNLink);
+    jest.spyOn(Images, "find").mockImplementation((query) => {
+      const regex = query.domainame.$regex;
+      const filteredImages = mockImages.filter((company) => regex.test(company.domainame));
+      return filteredImages;
+    });
+
+    const mockQuery = { domainKey: "go" };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    const expectedData = [
+      {
+        companyName: "GODADDY",
+        image: mockCDNLink
+      },
+      {
+        companyName: "GOOGLE",
+        image: mockCDNLink  
+      }
+    ];
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      statusCode: 200,
+      data: expectedData,
+    });
+  });
+
+  it("200 - Success response when domain URL is given", async () => {
+    jest.spyOn(ImageService, "fetchImageByCompanyFree").mockResolvedValue(mockCDNLink);
+    jest.spyOn(Images, "find").mockImplementation((query) => {
+      const regex = query.domainame.$regex;
+      const filteredImages = mockImages.filter((company) => regex.test(company.domainame));
+      return filteredImages;
+    });
+
+    const mockQuery = { domainKey: "https://www.aircon.com" };
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    const expectedData = [
+      {
+        companyName: "AIRCON",
+        image: mockCDNLink
+      }
+    ];
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      statusCode: 200,
+      data: expectedData,
+    });
+  });
+});

--- a/server/__tests__/unit/controllers/public/search.js
+++ b/server/__tests__/unit/controllers/public/search.js
@@ -53,6 +53,19 @@ describe("demoSearchLogoController", () => {
     });
   });
 
+  it("422 - domainKey URL cannot be empty", async () => {
+    const mockQuery = { domainKey: "https://.com" };
+
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+
+    expect(response.status).toBe(422);
+    expect(response.body).toEqual({
+      message: "domainKey URL cannot be empty",
+      statusCode: 422,
+      error: STATUS_CODES[422],
+    });
+  });
+
   it("500 - Unexpected error", async () => {
     jest.spyOn(ImageService, "fetchImageByCompanyFree").mockImplementation(() => {
       throw new Error("Unexpected error");
@@ -70,6 +83,20 @@ describe("demoSearchLogoController", () => {
       message: "Unexpected error",
       error: STATUS_CODES[500],
       statusCode: 500,
+    });
+  });
+
+  it("404 - No companies found", async () => {
+    const mockQuery = { domainKey: "unknownDomain" };
+    jest.spyOn(Images, "find").mockResolvedValue([]);
+  
+    const response = await request(app).get(ENDPOINT).query(mockQuery);
+  
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      message: "No companies found matching the provided domain key.",
+      statusCode: 404,
+      error: STATUS_CODES[404],
     });
   });
 

--- a/server/controllers/business/search.js
+++ b/server/controllers/business/search.js
@@ -1,0 +1,77 @@
+const Joi = require("joi");
+const { STATUS_CODES } = require("http");
+const { isAPIKeyPresent, fetchImageByCompanyFree } = require("../../services");
+const { updateApiUsageCount, isApiUsageLimitExceed } = require("../../services/Subscriptions");
+const { fetchUserByApiKey } = require("../../services/Keys");
+const Images = require("../../models/Images");
+
+const getSearchQuerySchema = Joi.object({
+  domainKey: Joi.string()
+    .regex(/^[A-Za-z0-9&-/:.]+$/)
+    .required().messages({
+      "any.required": "domainKey is required",
+      "string.pattern.base": "Invalid domainKey",
+    }),
+  API_KEY: Joi.string().guid({ version: "uuidv4" }).required().messages({
+    "any.required": "API key is required"
+  }),
+});
+
+async function searchLogoController(req, res, next) {
+  try{
+    const { error, value } = getSearchQuerySchema.validate(req.query);
+    if (!!error) {
+      return res.status(422).json({
+        message: error.message,
+        statusCode: 422,
+        error: STATUS_CODES[422],
+      });
+    }
+
+    const { domainKey, API_KEY } = value;
+    let companyNameBeginsWith = domainKey.replace(/.+\/\/|www.|\..+/g, "").toUpperCase();
+
+    const apiKeyPresent = await isAPIKeyPresent(API_KEY);
+    if (!apiKeyPresent) {
+      return res.status(403).json({
+        message: "Invalid API key",
+        statusCode: 403,
+        error: STATUS_CODES[403],
+      });
+    }
+
+    const userId =await fetchUserByApiKey(API_KEY);
+    const isExceed = await isApiUsageLimitExceed(userId);
+    if(isExceed){
+      return res.status(403).json({
+        message: "Limit reached. Consider upgrading your plan",
+        statusCode: 403,
+        error: STATUS_CODES[403]
+      });
+    }
+
+    const regexPattern = new RegExp(`^${companyNameBeginsWith}`, "i");
+    const companyList = await Images.find({
+      domainame: { $regex: regexPattern }
+    });
+
+    const dataList = [];
+    for(const company of companyList){
+      const signedUrl = await fetchImageByCompanyFree(company.domainame);
+
+      dataList.push({
+        companyName: company.domainame,
+        image: signedUrl
+      });
+    }
+    
+    return res.status(200).json({
+      statusCode: 200,
+      data: dataList,
+    });
+  } catch(err) {
+    next(err);
+  }
+};
+
+module.exports = searchLogoController;

--- a/server/controllers/public/search.js
+++ b/server/controllers/public/search.js
@@ -25,17 +25,30 @@ async function demoSearchLogoController(req, res, next) {
 
     const { domainKey } = value;
     let companyNameBeginsWith = domainKey.replace(/.+\/\/|www.|\..+/g, "").toUpperCase();
+    if(companyNameBeginsWith === "") {
+      return res.status(422).json({
+        message: "domainKey URL cannot be empty",
+        statusCode: 422,
+        error: STATUS_CODES[422],
+      });
+    }
 
     const regexPattern = new RegExp(`^${companyNameBeginsWith}`, "i");
     const companyList = await Images.find({
       domainame: { $regex: regexPattern }
     });
 
-    const companyListSorted = companyList.sort((a, b) => a.domainame.localeCompare(b.domainame));
+    if (companyList.length === 0) {
+      return res.status(404).json({
+        message: "No companies found matching the provided domain key.",
+        statusCode: 404,
+        error: STATUS_CODES[404],
+      });
+    }
 
     const dataList = [];
-    for(const company of companyListSorted){
-      const signedUrl = await fetchImageByCompanyFree(company.domainame);
+    for(const company of companyList){
+      const signedUrl = await fetchImageByCompanyFree(company.domainame, undefined, false);
 
       if(!signedUrl) continue;
 

--- a/server/routes/business.js
+++ b/server/routes/business.js
@@ -1,6 +1,8 @@
 const router = require("express").Router();
 const getLogoController = require("../controllers/business/logo");
+const searchLogoController = require("../controllers/business/search");
 
 router.get("/logo", getLogoController);
+router.get("/search", searchLogoController);
 
 module.exports = router;

--- a/server/routes/public.js
+++ b/server/routes/public.js
@@ -1,8 +1,10 @@
 const router = require("express").Router();
 const contactUsController = require("../controllers/public/contact-us");
 const demoLogoController = require("../controllers/public/logo");
+const demoSearchLogoController = require("../controllers/public/search");
 
 router.post("/contact-us", contactUsController);
 router.get("/logo", demoLogoController);
+router.get("/search", demoSearchLogoController);
 
 module.exports = router; 

--- a/server/services/Images.js
+++ b/server/services/Images.js
@@ -28,16 +28,23 @@ async function uploadToS3(file, imageName, extension) {
   }
 };
 
-async function fetchImageByCompanyFree(company, default_extension = "png") {
+async function fetchImageByCompanyFree(company, default_extension = "png", checkDb = true) {
   try {
-    const image = await Images.findOne({
-      domainame: company,
-      extension: default_extension
-    });
-    if (!image) return null;
-    const imageUrl = `${default_extension}/${image.domainame}.${default_extension}`;
+    let domainName = company;
+    
+    if (checkDb) {
+      const image = await Images.findOne({
+        domainame: company,
+        extension: default_extension
+      });
+      if (!image) return null;
+      domainName = image.domainame;
+    }
+
+    const imageUrl = `${default_extension}/${domainName}.${default_extension}`;
     const cloudFrontUrl = cloudFrontSignedURL(`/${imageUrl}`).data;
     return cloudFrontUrl;
+
   } catch (err) {
     throw err;
   }

--- a/server/utils/mocks/Images.js
+++ b/server/utils/mocks/Images.js
@@ -12,6 +12,27 @@ const mockImages = [
     "imageId": "12579986-7ad0-4a58-b204-211b583ab05b",
     "createdAt": new Date("02-02-2002"),
     "updatedAt": new Date("02-02-2002"),
+  },
+  {
+    domainame: "GODADDY",
+    extension: "png",
+    uploadedBy: "67c340cc281d9c96aca21ra2",
+    createdAt: new Date("02-02-2002"),
+    updatedAt: new Date("02-02-2002"),
+  },
+  {
+    domainame: "GOOGLE",
+    extension: "png",
+    uploadedBy: "67c340cc281d9c96aca21ra2",
+    createdAt: new Date("02-02-2002"),
+    updatedAt: new Date("02-02-2002"),
+  },
+  {
+    domainame: "AIRCON",
+    extension: "png",
+    uploadedBy: "67c340cc281d9c96aca21ra2",
+    createdAt: new Date("02-02-2002"),
+    updatedAt: new Date("02-02-2002"),
   }
 ];
 


### PR DESCRIPTION
### Summary

This PR implements Logo Search API for the **Logo Executive** platform, addressing [Issue #361](https://github.com/TeamShiksha/logoexecutive/issues/361). This API allows users to retrieve logos based on a search key (initial characters), with separate endpoints for public and internal use.
  
### Description:

Two separate endpoints have been implemented for Public & Internal Use.

#### Endpoint 1 (Public Use): `/api/business/search?domainKey={KEY}&API_KEY={YOUR_API_KEY}`

**Method:** GET

| Parameter | Type   | Description                                                    | Required |
| --------- | ------ | -------------------------------------------------------------- | -------- |
| domainKey       | string | The initial character(s) that the logo URLs should begin with. | Yes      |
| API_KEY   | string | The API Key generated from the dashboard.                      | Yes      |

#### Endpoint 2 (Internal): `/api/public/search?domainKey={KEY}`

**Method:** GET

| Parameter | Type   | Description                                                    | Required |
| --------- | ------ | -------------------------------------------------------------- | -------- |
| domainKey       | string | The initial character(s) that the logo URLs should begin with. | Yes      |

### Key Features:
- Fetches logo URLs based on the starting characters of domain names.
- `business/search` endpoint requires an `API_KEY` for authentication.
- Error handling for missing or invalid parameters (`domainKey`, `API_KEY`).
- Comprehensive Unit test cases have been written to cover various scenarios, including successful logo search, missing or invalid `domainKey` and `API_KEY` parameters.
- Tests also verify proper functionality for both public and internal APIs, confirming that logo URLs are returned correctly based on the search key.


### How to Test the Changes

- **Start the server with `yarn start:server`**
- Hit any of the two endpoints with proper query params (`domainKey / API_KEY`). And you can expect response as shown in the below screenshot.

![Screenshot 2024-09-13 233904](https://github.com/user-attachments/assets/84b4ba60-9bbe-4de2-b765-1c9de987012e)


### Screenshots or Recordings


https://github.com/user-attachments/assets/00a816fd-96bc-41e3-89c2-fc88f9d3c912

### Test Results : Server
![Screenshot 2024-09-13 231807](https://github.com/user-attachments/assets/6d79e22d-3cfe-4849-91d3-f7c59be2bfb3)

### Test Results : Client
![Screenshot 2024-09-13 232033](https://github.com/user-attachments/assets/ab9a077a-c44b-494a-9be2-b8daf53dc4ad)

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
