### PR TITLE
Feature: HTML email template

### DIFF
--- a/server/__tests__/unit/utils/sendEmail.js
+++ b/server/__tests__/unit/utils/sendEmail.js
@@ -36,6 +36,7 @@ describe("sendEmail", () => {
       to: "test@example.com",
       subject: "Test Subject",
       text: "Test Body",
+      html: "Test Body",
     });
     expect(result).toEqual({ success: true });
   });
@@ -71,6 +72,7 @@ describe("sendEmail", () => {
       to: "test@example.com",
       subject: "Test Subject",
       text: "Test Body",
+      html: "Test Body",
     });
     expect(result).toEqual({ success: false, error: new Error("Test Error") });
   });

--- a/server/controllers/auth/forgot-password.js
+++ b/server/controllers/auth/forgot-password.js
@@ -50,8 +50,8 @@ async function forgotPasswordController(req, res, next) {
     const template = handlebars.compile(htmlFile);
     const replacements = {
       url: userToken.tokenURL(),
-      message1: "It seems like you forgot your password?",
-      message2: "Please click on the following link to reset your password"
+      highlighted_text: "It seems like you forgot your password?",
+      text: "Please click on the following link to reset your password"
     };
     const htmlBody = template(replacements);
     const nodeMailerRes = await sendEmail(user.email,  "Change Password", htmlBody);

--- a/server/controllers/auth/forgot-password.js
+++ b/server/controllers/auth/forgot-password.js
@@ -3,6 +3,81 @@ const { STATUS_CODES } = require("http");
 const { fetchUserByEmail, createForgotToken } = require("../../services");
 const { sendEmail } = require("../../utils/sendEmail");
 
+const getHTMLBody = (url) =>{
+  return `<!DOCTYPE html>
+  <html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forgot Password</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+      rel="stylesheet" />
+  </head>
+
+  <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+    <table width="100%" cellpadding="0" cellspacing="0"
+      style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+      <tr>
+        <td style="padding: 20px; background-color: #6b5b95;">
+          <a href="https://logoexecutive.vercel.app/home"
+            style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+            <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+              alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
+            <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 50px 20px; text-align: left;">
+          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
+          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
+          <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>It seems like you forgot your
+              password?</strong></p>
+          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
+            password</p>
+          <a href="${url}"
+            style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
+            on the link</a>
+        </td>
+      </tr>
+      <tr>
+        <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+          <table width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="padding-bottom: 10px;">
+                <p style="font-size: 14px; color: #777; margin: 0;">
+                  This is an automated message from OpenLogo. Please do not reply to this email.
+                  <br>
+                  Copyright © 2024 | OpenLogo
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                  <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                    style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                    Powered By
+                    <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                      alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                  </a>
+                </div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+
+  </html>`;
+};
+
 const forgotPasswordSchema = Joi.object().keys({
   email: Joi.string()
     .trim()
@@ -46,8 +121,8 @@ async function forgotPasswordController(req, res, next) {
         statusCode: 503,
       });
 
-    const mail = mailText(userToken.tokenURL());
-    const nodeMailerRes = await sendEmail(user.email, mail.subject, mail.body);
+    const htmlBody = getHTMLBody(userToken.tokenURL()); 
+    const nodeMailerRes = await sendEmail(user.email,  "Change Password", htmlBody);
     if (!nodeMailerRes.success)
       return res.status(500).json({
         error: STATUS_CODES[500],

--- a/server/controllers/auth/forgot-password.js
+++ b/server/controllers/auth/forgot-password.js
@@ -21,19 +21,19 @@ const getHTMLBody = (url) =>{
         <table width="100%" cellpadding="0" cellspacing="0"
           style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
           <tr>
-            <td style="padding: 20px; background-color: #6b5b95;">
+            <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
               <a href="https://logoexecutive.vercel.app/home"
-                style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+                style="color: rgb(17, 24, 39); text-decoration: none;">
                 <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
+                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
                 <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
               </a>
-            </td>
+           </td>
           </tr>
           <tr>
             <td style="padding: 50px 20px; text-align: left;">
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting LogoExecutive.</p>
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>It seems like you forgot your
                   password?</strong></p>
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
@@ -49,9 +49,7 @@ const getHTMLBody = (url) =>{
                 <tr>
                   <td style="padding-bottom: 10px;">
                     <p style="font-size: 14px; color: #777; margin: 0;">
-                      This is an automated message from OpenLogo. Please do not reply to this email.
-                      <br>
-                      Copyright © 2024 | OpenLogo
+                      Copyright © 2024 | LogoExecutive
                     </p>
                   </td>
                 </tr>
@@ -66,6 +64,13 @@ const getHTMLBody = (url) =>{
                           alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
                       </a>
                     </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 10px;">
+                    <p style="font-size: 10px; color: #777; margin: 0;">
+                      This is an automated message from LogoExecutive. Please do not reply to this email.
+                    </p>
                   </td>
                 </tr>
               </table>

--- a/server/controllers/auth/forgot-password.js
+++ b/server/controllers/auth/forgot-password.js
@@ -5,77 +5,75 @@ const { sendEmail } = require("../../utils/sendEmail");
 
 const getHTMLBody = (url) =>{
   return `<!DOCTYPE html>
-  <html lang="en">
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Forgot Password</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+          rel="stylesheet" />
+      </head>
 
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forgot Password</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
-      rel="stylesheet" />
-  </head>
-
-  <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
-    <table width="100%" cellpadding="0" cellspacing="0"
-      style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
-      <tr>
-        <td style="padding: 20px; background-color: #6b5b95;">
-          <a href="https://logoexecutive.vercel.app/home"
-            style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
-            <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-              alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
-            <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td style="padding: 50px 20px; text-align: left;">
-          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
-          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
-          <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>It seems like you forgot your
-              password?</strong></p>
-          <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
-            password</p>
-          <a href="${url}"
-            style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
-            on the link</a>
-        </td>
-      </tr>
-      <tr>
-        <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
-          <table width="100%" cellpadding="0" cellspacing="0">
-            <tr>
-              <td style="padding-bottom: 10px;">
-                <p style="font-size: 14px; color: #777; margin: 0;">
-                  This is an automated message from OpenLogo. Please do not reply to this email.
-                  <br>
-                  Copyright © 2024 | OpenLogo
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <div
-                  style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
-                  <a href="https://team.shiksha/" target="_blank" rel="noopener"
-                    style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
-                    Powered By
-                    <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
-                      alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
-                  </a>
-                </div>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-
-  </html>`;
+      <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+        <table width="100%" cellpadding="0" cellspacing="0"
+          style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="padding: 20px; background-color: #6b5b95;">
+              <a href="https://logoexecutive.vercel.app/home"
+                style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+                <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
+                <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 50px 20px; text-align: left;">
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>It seems like you forgot your
+                  password?</strong></p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
+                password</p>
+              <a href="${url}"
+                style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
+                on the link</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="padding-bottom: 10px;">
+                    <p style="font-size: 14px; color: #777; margin: 0;">
+                      This is an automated message from OpenLogo. Please do not reply to this email.
+                      <br>
+                      Copyright © 2024 | OpenLogo
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                      <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                        style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                        Powered By
+                        <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                          alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>`;
 };
 
 const forgotPasswordSchema = Joi.object().keys({

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -115,8 +115,8 @@ async function signupController(req, res, next) {
     const template = handlebars.compile(htmlFile);
     const replacements = {
       url: verificationToken.tokenURL(),
-      message1: "You need to verify your email",
-      message2: "Please click on the following link to verify your email"
+      highlighted_text: "You need to verify your email",
+      text: "Please click on the following link to verify your email"
     };
     const htmlBody = template(replacements);
     const emailRes = await sendEmail(

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -4,6 +4,78 @@ const { sendEmail } = require("../../utils/sendEmail");
 const { createUser, emailRecordExists,
   createVerifyToken, createSubscription } = require("../../services");
 
+const getHTMLBody = (url) =>{
+  return `<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Forgot Password</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+          rel="stylesheet" />
+      </head>
+    
+      <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+        <table width="100%" cellpadding="0" cellspacing="0"
+          style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="padding: 20px; background-color: #6b5b95;">
+              <a href="https://logoexecutive.vercel.app/home"
+                style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+                <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
+                <span style="font-size: 24px; font-weight: 800;">Verify Your Email</span>
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 50px 20px; text-align: left;">
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>Please verify your email, by visiting the below link.</strong></p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
+                password</p>
+              <a href="${url}"
+                style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
+                on the link to verify</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="padding-bottom: 10px;">
+                    <p style="font-size: 14px; color: #777; margin: 0;">
+                      This is an automated message from OpenLogo. Please do not reply to this email.
+                      <br>
+                      Copyright © 2024 | OpenLogo
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                      <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                        style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                        Powered By
+                        <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                          alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>`;
+};
+
 const signupPayloadSchema = Joi.object().keys({
   firstName: Joi.string()
     .trim()
@@ -106,10 +178,11 @@ async function signupController(req, res, next) {
         },
       );
 
+    const htmlBody = getHTMLBody(verificationToken.tokenURL()); 
     const emailRes = await sendEmail(
       newUser.email,
       "Please Verify your email",
-      verificationToken.tokenURL()
+      htmlBody
     );
     if (!emailRes.success) {
       return res.status(206).json(

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -1,85 +1,10 @@
 const Joi = require("joi");
 const { STATUS_CODES } = require("http");
+const fs = require("fs");
+const handlebars = require("handlebars");
 const { sendEmail } = require("../../utils/sendEmail");
 const { createUser, emailRecordExists,
   createVerifyToken, createSubscription } = require("../../services");
-
-const getHTMLBody = (url) =>{
-  return `<!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Verify Your Email</title>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
-          rel="stylesheet" />
-      </head>
-    
-      <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
-        <table width="100%" cellpadding="0" cellspacing="0"
-          style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
-          <tr>
-            <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
-              <a href="https://logoexecutive.vercel.app/home"
-                style="color: rgb(17, 24, 39); text-decoration: none;">
-                <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
-                <span style="font-size: 24px; font-weight: 800;">Verify Your Email</span>
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td style="padding: 50px 20px; text-align: left;">
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting LogoExecutive.</p>
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>Please verify your email, by visiting the below link.</strong></p>
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
-                password</p>
-              <a href="${url}"
-                style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
-                on the link to verify</a>
-            </td>
-          </tr>
-          <tr>
-            <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
-              <table width="100%" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td style="padding-bottom: 10px;">
-                    <p style="font-size: 14px; color: #777; margin: 0;">
-                      Copyright © 2024 | LogoExecutive
-                    </p>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <div
-                      style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
-                      <a href="https://team.shiksha/" target="_blank" rel="noopener"
-                        style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
-                        Powered By
-                        <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
-                          alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
-                      </a>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding-top: 10px;">
-                    <p style="font-size: 10px; color: #777; margin: 0;">
-                      This is an automated message from LogoExecutive. Please do not reply to this email.
-                    </p>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-        </table>
-      </body>
-    </html>`;
-};
 
 const signupPayloadSchema = Joi.object().keys({
   firstName: Joi.string()
@@ -183,7 +108,17 @@ async function signupController(req, res, next) {
         },
       );
 
-    const htmlBody = getHTMLBody(verificationToken.tokenURL()); 
+    const htmlFile = fs.readFileSync(
+      __dirname + "/../../templates/ForgotPasswordOrVerify.html",
+      "utf-8"
+    ).toString();
+    const template = handlebars.compile(htmlFile);
+    const replacements = {
+      url: verificationToken.tokenURL(),
+      message1: "You need to verify your email",
+      message2: "Please click on the following link to verify your email"
+    };
+    const htmlBody = template(replacements);
     const emailRes = await sendEmail(
       newUser.email,
       "Please Verify your email",

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -22,19 +22,19 @@ const getHTMLBody = (url) =>{
         <table width="100%" cellpadding="0" cellspacing="0"
           style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
           <tr>
-            <td style="padding: 20px; background-color: #6b5b95;">
+            <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
               <a href="https://logoexecutive.vercel.app/home"
-                style="color: #ffffff; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+                style="color: rgb(17, 24, 39); text-decoration: none;">
                 <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; filter: invert();">
-                <span style="font-size: 24px; font-weight: 800;">Verify Your Email</span>
+                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
+                <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
               </a>
             </td>
           </tr>
           <tr>
             <td style="padding: 50px 20px; text-align: left;">
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
-              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting Logoexecutive.</p>
+              <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting LogoExecutive.</p>
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>Please verify your email, by visiting the below link.</strong></p>
               <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Please click on the following link to reset your
                 password</p>
@@ -49,8 +49,6 @@ const getHTMLBody = (url) =>{
                 <tr>
                   <td style="padding-bottom: 10px;">
                     <p style="font-size: 14px; color: #777; margin: 0;">
-                      This is an automated message from OpenLogo. Please do not reply to this email.
-                      <br>
                       Copyright © 2024 | OpenLogo
                     </p>
                   </td>
@@ -66,6 +64,13 @@ const getHTMLBody = (url) =>{
                           alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
                       </a>
                     </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 10px;">
+                    <p style="font-size: 10px; color: #777; margin: 0;">
+                      This is an automated message from LogoExecutive. Please do not reply to this email.
+                    </p>
                   </td>
                 </tr>
               </table>

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -49,7 +49,7 @@ const getHTMLBody = (url) =>{
                 <tr>
                   <td style="padding-bottom: 10px;">
                     <p style="font-size: 14px; color: #777; margin: 0;">
-                      Copyright © 2024 | OpenLogo
+                      Copyright © 2024 | LogoExecutive
                     </p>
                   </td>
                 </tr>

--- a/server/controllers/auth/signup.js
+++ b/server/controllers/auth/signup.js
@@ -10,7 +10,7 @@ const getHTMLBody = (url) =>{
       <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Forgot Password</title>
+        <title>Verify Your Email</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
@@ -27,7 +27,7 @@ const getHTMLBody = (url) =>{
                 style="color: rgb(17, 24, 39); text-decoration: none;">
                 <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
                   alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
-                <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
+                <span style="font-size: 24px; font-weight: 800;">Verify Your Email</span>
               </a>
             </td>
           </tr>

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -7,71 +7,77 @@ const { sendEmail } = require("../../utils/sendEmail");
 const getHTMLReplyForCustomer = (message, reply) => {
   return `<!DOCTYPE html>
   <html lang="en">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap" rel="stylesheet" />
-      <style>
-        *,
-        *::before,
-        *::after {
-          box-sizing: border-box;
-          list-style: none;
-        }
-
-        * {
-          padding: 0;
-          margin: 0;
-          font-family: Inter;
-        }
-      </style>
-    </head>
-
-    <body style="--white: rgb(255, 255, 255); --smooth-purple: rgb(79, 70, 229); --black: rgb(17, 24, 39); --smooth-gray: rgb(107 114 128); --description: rgb(75, 85, 99); --light-purple: rgba(79, 70, 229, 0.1); --faded-purple: rgba(79, 70, 229, 0.5); --border: 2px solid rgb(229, 231, 235); --bradius: 6px; --shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; --small-text: 12px; --medium-text: 16px; --large-text: 20px; --gray-drag-drop-background: rgb(249, 250, 251); --error: rgb(255, 55, 55); --success: rgb(52, 168, 83); --table-heading-bg: rgb(226, 224, 224);">
-      <header style="padding: 20px; background-color: #f1f1f1;">
-        <a class="logo" href="https://logoexecutive.vercel.app/home" style="color: var(--black); cursor: pointer; text-decoration: none; display: flex; align-items: center; justify-content: center;">
-          <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp" style="height: 35px; width: 35px; margin-right: 10px;" />
-          <h2 style="font-size: 24px; font-weight: 800;">LogoExecutive</h2>
-        </a>
-      </header>
-      <main style="padding: 30px;">
-        <h4 style="font-weight: 400;">
-          Hi there,
-          <br />
-          <br />
-          Thanks for connecting with us through our contact-us form. We have prepared a response based on your query:
-          
-          <br />
-          <br />
-          <b>Query:</b>
-          <br />
-          ${message}
-          <br />
-
-          <br />
-          <b>Reply:</b>
-          <br />
-          ${reply}
-          <br />
-          
-          <br />
-          <br />
-          Thanks,
-          <br />
-          OpenLogo Team
-        </h4>
-      </main>
-      <footer class="footer" style="width: 100%; background-color: #f1f1f1; display: flex; padding: 12px 0; position: fixed; left: 0; bottom: 0; width: 100%;">
-        <section class="footer-child" style="padding: 12px; display: flex; justify-content: center; flex-direction: column; align-items: center; gap: 20px; flex-grow: 1; max-width: 500px; text-align: center; margin: 0 auto;">
-          <div class="footer-child-heading-container" style="display: flex; gap: 16px;">
-            <h4 style="font-size: var(--large-text); color: var(--black);">Copyright © 2024 | OpenLogo</h4>
-          </div>
-          <section class="poweredBy" style="display: flex; align-items: center; justify-content: center; border: 2px solid var(--smooth-purple); border-radius: 6px; padding: 2px 6px; cursor: pointer; color: var(--smooth-purple); font-weight: 700; font-size: var(--medium-text);">Powered By<img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp" alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;"></section>
-        </section>
-      </footer>
-    </body>
+  
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LogoExecutive Email</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+      rel="stylesheet" />
+  </head>
+  
+  <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+    <table width="100%" cellpadding="0" cellspacing="0"
+      style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+      <tr>
+        <td style="padding: 20px; background-color: #f1f1f1;">
+          <a href="https://logoexecutive.vercel.app/home"
+            style="color: rgb(17, 24, 39); text-decoration: none; display: inline-block;">
+            <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+              alt="Logo" style="height: 35px; width: 35px; vertical-align: middle; margin-right: 10px;">
+            <span style="font-size: 24px; font-weight: 800; vertical-align: middle;">LogoExecutive</span>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 50px 20px;">
+          <h4 style="font-weight: 400; margin: 0;">
+            Hi there,
+            <br><br>
+            Thanks for connecting with us through our contact-us form. We have prepared a response based on your question
+            (<b><i>${message}</i></b>) below:
+            <br><br>
+            <i>${reply}</i>
+            <br><br>
+            Thanks,<br>
+            OpenLogo Team
+          </h4>
+        </td>
+      </tr>
+      <tr>
+        <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+          <table width="100%" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="padding-bottom: 20px;">
+                <p style="font-size: 14px; color: #777; margin: 0;">
+                  This is an automated message from OpenLogo. Please do not reply to this email.
+                  <br>
+                  Copyright © 2024 | OpenLogo
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                  <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                    style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                    Powered By
+                    <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                      alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                  </a>
+                </div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+  
   </html>`;
 };
 

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -4,6 +4,77 @@ const { fetchUserFromId, updateForm } = require("../../services");
 const { isValidObjectId } = require("mongoose");
 const { sendEmail } = require("../../utils/sendEmail");
 
+const getHTMLReplyForCustomer = (message, reply) => {
+  return `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap" rel="stylesheet" />
+      <style>
+        *,
+        *::before,
+        *::after {
+          box-sizing: border-box;
+          list-style: none;
+        }
+
+        * {
+          padding: 0;
+          margin: 0;
+          font-family: Inter;
+        }
+      </style>
+    </head>
+
+    <body style="--white: rgb(255, 255, 255); --smooth-purple: rgb(79, 70, 229); --black: rgb(17, 24, 39); --smooth-gray: rgb(107 114 128); --description: rgb(75, 85, 99); --light-purple: rgba(79, 70, 229, 0.1); --faded-purple: rgba(79, 70, 229, 0.5); --border: 2px solid rgb(229, 231, 235); --bradius: 6px; --shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; --small-text: 12px; --medium-text: 16px; --large-text: 20px; --gray-drag-drop-background: rgb(249, 250, 251); --error: rgb(255, 55, 55); --success: rgb(52, 168, 83); --table-heading-bg: rgb(226, 224, 224);">
+      <header style="padding: 20px; background-color: #f1f1f1;">
+        <a class="logo" href="https://logoexecutive.vercel.app/home" style="color: var(--black); cursor: pointer; text-decoration: none; display: flex; align-items: center; justify-content: center;">
+          <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp" style="height: 35px; width: 35px; margin-right: 10px;" />
+          <h2 style="font-size: 24px; font-weight: 800;">LogoExecutive</h2>
+        </a>
+      </header>
+      <main style="padding: 30px;">
+        <h4 style="font-weight: 400;">
+          Hi there,
+          <br />
+          <br />
+          Thanks for connecting with us through our contact-us form. We have prepared a response based on your query:
+          
+          <br />
+          <br />
+          <b>Query:</b>
+          <br />
+          ${message}
+          <br />
+
+          <br />
+          <b>Reply:</b>
+          <br />
+          ${reply}
+          <br />
+          
+          <br />
+          <br />
+          Thanks,
+          <br />
+          OpenLogo Team
+        </h4>
+      </main>
+      <footer class="footer" style="width: 100%; background-color: #f1f1f1; display: flex; padding: 12px 0; position: fixed; left: 0; bottom: 0; width: 100%;">
+        <section class="footer-child" style="padding: 12px; display: flex; justify-content: center; flex-direction: column; align-items: center; gap: 20px; flex-grow: 1; max-width: 500px; text-align: center; margin: 0 auto;">
+          <div class="footer-child-heading-container" style="display: flex; gap: 16px;">
+            <h4 style="font-size: var(--large-text); color: var(--black);">Copyright © 2024 | OpenLogo</h4>
+          </div>
+          <section class="poweredBy" style="display: flex; align-items: center; justify-content: center; border: 2px solid var(--smooth-purple); border-radius: 6px; padding: 2px 6px; cursor: pointer; color: var(--smooth-purple); font-weight: 700; font-size: var(--medium-text);">Powered By<img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp" alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;"></section>
+        </section>
+      </footer>
+    </body>
+  </html>`;
+};
+
 const revertToCustomerPayloadSchema = Joi.object().keys({
   id: Joi.string()
     .custom((value, helpers) => {
@@ -62,10 +133,11 @@ async function revertToCustomerController(req, res, next) {
         message: "Already sent the response for this query!"
       });
     }
+    const htmlReply = getHTMLReplyForCustomer(revertForm.message, reply);
     const emailRes = await sendEmail(
       revertForm.email,
       "Response for your query at LogoExecutive",
-      reply
+      htmlReply
     );
     if (!emailRes.success) {
       return res.status(500).json({

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -27,7 +27,7 @@ const getHTMLReplyForCustomer = (message, reply) => {
                 style="color: rgb(17, 24, 39); text-decoration: none;">
                 <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
                   alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
-                <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
+                <span style="font-size: 24px; font-weight: 800;">LogoExecutive</span>
               </a>
            </td>
           </tr>

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -6,79 +6,77 @@ const { sendEmail } = require("../../utils/sendEmail");
 
 const getHTMLReplyForCustomer = (message, reply) => {
   return `<!DOCTYPE html>
-  <html lang="en">
-  
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>LogoExecutive Email</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
-      rel="stylesheet" />
-  </head>
-  
-  <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
-    <table width="100%" cellpadding="0" cellspacing="0"
-      style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
-      <tr>
-        <td style="padding: 20px; background-color: #f1f1f1;">
-          <a href="https://logoexecutive.vercel.app/home"
-            style="color: rgb(17, 24, 39); text-decoration: none; display: inline-block;">
-            <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-              alt="Logo" style="height: 35px; width: 35px; vertical-align: middle; margin-right: 10px;">
-            <span style="font-size: 24px; font-weight: 800; vertical-align: middle;">LogoExecutive</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td style="padding: 50px 20px;">
-          <h4 style="font-weight: 400; margin: 0;">
-            Hi there,
-            <br><br>
-            Thanks for connecting with us through our contact-us form. We have prepared a response based on your question
-            (<b><i>${message}</i></b>) below:
-            <br><br>
-            <i>${reply}</i>
-            <br><br>
-            Thanks,<br>
-            OpenLogo Team
-          </h4>
-        </td>
-      </tr>
-      <tr>
-        <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
-          <table width="100%" cellpadding="0" cellspacing="0">
-            <tr>
-              <td style="padding-bottom: 20px;">
-                <p style="font-size: 14px; color: #777; margin: 0;">
-                  This is an automated message from OpenLogo. Please do not reply to this email.
-                  <br>
-                  Copyright © 2024 | OpenLogo
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <div
-                  style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
-                  <a href="https://team.shiksha/" target="_blank" rel="noopener"
-                    style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
-                    Powered By
-                    <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
-                      alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
-                  </a>
-                </div>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-  
-  </html>`;
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>LogoExecutive Email</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+          rel="stylesheet" />
+      </head>
+      
+      <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+        <table width="100%" cellpadding="0" cellspacing="0"
+          style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="padding: 20px; background-color: #f1f1f1;">
+              <a href="https://logoexecutive.vercel.app/home"
+                style="color: rgb(17, 24, 39); text-decoration: none; display: inline-block;">
+                <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+                  alt="Logo" style="height: 35px; width: 35px; vertical-align: middle; margin-right: 10px;">
+                <span style="font-size: 24px; font-weight: 800; vertical-align: middle;">LogoExecutive</span>
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 50px 20px;">
+              <h4 style="font-weight: 400; margin: 0;">
+                Hi there,
+                <br><br>
+                Thanks for connecting with us through our contact-us form. We have prepared a response based on your question
+                (<b><i>${message}</i></b>) below:
+                <br><br>
+                <i>${reply}</i>
+                <br><br>
+                Thanks,<br>
+                OpenLogo Team
+              </h4>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="padding-bottom: 20px;">
+                    <p style="font-size: 14px; color: #777; margin: 0;">
+                      This is an automated message from OpenLogo. Please do not reply to this email.
+                      <br>
+                      Copyright © 2024 | OpenLogo
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                      <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                        style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                        Powered By
+                        <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                          alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>`;
 };
 
 const revertToCustomerPayloadSchema = Joi.object().keys({

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -1,88 +1,10 @@
 const Joi = require("joi");
 const { STATUS_CODES } = require("http");
+const fs = require("fs");
+const handlebars = require("handlebars");
 const { fetchUserFromId, updateForm } = require("../../services");
 const { isValidObjectId } = require("mongoose");
 const { sendEmail } = require("../../utils/sendEmail");
-
-const getHTMLReplyForCustomer = (message, reply) => {
-  return `<!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>LogoExecutive Email</title>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
-          rel="stylesheet" />
-      </head>
-      
-      <body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
-        <table width="100%" cellpadding="0" cellspacing="0"
-          style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
-          <tr>
-            <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
-              <a href="https://logoexecutive.vercel.app/home"
-                style="color: rgb(17, 24, 39); text-decoration: none;">
-                <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
-                <span style="font-size: 24px; font-weight: 800;">LogoExecutive</span>
-              </a>
-           </td>
-          </tr>
-          <tr>
-            <td style="padding: 50px 20px;">
-              <h4 style="font-weight: 400; margin: 0;">
-                Hi there,
-                <br><br>
-                Thanks for connecting with us through our contact-us form. We have prepared a response based on your question
-                (<b><i>${message}</i></b>) below:
-                <br><br>
-                <i>${reply}</i>
-                <br><br>
-                Thanks,<br>
-                LogoExecutive Team
-              </h4>
-            </td>
-          </tr>
-          <tr>
-            <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
-              <table width="100%" cellpadding="0" cellspacing="0">
-                <tr>
-                  <td style="padding-bottom: 10px;">
-                    <p style="font-size: 14px; color: #777; margin: 0;">
-                      Copyright © 2024 | LogoExecutive
-                    </p>
-                  </td>
-                </tr>
-                <tr>
-                  <td>
-                    <div
-                      style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
-                      <a href="https://team.shiksha/" target="_blank" rel="noopener"
-                        style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
-                        Powered By
-                        <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
-                          alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
-                      </a>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding-top: 10px;">
-                    <p style="font-size: 10px; color: #777; margin: 0;">
-                      This is an automated message from LogoExecutive. Please do not reply to this email.
-                    </p>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-        </table>
-      </body>
-    </html>`;
-};
 
 const revertToCustomerPayloadSchema = Joi.object().keys({
   id: Joi.string()
@@ -142,11 +64,20 @@ async function revertToCustomerController(req, res, next) {
         message: "Already sent the response for this query!"
       });
     }
-    const htmlReply = getHTMLReplyForCustomer(revertForm.message, reply);
+    const htmlFile = fs.readFileSync(
+      __dirname + "/../../templates/RevertEmail.html",
+      "utf-8"
+    ).toString();
+    const template = handlebars.compile(htmlFile);
+    const replacements = {
+      message: revertForm.message,
+      reply
+    };
+    const htmlBody = template(replacements);
     const emailRes = await sendEmail(
       revertForm.email,
       "Response for your query at LogoExecutive",
-      htmlReply
+      htmlBody
     );
     if (!emailRes.success) {
       return res.status(500).json({

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -22,14 +22,14 @@ const getHTMLReplyForCustomer = (message, reply) => {
         <table width="100%" cellpadding="0" cellspacing="0"
           style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
           <tr>
-            <td style="padding: 20px; background-color: #f1f1f1;">
+            <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
               <a href="https://logoexecutive.vercel.app/home"
-                style="color: rgb(17, 24, 39); text-decoration: none; display: inline-block;">
+                style="color: rgb(17, 24, 39); text-decoration: none;">
                 <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
-                  alt="Logo" style="height: 35px; width: 35px; vertical-align: middle; margin-right: 10px;">
-                <span style="font-size: 24px; font-weight: 800; vertical-align: middle;">LogoExecutive</span>
+                  alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
+                <span style="font-size: 24px; font-weight: 800;">Forgot Password</span>
               </a>
-            </td>
+           </td>
           </tr>
           <tr>
             <td style="padding: 50px 20px;">
@@ -50,10 +50,8 @@ const getHTMLReplyForCustomer = (message, reply) => {
             <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                  <td style="padding-bottom: 20px;">
+                  <td style="padding-bottom: 10px;">
                     <p style="font-size: 14px; color: #777; margin: 0;">
-                      This is an automated message from OpenLogo. Please do not reply to this email.
-                      <br>
                       Copyright © 2024 | OpenLogo
                     </p>
                   </td>
@@ -69,6 +67,13 @@ const getHTMLReplyForCustomer = (message, reply) => {
                           alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
                       </a>
                     </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding-top: 10px;">
+                    <p style="font-size: 10px; color: #777; margin: 0;">
+                      This is an automated message from LogoExecutive. Please do not reply to this email.
+                    </p>
                   </td>
                 </tr>
               </table>

--- a/server/controllers/operator/revert.js
+++ b/server/controllers/operator/revert.js
@@ -42,7 +42,7 @@ const getHTMLReplyForCustomer = (message, reply) => {
                 <i>${reply}</i>
                 <br><br>
                 Thanks,<br>
-                OpenLogo Team
+                LogoExecutive Team
               </h4>
             </td>
           </tr>
@@ -52,7 +52,7 @@ const getHTMLReplyForCustomer = (message, reply) => {
                 <tr>
                   <td style="padding-bottom: 10px;">
                     <p style="font-size: 14px; color: #777; margin: 0;">
-                      Copyright © 2024 | OpenLogo
+                      Copyright © 2024 | LogoExecutive
                     </p>
                   </td>
                 </tr>

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "handlebars": "^4.7.8",
     "joi": "^17.12.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.1",

--- a/server/services/ContactUs.js
+++ b/server/services/ContactUs.js
@@ -68,7 +68,7 @@ async function updateForm(formId, reply, operatorId) {
       }
     );
     if (result.modifiedCount === 0) throw new Error("MongoDB operation failed");
-    return { reply, activityStatus: true, assignedTo: operatorId, email: currentForm.email };
+    return { reply, activityStatus: true, assignedTo: operatorId, email: currentForm.email, message: currentForm.message };
   } catch (error) {
     throw error;
   }

--- a/server/templates/ForgotPasswordOrVerify.html
+++ b/server/templates/ForgotPasswordOrVerify.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenLogo Email</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+    rel="stylesheet" />
+</head>
+
+<body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+  <table width="100%" cellpadding="0" cellspacing="0"
+    style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+    <tr>
+      <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
+        <a href="https://logoexecutive.vercel.app/home" style="color: rgb(17, 24, 39); text-decoration: none;">
+          <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+            alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
+          <span style="font-size: 24px; font-weight: 800;">OpenLogo</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 50px 20px; text-align: left;">
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting OpenLogo.</p>
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>{{message1}}</strong></p>
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;">{{message2}}</p>
+        <a href="{{url}}"
+          style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
+          on the link</a>
+      </td>
+    </tr>
+    <tr>
+      <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+        <table width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="padding-bottom: 10px;">
+              <p style="font-size: 14px; color: #777; margin: 0;">
+                Copyright © 2024 | OpenLogo
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                  style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                  Powered By
+                  <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                    alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top: 10px;">
+              <p style="font-size: 10px; color: #777; margin: 0;">
+                This is an automated message from OpenLogo. Please do not reply to this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/server/templates/ForgotPasswordOrVerify.html
+++ b/server/templates/ForgotPasswordOrVerify.html
@@ -28,11 +28,11 @@
       <td style="padding: 50px 20px; text-align: left;">
         <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Hi there,</p>
         <p style="font-size: 16px; color: #333; margin-bottom: 10px;">Thank you for visiting OpenLogo.</p>
-        <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>{{message1}}</strong></p>
-        <p style="font-size: 16px; color: #333; margin-bottom: 10px;">{{message2}}</p>
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;"><strong>{{highlighted_text}}</strong></p>
+        <p style="font-size: 16px; color: #333; margin-bottom: 10px;">{{text}}</p>
         <a href="{{url}}"
           style="display: inline-block; cursor: pointer; border: none; padding: 12px 20px; font-size: 16px; font-weight: bold; background-color: rgb(79, 70, 229); color: white; border: 2px solid rgb(229, 231, 235); text-decoration: none; border-radius: 6px; transition: 200ms ease-in-out; box-shadow: rgba(140, 152, 164, 0.125) 0px 6px 24px 0px; margin-top: 20px;">Click
-          on the link</a>
+          Here</a>
       </td>
     </tr>
     <tr>

--- a/server/templates/RevertEmail.html
+++ b/server/templates/RevertEmail.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenLogo Email</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
+    rel="stylesheet" />
+</head>
+
+<body style="margin: 0; padding: 0; font-family: Inter, Arial, sans-serif; box-sizing: border-box;">
+  <table width="100%" cellpadding="0" cellspacing="0"
+    style="background-color: #ffffff; max-width: 675px; margin: 0 auto; border: 1px solid #ddd; box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);">
+    <tr>
+      <td style="padding: 20px; background-color: #f1f1f1; margin: 0 auto; text-align: center">
+        <a href="https://logoexecutive.vercel.app/home" style="color: rgb(17, 24, 39); text-decoration: none;">
+          <img src="https://logoexecutive.vercel.app/static/media/business-man-logo.3a122f718b0294570293.webp"
+            alt="Logo" style="height: 35px; width: 35px; margin-right: 10px; vertical-align: bottom;">
+          <span style="font-size: 24px; font-weight: 800;">OpenLogo</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding: 50px 20px;">
+        <h4 style="font-weight: 400; margin: 0;">
+          Hi there,
+          <br><br>
+          Thanks for connecting with us through our contact-us form. We have prepared a response based on your question
+          (<b><i>{{message}}</i></b>) below:
+          <br><br>
+          <i>{{reply}}</i>
+          <br><br>
+          Thanks,<br>
+          OpenLogo Team
+        </h4>
+      </td>
+    </tr>
+    <tr>
+      <td style="background-color: #f1f1f1; padding: 12px; text-align: center;">
+        <table width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td style="padding-bottom: 10px;">
+              <p style="font-size: 14px; color: #777; margin: 0;">
+                Copyright © 2024 | OpenLogo
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                style="display: inline-block; border: 2px solid rgb(79, 70, 229); border-radius: 6px; padding: 2px 6px;">
+                <a href="https://team.shiksha/" target="_blank" rel="noopener"
+                  style="text-decoration: none; color: rgb(79, 70, 229); font-weight: 700; font-size: 16px; display: flex; align-items: center;">
+                  Powered By
+                  <img src="https://logoexecutive.vercel.app/static/media/teamshishalogo.7bfb117958cfe1b031c9.webp"
+                    alt="TeamShiksha Logo" style="margin-left: 5px; width: auto; height: 18px;">
+                </a>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top: 10px;">
+              <p style="font-size: 10px; color: #777; margin: 0;">
+                This is an automated message from OpenLogo. Please do not reply to this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/server/utils/sendEmail.js
+++ b/server/utils/sendEmail.js
@@ -26,6 +26,7 @@ async function sendEmail(email, subject, text) {
       to: email,
       subject: subject,
       text: text,
+      html: text,
     });
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
### Summary

#368

This PR implements HTML templates for sending out emails to the users of LogoExecutive. Currently, we're just sending plain emails with very little content. So, this change will improve the communication and brand image.

### Approach

Multiple approaches were taken to create the templates. I made plain HTML templates using some CSS. However, after testing them on various clients, it was observed that the behavior of plain HTML structure is quite different for different clients. So to make it consistent, table structure is used and instead of using classes inline styles are used. (A good guide for creating HTML templates: https://www.freecodecamp.org/news/how-to-create-a-responsive-html-email-template/)

### How to Test the Changes

Try sending out an email using operator credentials or click on forgot password. You'll receive the email in the new templates

### Screenshots or Recordings

These are the screenshots taken for multiple clients

**Before**:
![image](https://github.com/user-attachments/assets/66b7964b-c7cd-41da-95d0-5a5b37854c71)
![image](https://github.com/user-attachments/assets/9dcdd46e-8531-46fd-814c-d7e816f659fd)
![image](https://github.com/user-attachments/assets/7957909e-af0b-4024-b14d-874ac3b05fdb)

**After**:
![image](https://github.com/user-attachments/assets/4b2e4377-c2d2-4736-8d6c-948b38426918)
![image](https://github.com/user-attachments/assets/faa3c6e0-f448-4c0b-88be-c24162bf6676)
![image](https://github.com/user-attachments/assets/3891bb90-6a71-426a-b92a-a1275c30146e)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
