### PR TITLE
add: more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue_form.yml
@@ -1,0 +1,52 @@
+name: Documentation Issue
+description: Use this form to report documentation issues, improvements, or missing content
+labels: ["documentation", "low priority"]
+body:        
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of Documentation Issue
+      description: What type of documentation issue are you reporting?
+      options:
+        - Missing Documentation
+        - Incorrect Information
+        - Unclear Explanation
+        - Outdated Content
+        - Broken Links
+        - Typo/Grammar Error
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Please describe what's wrong or missing in the documentation
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-change
+    attributes:
+      label: Suggested Changes
+      description: Please share any specific suggestions you have for improving the documentation.
+
+  - type: input
+    id: location
+    attributes:
+      label: Documentation Location
+      description: Please specify where this documentation issue is located (URL or file path).
+      placeholder: "e.g., docs/README.md"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched for similar issues before creating this one.
+        - label: I have provided all the necessary information to understand the documentation issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation_issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue_form.yml
@@ -1,45 +1,21 @@
 name: Documentation Issue
 description: Use this form to report documentation issues, improvements, or missing content
 labels: ["documentation", "low priority"]
-body:        
-  - type: dropdown
-    id: issue-type
-    attributes:
-      label: Type of Documentation Issue
-      description: What type of documentation issue are you reporting?
-      options:
-        - Missing Documentation
-        - Incorrect Information
-        - Unclear Explanation
-        - Outdated Content
-        - Broken Links
-        - Typo/Grammar Error
-        - Other
-    validations:
-      required: true
-
+body:  
+      
   - type: textarea
-    id: issue-description
+    id: description
     attributes:
-      label: Issue Description
+      label: Description
       description: Please describe what's wrong or missing in the documentation
     validations:
       required: true
 
   - type: textarea
-    id: suggested-change
+    id: change-reason
     attributes:
-      label: Suggested Changes
-      description: Please share any specific suggestions you have for improving the documentation.
-
-  - type: input
-    id: location
-    attributes:
-      label: Documentation Location
-      description: Please specify where this documentation issue is located (URL or file path).
-      placeholder: "e.g., docs/README.md"
-    validations:
-      required: true
+      label: Reason of Change
+      description: Please descibe why this change or addition is necessary.
 
   - type: checkboxes
     id: confirmation
@@ -47,6 +23,6 @@ body:
       label: Confirmation
       options:
         - label: I have searched for similar issues before creating this one.
-        - label: I have provided all the necessary information to understand the documentation issue.
+        - label: I have provided all the necessary information to understand this documentation issue.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/others_form.yml
+++ b/.github/ISSUE_TEMPLATE/others_form.yml
@@ -1,0 +1,20 @@
+name: Other Issue Form
+description: Use this form for issues that don't fit other categories
+labels: ["other", "low priority"]
+body:
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Briefly describe the issue you're facing.
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmation-checklist
+    attributes:
+      label: Confirmation Checklist
+      options:
+        - label: I have searched for similar issues before submitting this one.
+        - label: I am sure that this issue doesn't fit any other categories.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/others_form.yml
+++ b/.github/ISSUE_TEMPLATE/others_form.yml
@@ -1,6 +1,6 @@
 name: Other Issue Form
 description: Use this form for issues that don't fit other categories
-labels: ["other", "low priority"]
+labels: ["low priority"]
 body:
   - type: textarea
     id: issue-description


### PR DESCRIPTION
### Summary

This PR adds new issue templates for documentation related issues and other category.

### Approach

Previously, contributors were only presented with a single issue template, which often caused confusion when reporting issues. This also made it difficult for maintainers to prfioritize and address the most critical issues. With this update, contributors will now have the option to directly raise documentation issues or other types of issues, streamlining the issue reporting process and improving overall project management.

Issue ticket number : https://github.com/TeamShiksha/logoexecutive/issues/391

<!-- Describe your changes in detail. Include the task or issue that this PR resolves, if applicable. -->

### How to Test the Changes

To test these changes, navigate to the repository's "New Issue" page and verify that the options for "Documentation Issue" and "Other Issue" are available and function as expected

<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Screenshots or Recordings

![documentation new](https://github.com/user-attachments/assets/f06aabb4-ac68-4350-b387-2be1d2f8c2a6)
![Other issue](https://github.com/user-attachments/assets/1befb9b5-c5cd-4130-ab65-6fff05961e6a)

<!-- If applicable, add screenshots or recordings to help explain your changes. -->

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
