### PR TITLE
enhance api-key-table and modal according to figma design

### DIFF
--- a/client/src/components/admindashboard/ReuploadImageModal.css
+++ b/client/src/components/admindashboard/ReuploadImageModal.css
@@ -14,14 +14,13 @@
 .modal-content {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+
 	justify-content: center;
 	background: #fff;
 	padding: 20px;
 	border-radius: 5px;
 	width: auto;
 	height: auto;
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 .modal-close-button {

--- a/client/src/components/common/modal/Modal.css
+++ b/client/src/components/common/modal/Modal.css
@@ -3,7 +3,7 @@
 	width: 100%;
 	background: linear-gradient(90deg, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.3));
 	z-index: 1;
-	backdrop-filter: blur(2px);
+
 	position: fixed;
 	inset: 0;
 	display: flex;
@@ -12,7 +12,7 @@
 }
 
 .modal-container {
-	max-width: 500px;
+	max-width: 400px;
 	background-color: white;
 	padding: 30px 14px 20px;
 	margin: 30px 16px;

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import {MdDeleteOutline} from 'react-icons/md';
 import {formatDate} from '../../utils/helpers';
 import Modal from '../common/modal/Modal';
 import {useRef, useState} from 'react';

--- a/client/src/components/dashboard/ApiKeyTable.js
+++ b/client/src/components/dashboard/ApiKeyTable.js
@@ -25,9 +25,9 @@ function ApiKeyTable({keys, deleteKey, handleCloseKey}) {
 				<table>
 					<thead>
 						<tr>
-							<th>DESCRIPTION</th>
-							<th>ACTION</th>
-							<th>CREATE DATE</th>
+							<th>Description</th>
+							<th>Created </th>
+							{/* <th>CREATE DATE</th> */}
 						</tr>
 					</thead>
 					<tbody>
@@ -42,16 +42,17 @@ function ApiKeyTable({keys, deleteKey, handleCloseKey}) {
 						{keys.map((key, index) => (
 							<tr key={index}>
 								<td>{key.keyDescription}</td>
+								<td>{formatDate(key?.createdAt)}</td>
 								<td>
 									<button
 										className='api-key-delete-button'
 										data-testid='api-key-delete'
 										onClick={() => showConfirmationModal(key.keyId)}
 									>
-										<MdDeleteOutline />
+										{/* <MdDeleteOutline /> */}
+										Delete
 									</button>
 								</td>
-								<td>{formatDate(key?.createdAt)}</td>
 							</tr>
 						))}
 					</tbody>

--- a/client/src/pages/dashboard/Dashboard.css
+++ b/client/src/pages/dashboard/Dashboard.css
@@ -248,7 +248,7 @@
 .api-key-table {
 	padding: 0px;
 	width: 100%;
-	text-align: center;
+	text-align: start;
 }
 
 .api-key-table .content-item-heading {
@@ -259,22 +259,26 @@
 .api-key-table table {
 	font-style: normal;
 	font-size: var(--medium-text);
+	background-color: rgb(247, 245, 247);
 	line-height: 175%;
 	border-spacing: 0;
 	white-space: nowrap;
 }
 
 .api-key-table thead tr th {
-	background-color: rgb(226, 224, 224);
 	padding: 8px;
-	font-weight: 500;
+	padding-left: 15px;
+	background-color: rgb(247, 245, 247);
+	font-weight: 400;
+	text-align: start;
 	color: var(--smooth-gray);
 }
 
 .api-key-table tbody tr td {
 	padding: 8px;
+	padding-left: 15px;
 	font-weight: 400;
-	color: var(--smooth-gray);
+	color: black;
 	border-top: var(--border);
 }
 
@@ -287,7 +291,9 @@
 .api-key-delete-button {
 	margin: 0 auto;
 	border: none;
-	border-radius: 99px;
+	color: red;
+	background-color: #fff;
+	border-radius: 5px;
 	display: flex;
 	align-items: center;
 	padding: 8px 12px;

--- a/client/src/pages/dashboard/Dashboard.test.js
+++ b/client/src/pages/dashboard/Dashboard.test.js
@@ -51,7 +51,7 @@ describe('Dashboard Component', () => {
 		expect(usageComponent).toBeInTheDocument();
 		const apiKeyFormComponent = screen.getByText('Generate your API key');
 		expect(apiKeyFormComponent).toBeInTheDocument();
-		const apiKeyTableComponent = screen.getByText('DESCRIPTION');
+		const apiKeyTableComponent = screen.getByText('Description');
 		expect(apiKeyTableComponent).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
### Summary

Create the API-key table and modal when deleting an API key.

### Approach

The API key table developed according to figma design.

Table Figma Design
![Screenshot 2024-12-03 120010](https://github.com/user-attachments/assets/4243c07c-1f9c-4fe3-a2e3-b57044ff8d12)

Changed table
![Screenshot 2024-12-03 120214](https://github.com/user-attachments/assets/ba59387b-21b4-40ba-ab0b-81228b7d1684)

Modal figma design (Modal should be similar to the below modal)
![Screenshot 2024-12-03 120304](https://github.com/user-attachments/assets/62d1f5d1-8b58-47c2-b1dc-19fcdcda9517)

Changed modal
![Screenshot 2024-12-03 120345](https://github.com/user-attachments/assets/5c6b878e-0cbc-47ea-81cd-f9e498d610a7)

Existing modal is a common component used throughout the dashboard and not unique to "api-key delete" modal so minimum style changes were made.

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [x] I have updated the documentation to reflect the changes.
