### PR TITLE
Modified the ui of the settings page to move the username and email to the center of the card.

### DIFF
--- a/packages/ui/components/settingsPage/SettingCard.module.css
+++ b/packages/ui/components/settingsPage/SettingCard.module.css
@@ -28,6 +28,10 @@
 
 .userDetails {
   margin-top: auto; 
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height : 100%;
   text-align: left;
 }
 


### PR DESCRIPTION
### Summary

Moved the username and email to the center of the card in the settings page.

### Approach

Updated the CSS for the userdetails div to center the username and email within the card.

### How to Test the Changes

The changes can be tested by rendering the settings page on both desktop and mobile device.

### Screenshots or Recordings

![settings page](https://github.com/user-attachments/assets/20e5ec01-3227-4172-8d2a-e070795df243)

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
