### PR TITLE
Added user info form on dashboard page

### DIFF
--- a/packages/ui/src/components/common/input/CustomInput.jsx
+++ b/packages/ui/src/components/common/input/CustomInput.jsx
@@ -2,7 +2,16 @@ import PropTypes from "prop-types";
 import { useState } from "react";
 import styles from "./CustomInput.module.css";
 
-function CustomInput({ type, name, label, value, onChange, error, className }) {
+function CustomInput({
+  type,
+  name,
+  label,
+  value,
+  onChange,
+  error,
+  className,
+  disabled,
+}) {
   const [isFocused, setIsFocused] = useState(false);
   const handleFocus = () => setIsFocused(true);
   const handleBlur = () => setIsFocused(false);
@@ -18,6 +27,7 @@ function CustomInput({ type, name, label, value, onChange, error, className }) {
         onFocus={handleFocus}
         onBlur={handleBlur}
         onChange={onChange}
+        disabled={disabled}
       />
       <label
         className={`${styles.customInputLabel} ${
@@ -40,6 +50,7 @@ CustomInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   error: PropTypes.string,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 export default CustomInput;

--- a/packages/ui/src/components/dashboard/UserInfo/UserInfo.jsx
+++ b/packages/ui/src/components/dashboard/UserInfo/UserInfo.jsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { UserInfoItems } from "../../../utils/constants";
+import styles from "./UserInfo.module.css";
+import CustomInput from "../../common/input/CustomInput";
+import Button from "../../common/button/Button";
+
+function UserInfo() {
+  const [userInfo, setUserInfo] = useState({
+    name: "John Doe",
+    email: "johndoe@gamil.com",
+    isBtnDisabled: true,
+  });
+
+  const handleUserInfoChange = (itemType, e) => {
+    const { value } = e.target;
+
+    setUserInfo((prevUserInfo) => {
+      return {
+        ...prevUserInfo,
+        isBtnDisabled: false,
+        [itemType]: value,
+      };
+    });
+  };
+
+  const handleUserInfoUpdate = (e) => {
+    e.preventDefault();
+
+    // to be implemented
+  };
+
+  return (
+    <div className={styles.dashboardContentItem}>
+      <h6 className={styles.contentItemHeading}>User Info</h6>
+      <form className={styles.userInfoInputGroup}>
+        <CustomInput
+          type="text"
+          name={UserInfoItems.NAME}
+          label="username"
+          value={userInfo.name}
+          onChange={(e) => handleUserInfoChange(UserInfoItems.NAME, e)}
+        />
+        <CustomInput
+          type="email"
+          name={UserInfoItems.EMAIL}
+          label="email"
+          value={userInfo.email}
+          onChange={(e) => handleUserInfoChange(UserInfoItems.EMAIL, e)}
+          disabled={true}
+        />
+        <Button
+          onClick={handleUserInfoUpdate}
+          disabled={userInfo.isBtnDisabled}
+          className={styles.saveUserInfoBtn}
+        >
+          Save
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export default UserInfo;

--- a/packages/ui/src/components/dashboard/UserInfo/UserInfo.module.css
+++ b/packages/ui/src/components/dashboard/UserInfo/UserInfo.module.css
@@ -1,0 +1,35 @@
+.dashboardContentItem {
+  border-radius: 8px;
+  border: var(--border);
+  box-shadow: 0 4px 6px rgba(0, 0.1, 0.1, 0.1);
+  background-color: var(--white);
+  padding: 24px 32px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.contentItemHeading {
+  color: var(--black);
+  font-size: var(--large-text);
+  font-weight: 500;
+  line-height: 20px;
+  margin-bottom: 12px;
+}
+
+.userInfoInputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.saveUserInfoBtn {
+  background-color: var(--primary);
+  border-radius: 8px;
+}
+
+.saveUserInfoBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -1,6 +1,7 @@
 import ApiKeyForm from "../../components/dashboard/ApiKeyForm/ApiKeyForm";
 import CurrentPlan from "../../components/dashboard/CurrentPlan/CurrentPlan";
 import Usage from "../../components/dashboard/Usage/Usage";
+import UserInfo from "../../components/dashboard/UserInfo/UserInfo";
 import styles from "./Dashboard.module.css";
 
 function Dashboard() {
@@ -14,6 +15,9 @@ function Dashboard() {
             <ApiKeyForm />
           </div>
           <CurrentPlan />
+        </section>
+        <section className={styles.dashboardContentSection}>
+          <UserInfo />
         </section>
       </div>
     </div>

--- a/packages/ui/src/utils/constants.js
+++ b/packages/ui/src/utils/constants.js
@@ -613,8 +613,3 @@ export const SETTING = [
     buttontitle: "Delete Account",
   },
 ];
-
-export const UserInfoItems = {
-  NAME: "name",
-  EMAIL: "email",
-};

--- a/packages/ui/src/utils/constants.js
+++ b/packages/ui/src/utils/constants.js
@@ -613,3 +613,8 @@ export const SETTING = [
     buttontitle: "Delete Account",
   },
 ];
+
+export const UserInfoItems = {
+  NAME: "name",
+  EMAIL: "email",
+};


### PR DESCRIPTION
Closes #485 

### Summary

Created a "User Info" form on the dashboard page that allows logged-in users to view and edit their profile information.

### Approach

1. Added a form on dashboard page where username and email are pre-filled an form can't be submitted.
2. Email field is un-editable and once user starts typing into username field save button to submit form get's enabled.

### Screenshots or Recordings
![Screenshot (283)](https://github.com/user-attachments/assets/6e5fd1b9-af98-48e4-8449-2bb50fe96ea8)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
