### PR TITLE
Enhancement: Move setting card to dashboard

### DIFF
--- a/packages/ui/src/components/common/button/Button.jsx
+++ b/packages/ui/src/components/common/button/Button.jsx
@@ -21,7 +21,7 @@ const Button = ({
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
-  variant: PropTypes.oneOf(["primary", "secondary"]).isRequired,
+  variant: PropTypes.oneOf(["primary", "secondary", "danger"]).isRequired,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/ui/src/components/common/button/Button.module.css
+++ b/packages/ui/src/components/common/button/Button.module.css
@@ -40,3 +40,13 @@ button:disabled:hover {
   border-color: var(--primary);
   color: var(--primary);
 }
+
+.danger {
+  background-color: rgba(255, 69, 58, 1); 
+  color: var(--white);
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.danger:hover {
+  background-color: rgba(220, 53, 53, 1); 
+}

--- a/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
@@ -6,7 +6,7 @@ import { SETTING } from "../../../utils/constants";
   function SettingCard()  {
   return (
       <div className={styles.dashboardContentItem}>
-        <h6 className={styles.contentItemHeading}>Profile</h6>
+        <h6 className={styles.contentItemHeading}>Setting</h6>
         {SETTING.map((setting, index) => (
           <div key={index} className={styles.actionButtonWrapper}>
             <p className={styles.actionText}>{setting.subtitle}</p>

--- a/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styles from "./SettingCard.module.css";
+import Button from "../../common/button/Button";
+import { SETTING } from "../../../utils/constants";
+
+  function SettingCard()  {
+  return (
+      <div className={styles.dashboardContentItem}>
+        <h6 className={styles.contentItemHeading}>Profile</h6>
+        {SETTING.map((setting, index) => (
+          <div key={index} className={styles.actionButtonWrapper}>
+            <p className={styles.actionText}>{setting.subtitle}</p>
+            <Button
+              type="submit"
+              variant={setting.buttontitle.toLowerCase().includes("delete") ? "danger" : "primary"}
+              className={styles.actionButton}
+            >
+              {setting.buttontitle}
+            </Button>
+          </div>
+        ))}
+      </div>
+  );
+};
+export default SettingCard;

--- a/packages/ui/src/components/dashboard/settingpage/SettingCard.module.css
+++ b/packages/ui/src/components/dashboard/settingpage/SettingCard.module.css
@@ -1,0 +1,41 @@
+.dashboardContentItem {
+    border-radius: 0.5rem; 
+    border: var(--border);
+    box-shadow: 0 0.25rem 0.375rem rgba(0, 0.1, 0.1, 0.1); 
+    background-color: var(--white);
+    padding: 1.5rem 2rem; 
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex: 1;
+  }
+  
+  .contentItemHeading {
+    color: var(--black);
+    font-size: var(--large-text);
+    font-weight: 500;
+    line-height: 1.25rem; 
+    margin: 0;
+  }
+  
+  .actionButtonWrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem; 
+    align-items: center;
+  }
+  
+  .actionText {
+    font-size: var(--medium-text);
+    font-weight: 400;
+    line-height: 1.25rem; 
+    color: var(--description);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .actionButton {
+    width: 100%;
+  }
+  

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -3,6 +3,7 @@ import CurrentPlan from "../../components/dashboard/currentplan/CurrentPlan";
 import Usage from "../../components/dashboard/usage/Usage";
 import ChangePassword from "../../components/dashboard/changepassword/ChangePassword";
 import styles from "./Dashboard.module.css";
+import SettingCard from "../../components/dashboard/settingpage/SettingCard";
 
 function Dashboard() {
   return (
@@ -20,6 +21,7 @@ function Dashboard() {
       <div className={styles.dashboardContentContainer}>
         <section className={styles.dashboardContentSection}>
           <ChangePassword />
+          <SettingCard/>
         </section>
       </div>
     </div>


### PR DESCRIPTION
### Summary

Fix: #481 

1.Moved settings option to dashboard.

### Approach

1.Created new settingCard component and used it in the dashboard page. Component contains two buttons namely, download and delete.

### How to Test the Changes

1.Visit the /dashboard page you can see the settings component.

### Screenshots or Recordings

![image](https://github.com/user-attachments/assets/04ac1104-0912-4f9e-98c8-8e22d00b2d05)
## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
