### PR TITLE
Typo in activeAccordion state FAQs.js

### DIFF
--- a/client/src/components/faqs/FAQs.js
+++ b/client/src/components/faqs/FAQs.js
@@ -4,9 +4,9 @@ import Accordion from '../common/accordion/Accordion';
 import './FAQs.css';
 
 const FAQs = () => {
-	const [activeAccordian, setActiveAccordion] = useState(false);
+	const [activeAccordion, setActiveAccordion] = useState(false);
 	function handleChange(accordion) {
-		setActiveAccordion(activeAccordian === accordion ? false : accordion);
+		setActiveAccordion(activeAccordion === accordion ? false : accordion);
 	}
 
 	return (
@@ -17,7 +17,7 @@ const FAQs = () => {
 					return (
 						<Accordion
 							key={faq.title}
-							expanded={activeAccordian === faq.title}
+							expanded={activeAccordion === faq.title}
 							title={faq.title}
 							toggle={handleChange}
 						>


### PR DESCRIPTION

### Summary

There was a typo in the activeAccordion State variable. Fixed it for better readability.

### Approach

The state variable was called activeAccordian. I renamed it to activeAccordion.