### PR TITLE
Fix #513 : typo in Footer

### DIFF
--- a/packages/ui/src/components/footer/Footer.jsx
+++ b/packages/ui/src/components/footer/Footer.jsx
@@ -23,7 +23,7 @@ function Footer() {
           rel="noopener noreferrer"
           className={styles["footer-powered"]}
         >
-          Powered by TeamShiksa
+          Powered by TeamShiksha
         </a>
       </div>
     </footer>


### PR DESCRIPTION
### Summary

Corrected Team Shiksha's spelling in the footer

### Approach

Fixed the typo

### How to Test the Changes

- Run the ui (pnpm --filter ui start)
- Go to http://localhost:3000
- You should be able to see the updated footer now.

### Screenshots or Recordings

Updated Footer:
![image](https://github.com/user-attachments/assets/b35ed338-2dff-42cb-8d99-42acf7b654cd)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
