### PR TITLE
Add test for SettingCard component

### DIFF
--- a/packages/ui/__tests__/SettingCard.test.jsx
+++ b/packages/ui/__tests__/SettingCard.test.jsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SettingCard from "../src/components/dashboard/settingpage/SettingCard";
+import { SETTING } from "../src/utils/Constants";
+
+describe("SettingCard Component", () => {
+  it("renders the SettingCard component with correct number of buttons", () => {
+    render(<SettingCard />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(SETTING.length);
+  });
+
+  it("displays correct button titles and subtitles", () => {
+    render(<SettingCard />);
+    SETTING.forEach(({ subtitle, buttontitle }) => {
+      const buttonElement = screen.getByText(buttontitle);
+      const subtitleElement = screen.getByText(subtitle);
+
+      expect(buttonElement).toBeInTheDocument();
+      expect(subtitleElement).toBeInTheDocument();
+    });
+  });
+
+  it("assigns correct button variants", () => {
+    render(<SettingCard />);
+    SETTING.forEach(({ buttontitle }) => {
+      const button = screen.getByText(buttontitle);
+      const isDeleteButton = buttontitle.toLowerCase().includes("delete");
+
+      if (isDeleteButton) {
+        expect(button).toHaveAttribute(
+          "class",
+          expect.stringContaining("danger")
+        );
+      } else {
+        expect(button).toHaveAttribute(
+          "class",
+          expect.stringContaining("primary")
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Summary
test: #522 
This PR introduces the test cases for SettingCard component on the dashboard page.

### Approach

Created a dedicated test file inside the tests folder to ensure proper organization and modularity of tests.
The tests focus on verifying the rendering, content, and button behavior within the SettingCard component.
Implemented 3 test cases Rendering ,Button count ,Button variant.
### How to Test the Changes
Run Local Tests:
Test ui : pnpm --filter ui test


### Screenshots or Recordings

![image](https://github.com/user-attachments/assets/924935b6-037d-4df7-ae5d-a5163eea243d)
![Screenshot 2025-02-03 200302](https://github.com/user-attachments/assets/3725795a-7cd3-4bd4-ae6f-7a15adf2d1c3)

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [x] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
