### PR TITLE
Add prettier config to /app

### DIFF
--- a/packages/app/.prettierrc.json
+++ b/packages/app/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}


### PR DESCRIPTION
### Summary

Added prettierrc.json file in /app

### Approach

The backend /app didn't have a .prettier.json file leading to inconsistent formatting due to local configs.
Added the same config as the frontend.

## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
