### PR TITLE
Fix #526 : inconsistent dialog behavior on home page

### DIFF
--- a/packages/ui/src/components/auth/SignForm.module.css
+++ b/packages/ui/src/components/auth/SignForm.module.css
@@ -74,10 +74,11 @@
 
 .closeButton {
   position: absolute;
-  top: -10px;
-  right: -10px;
+  top: 2px;
+  right: 16px;
   background: none;
   border: none;
+  color: #666;
   font-size: 2rem;
   cursor: pointer;
   z-index: 2;
@@ -104,6 +105,7 @@
     top: 8px;
     right: 8px;
   }
+
   .horizontalLine {
     width: 90%;
   }

--- a/packages/ui/src/components/contact/GetInTouch.jsx
+++ b/packages/ui/src/components/contact/GetInTouch.jsx
@@ -30,17 +30,7 @@ function GetInTouch() {
         </Button>
       </div>
 
-      {isModalOpen && (
-        <dialog
-          className={styles.modalOverlay}
-          open={isModalOpen}
-          onClose={closeModal}
-        >
-          <div className={styles.modalContent}>
-            <ContactForm closeModal={closeModal} />
-          </div>
-        </dialog>
-      )}
+      {isModalOpen && <ContactForm closeModal={closeModal} />}
     </div>
   );
 }

--- a/packages/ui/src/components/header/Header.jsx
+++ b/packages/ui/src/components/header/Header.jsx
@@ -56,7 +56,7 @@ const Header = () => {
         <AuthModal
           isOpen={signupModal}
           onClose={() => {
-            setSignupModal(true);
+            setSignupModal(false);
           }}
         />
         <button className={styles.hamburger} onClick={toggleMenu}>


### PR DESCRIPTION
### Summary

Fixed the issues in multiple dialogs on the homepage.
- The signin/signup modal now closes correctly on clicking on close button or clicking outside.
- The close button is rendered correctly.
- The getInTouch contact form has correct overlay and renders correctly now.

### Approach
Fixes #526 
- Fixed the incorrect onclose function on header dialog.
- Changed position of the close button on modals so they display correctly
- removed redundant nested tags used to render the contact form in getInTouch dialog card.

### How to Test the Changes

- Clone the repository and switch to this branch.
- Run the ui app using `pnpm --filter ui start`
- you should be able to see the changes now.
<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Screenshots or Recordings

Current behaviour:
![ezgif-3aea485ad4a00](https://github.com/user-attachments/assets/766b7c9e-d3dd-4497-8f63-07f810a8cf7c)

Corrected behaviour:
![ezgif-3d909e0ca28d4](https://github.com/user-attachments/assets/b883ec12-99a6-491f-8afb-93af6ee6a238)


## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
