### PR TITLE
Fix #544 make privacy page responsive

### DIFF
--- a/packages/ui/src/page/privacypolicy/PrivacyPolicy.jsx
+++ b/packages/ui/src/page/privacypolicy/PrivacyPolicy.jsx
@@ -2,8 +2,8 @@ import styles from "./PrivacyPolicy.module.css";
 
 const PrivacyPolicy = () => {
   return (
-    <div className={styles.container}>
-      <h2 className={styles.heading}>Openlogo Terms of Services</h2>
+    <div className={`container ${styles["privacy-page-container"]}`}>
+      <h2 className={styles.heading}>Openlogo Terms of Service</h2>
       <p className={styles.text}>
         Thank you for choosing OpenLogo! Before using our services, please
         review our Terms of Service carefully. This agreement is a crucial
@@ -52,7 +52,7 @@ const PrivacyPolicy = () => {
         is 100% secure. While we strive to use commercially acceptable means to
         protect your personal information, we cannot guarantee its absolute
         security. We retain your personal data only as long as necessary to
-        fulfill its purposes or as required by law.
+        fulfill its purpose or as required by law.
       </p>
       <p className={styles.text}>
         Openlogo&apos;s services are not intended for children under 13, and we

--- a/packages/ui/src/page/privacypolicy/PrivacyPolicy.module.css
+++ b/packages/ui/src/page/privacypolicy/PrivacyPolicy.module.css
@@ -3,11 +3,11 @@
   line-height: 1.8rem;
   font-size: 1.2rem;
   font-weight: 500;
+  margin: 1rem 0;
 }
 
-.container {
-  margin: 1rem 2rem;
-  padding: 2rem 5rem;
+.privacy-page-container {
+  margin: 2rem 0;
 }
 
 .heading {
@@ -15,4 +15,10 @@
   font-size: 3rem;
   margin-bottom: 1rem;
   color: var(--black);
+}
+
+@media screen and (max-width: 480px) {
+  .heading {
+    font-size: 2.25rem;
+  }
 }


### PR DESCRIPTION
### Summary

This PR enhances the responsiveness of the Privacy Policy page by introducing media queries to optimize layout and typography for smaller screens.

### Approach

<!-- Describe your changes in detail. Include the task or issue that this PR resolves, if applicable. -->
Added CSS media queries for the following 480px breakpoint to reduce large heading size.
Removed custom container class and replace with site wide container class.
Added spacing between paragraph blocks.

### How to Test the Changes

<!-- Describe the steps to test your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- Run the ui: `pnpm --filter ui start`
- navigate to /privacy page
- Resize the browser window to different screen widths (768px, 564px, 480px).
- Verify that:
    -  The container margins and padding adjust properly at each breakpoint.
    -  The heading size decreases at 480px for better readability.

### Screenshots or Recordings

https://github.com/user-attachments/assets/b71c0e43-c1cd-4e5d-ac51-b6ea0ec9e033



## Checklist

<!-- To tick a checkbox, change '[ ]' to '[x]' -->
- [ ] I have added/updated tests that cover the changes.
- [ ] I have updated the documentation to reflect the changes.
