### PR TITLE
Added Swagger Documentation

### DIFF
--- a/packages/app/index.js
+++ b/packages/app/index.js
@@ -2,6 +2,8 @@ const dotenv = require("dotenv");
 const express = require("express");
 const mongoose = require("mongoose");
 const cookieParser = require("cookie-parser");
+const swaggerUi = require("swagger-ui-express");
+const swaggerSpec = require("./utils/swagger");
 const { validateEnv } = require("./utils/envSchema");
 const logger = require("./utils/logger");
 const routes = require("./routes/index");
@@ -31,6 +33,7 @@ const app = express();
 app.use(cookieParser());
 app.disable("x-powered-by");
 app.use(express.json());
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use("/api/", routes);
 
 if (process.env.NODE_ENV !== "test") {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,6 +31,8 @@
     "multer": "^1.4.5-lts.1",
     "newrelic": "^12.6.1",
     "newrelic-winston-transport": "^2.2.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^9.0.1",
     "winston": "^3.16.0"
   },

--- a/packages/app/routes/users.js
+++ b/packages/app/routes/users.js
@@ -10,6 +10,91 @@ const {
   logoRequestController,
 } = require("../controllers/users");
 
+/**
+ * @swagger
+ * /api/users/me:
+ *   get:
+ *     summary: Retrieve user information
+ *     tags:
+ *       - Users
+ *     responses:
+ *       200:
+ *         description: Retrieve user profile, subscription, and API key information
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     name:
+ *                       type: string
+ *                       description: The user's last name
+ *                       example: John Doe
+ *                     email:
+ *                       type: string
+ *                       description: The user's email
+ *                       example: johndoe@gmail.com
+ *                     userId:
+ *                       type: string
+ *                       description: The user ID
+ *                       example: 672fa704e0af81f237142905
+ *                     userType:
+ *                       type: string
+ *                       description: The user's type
+ *                       example: CUSTOMER
+ *                     subscription:
+ *                       type: object
+ *                       properties:
+ *                         subscriptionId:
+ *                           type: string
+ *                           description: The subscription ID
+ *                           example: 672fa704e0af81f237142908
+ *                         subscriptionType:
+ *                           type: string
+ *                           description: The subscription type
+ *                           example: HOBBY
+ *                         keyLimit:
+ *                           type: integer
+ *                           description: The key limit for the subscription
+ *                           example: 2
+ *                         usageLimit:
+ *                           type: integer
+ *                           description: The usage limit for the subscription
+ *                           example: 500
+ *                         usageCount:
+ *                           type: integer
+ *                           description: The current usage count
+ *                           example: 0
+ *                         isActive:
+ *                           type: boolean
+ *                           description: Whether the subscription is active
+ *                           example: true
+ *                         updatedAt:
+ *                           type: string
+ *                           format: date-time
+ *                           description: The last update date of the subscription
+ *                           example: 2024-12-09T18:45:12.704Z
+ *                     keys:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           keyId:
+ *                             type: string
+ *                             description: The key ID
+ *                             example: 673063b210bf0bc1f1663351
+ *                           keyDescription:
+ *                             type: string
+ *                             description: The key description
+ *                             example: Dev server
+ *                           updatedAt:
+ *                             type: string
+ *                             format: date-time
+ *                             description: The last update date of the key
+ *                             example: 2024-11-10T07:41:38.224Z
+ */
 router.get("/", authMiddleware(), getUserDataController);
 router.patch("/", authMiddleware(), updateProfileController);
 router.delete("/", authMiddleware(), deleteUserAccountController);

--- a/packages/app/utils/swagger.js
+++ b/packages/app/utils/swagger.js
@@ -1,0 +1,18 @@
+const swaggerJSDoc = require("swagger-jsdoc");
+
+const options = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "Openlogo API Documentation",
+      version: "1.0.0",
+      description:
+        "Openlogo is your partner in logo exploration. Our platform boasts a collection of APIs designed to simplify the process of obtaining company logos.",
+    },
+  },
+  apis: ["./routes/*.js"],
+};
+
+const swaggerSpec = swaggerJSDoc(options);
+
+module.exports = swaggerSpec;


### PR DESCRIPTION
## Description
This PR add swagger documentation configuration and an example docs for `api/users/me` endpoint. Using this others can add the documentations accordingly. After running the nodejs server, developers can visit: `http://localhost:{PORT}/docs` in order to view the documentation.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [X] 📄 Documentation Update
- [X] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/03818268-231c-43cf-ae50-655f9030591c)


## Checklist
- [X] I have performed a self-review of my code  
- [X] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [X] New and existing unit tests pass locally with my changes
