### PR TITLE
Stretch footer

### DIFF
--- a/packages/ui/src/components/footer/Footer.module.css
+++ b/packages/ui/src/components/footer/Footer.module.css
@@ -2,6 +2,7 @@
   display: flex;
   background-color: var(--white);
   border-bottom: var(--border);
+  border-top: var(--border);
   position: -webkit-sticky;
   position: sticky;
   top: 0;
@@ -14,7 +15,6 @@
   width: 100%;
   justify-content: space-between;
   padding: 1.2rem 0;
-  border-top: var(--border);
   align-items: center;
 }
 


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
This PR aims to fix the inconsistent designing of the footer. Currently the header covers the entire width of the screen but the footer doesn't. After these changes the footer will be covering the entire width of the screen similar to the the header.

Fixes: #629 

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
**Before:** 
![Screenshot 2025-04-14 231206](https://github.com/user-attachments/assets/f058b8c0-f62f-420a-ada1-3491fa667e0e)

**After**
![Screenshot 2025-04-14 231311](https://github.com/user-attachments/assets/c90db47a-e6fd-4720-9b69-135faebfd3e0)

## Checklist
- [X] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [X] New and existing unit tests pass locally with my changes
