### PR TITLE
Add Custom Reusable Loading Spinner

### DIFF
--- a/packages/ui/__tests__/components/auth/Signin.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signin.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { AuthContext } from "../../../src/contexts/Contexts";
 import SignIn from "../../../src/components/auth/Signin";
 import { BUTTON_TEXT, SIGNIN } from "../../../src/utils/Constants";
@@ -146,19 +146,16 @@ describe("SignInForm UI and Functionality Tests", () => {
     expect(screen.getByText(errorMsg)).toBeInTheDocument();
   });
 
-  it("disables input fields and submit button when loading", async () => {
-    const authContext = mockAuthContext(false);
+  const delayedResolve = () =>
+    new Promise((resolve) => setTimeout(() => resolve(true), 1000));
+  let authContext;
 
-    const delayedResolve = () => {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(true);
-        }, 1000);
-      });
-    };
-
+  beforeEach(() => {
+    authContext = mockAuthContext(false);
     mockedMakeRequest.mockImplementation(delayedResolve);
+  });
 
+  it("disables input fields and submit button when loading", async () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
@@ -175,6 +172,7 @@ describe("SignInForm UI and Functionality Tests", () => {
 
     fireEvent.change(emailInput, { target: { value: "test@example.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
+
     fireEvent.click(submitButton);
 
     await waitFor(() => {

--- a/packages/ui/__tests__/components/auth/Signin.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signin.test.jsx
@@ -148,9 +148,16 @@ describe("SignInForm UI and Functionality Tests", () => {
 
   it("disables input fields and submit button when loading", async () => {
     const authContext = mockAuthContext(false);
-    mockedMakeRequest.mockImplementation(() => {
-      return new Promise((resolve) => setTimeout(() => resolve(true), 1000));
-    });
+
+    const delayedResolve = () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(true);
+        }, 1000);
+      });
+    };
+
+    mockedMakeRequest.mockImplementation(delayedResolve);
 
     render(
       <BrowserRouter>
@@ -166,13 +173,8 @@ describe("SignInForm UI and Functionality Tests", () => {
       name: BUTTON_TEXT.signIn,
     });
 
-    fireEvent.change(emailInput, {
-      target: { value: "test@example.com" },
-    });
-    fireEvent.change(passwordInput, {
-      target: { value: "password123" },
-    });
-
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    fireEvent.change(passwordInput, { target: { value: "password123" } });
     fireEvent.click(submitButton);
 
     await waitFor(() => {

--- a/packages/ui/__tests__/components/auth/Signin.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signin.test.jsx
@@ -145,4 +145,40 @@ describe("SignInForm UI and Functionality Tests", () => {
 
     expect(screen.getByText(errorMsg)).toBeInTheDocument();
   });
+
+  it("disables input fields and submit button when loading", async () => {
+    const authContext = mockAuthContext(false);
+    mockedMakeRequest.mockImplementation(() => {
+      return new Promise((resolve) => setTimeout(() => resolve(true), 1000));
+    });
+
+    render(
+      <BrowserRouter>
+        <AuthContext.Provider value={authContext}>
+          <SignIn toggleForm={vi.fn()} onClose={vi.fn()} />
+        </AuthContext.Provider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByLabelText("Email");
+    const passwordInput = screen.getByLabelText("Password");
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.signIn,
+    });
+
+    fireEvent.change(emailInput, {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(passwordInput, {
+      target: { value: "password123" },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(emailInput).toBeDisabled();
+      expect(passwordInput).toBeDisabled();
+      expect(submitButton).toBeDisabled();
+    });
+  });
 });

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -253,9 +253,13 @@ describe("SignUpForm UI and Functionality Tests", () => {
   });
 
   it("disables input fields and submit button when loading", async () => {
-    mockedMakeRequest.mockImplementation(() => {
-      return new Promise((resolve) => setTimeout(() => resolve(true), 1000));
-    });
+    const delayedResolve = () => {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(true), 1000);
+      });
+    };
+
+    mockedMakeRequest.mockImplementation(delayedResolve);
 
     render(<SignUpForm toggleForm={vi.fn()} />);
 
@@ -267,18 +271,10 @@ describe("SignUpForm UI and Functionality Tests", () => {
       name: SIGNUP.submitButton,
     });
 
-    fireEvent.change(nameInput, {
-      target: { value: "Test" },
-    });
-    fireEvent.change(emailInput, {
-      target: { value: "test@gmail.com" },
-    });
-    fireEvent.change(passwordInput, {
-      target: { value: "Test@1234" },
-    });
-    fireEvent.change(confirmPasswordInput, {
-      target: { value: "Test@1234" },
-    });
+    fireEvent.change(nameInput, { target: { value: "Test" } });
+    fireEvent.change(emailInput, { target: { value: "test@gmail.com" } });
+    fireEvent.change(passwordInput, { target: { value: "Test@1234" } });
+    fireEvent.change(confirmPasswordInput, { target: { value: "Test@1234" } });
 
     fireEvent.click(submitButton);
 

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -251,4 +251,43 @@ describe("SignUpForm UI and Functionality Tests", () => {
     });
     expect(signUpButton).toBeDisabled();
   });
+
+  it("disables input fields and submit button when loading", async () => {
+    mockedMakeRequest.mockImplementation(() => {
+      return new Promise((resolve) => setTimeout(() => resolve(true), 1000));
+    });
+
+    render(<SignUpForm toggleForm={vi.fn()} />);
+
+    const nameInput = screen.getByLabelText("Name");
+    const emailInput = screen.getByLabelText("Email");
+    const passwordInput = screen.getByLabelText("Password");
+    const confirmPasswordInput = screen.getByLabelText("Confirm Password");
+    const submitButton = screen.getByRole("button", {
+      name: SIGNUP.submitButton,
+    });
+
+    fireEvent.change(nameInput, {
+      target: { value: "Test" },
+    });
+    fireEvent.change(emailInput, {
+      target: { value: "test@gmail.com" },
+    });
+    fireEvent.change(passwordInput, {
+      target: { value: "Test@1234" },
+    });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "Test@1234" },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(nameInput).toBeDisabled();
+      expect(emailInput).toBeDisabled();
+      expect(passwordInput).toBeDisabled();
+      expect(confirmPasswordInput).toBeDisabled();
+      expect(submitButton).toBeDisabled();
+    });
+  });
 });

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import SignUpForm from "../../../src/components/auth/Signup";
 import {
   SIGNUP,
@@ -252,15 +252,14 @@ describe("SignUpForm UI and Functionality Tests", () => {
     expect(signUpButton).toBeDisabled();
   });
 
-  it("disables input fields and submit button when loading", async () => {
-    const delayedResolve = () => {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(true), 1000);
-      });
-    };
+  const delayedResolve = () =>
+    new Promise((resolve) => setTimeout(() => resolve(true), 1000));
 
+  beforeEach(() => {
     mockedMakeRequest.mockImplementation(delayedResolve);
+  });
 
+  it("disables input fields and submit button when loading", async () => {
     render(<SignUpForm toggleForm={vi.fn()} />);
 
     const nameInput = screen.getByLabelText("Name");

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -17,6 +17,7 @@ const SignIn = ({ toggleForm, onClose }) => {
   const [focusedField, setFocusedField] = useState(null);
   const [isFormValid, setIsFormValid] = useState(false);
   const { setIsAuthenticated } = useContext(AuthContext);
+  const [isLoading, setIsLoading] = useState(false);
   const { makeRequest, errorMsg } = useApi({
     method: "post",
     url: `/auth/signin`,
@@ -57,6 +58,7 @@ const SignIn = ({ toggleForm, onClose }) => {
   const handleSubmit = async (submitEvent) => {
     submitEvent.preventDefault();
     setIsSubmit(true);
+    setIsLoading(true);
     const success = await makeRequest();
     if (success) {
       setFormData(SIGNIN.initialValues);
@@ -66,6 +68,7 @@ const SignIn = ({ toggleForm, onClose }) => {
       onClose();
       navigate("/dashboard");
     }
+    setIsLoading(false);
   };
 
   const handleGuestSignIn = async (submitEvent) => {
@@ -100,6 +103,7 @@ const SignIn = ({ toggleForm, onClose }) => {
               onChange={handleChange}
               onFocus={() => setFocusedField(field.name)}
               onBlur={() => setFocusedField(null)}
+              disabled={isLoading}
             />
           ))}
         </div>
@@ -110,6 +114,7 @@ const SignIn = ({ toggleForm, onClose }) => {
           type="submit"
           variant="primary"
           disabled={!isFormValid && isSubmit}
+          isLoading={isLoading}
         >
           {BUTTON_TEXT.signIn}
         </Button>

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -13,6 +13,7 @@ function SignUp({ toggleForm }) {
   const [isSubmit, setIsSubmit] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
   const [focusedField, setFocusedField] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
   const { makeRequest, errorMsg } = useApi({
     url: `/auth/signup`,
     method: "post",
@@ -53,12 +54,14 @@ function SignUp({ toggleForm }) {
     setFormErrors({});
     setIsSubmit(false);
     setFocusedField(null);
+    setIsLoading(true);
 
     const success = await makeRequest();
     if (success) {
       setFormValues(SIGNUP.initialValues);
       setIsSubmit(true);
     }
+    setIsLoading(false);
   };
 
   return (
@@ -85,13 +88,15 @@ function SignUp({ toggleForm }) {
               onChange={handleChange}
               onFocus={() => setFocusedField(field.name)}
               onBlur={() => setFocusedField(null)}
+              disabled={isLoading}
             />
           ))}
         </div>
         <Button
           type="submit"
           variant="primary"
-          disabled={!isFormValid || isSubmit}
+          disabled={!isFormValid || isSubmit || isLoading}
+          isLoading={isLoading}
         >
           {BUTTON_TEXT.signUp}
         </Button>

--- a/packages/ui/src/components/common/button/Button.jsx
+++ b/packages/ui/src/components/common/button/Button.jsx
@@ -10,9 +10,9 @@ const Button = ({
   disabled = false,
   className = "",
   isLoading = false,
-  spinnerSize = 20,
-  spinnerBorder = 4,
-  spinnerColor = "white",
+  spinnerSize,
+  spinnerBorder,
+  spinnerColor,
 }) => {
   const [buttonWidth, setButtonWidth] = useState(null);
   const buttonRef = useRef(null);

--- a/packages/ui/src/components/common/button/Button.jsx
+++ b/packages/ui/src/components/common/button/Button.jsx
@@ -1,5 +1,7 @@
+import { useState, useRef, useEffect } from "react";
 import styles from "./Button.module.css";
 import { PropTypes } from "prop-types";
+import LoadingSpinner from "../loadingspinner/LoadingSpinner";
 
 const Button = ({
   children,
@@ -7,14 +9,58 @@ const Button = ({
   onClick = () => {},
   disabled = false,
   className = "",
+  isLoading = false,
+  spinnerSize = 20,
+  spinnerBorder = 4,
+  spinnerColor = "white",
 }) => {
+  const [buttonWidth, setButtonWidth] = useState(null);
+  const buttonRef = useRef(null);
+
+  const captureButtonWidth = () => {
+    if (buttonRef.current) {
+      setButtonWidth(buttonRef.current.offsetWidth);
+    }
+  };
+
+  useEffect(() => {
+    captureButtonWidth();
+    const handleResize = () => {
+      if (!isLoading) {
+        setButtonWidth(null);
+      }
+      captureButtonWidth();
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [isLoading]);
+
+  const buttonStyle =
+    buttonWidth && isLoading
+      ? { width: `${buttonWidth}px`, minWidth: `${buttonWidth}px` }
+      : {};
+
   return (
     <button
+      ref={buttonRef}
       onClick={onClick}
-      disabled={disabled}
+      disabled={disabled || isLoading}
       className={`${styles[variant]} ${className} ${styles.button}`}
+      style={buttonStyle}
     >
-      {children}
+      {isLoading ? (
+        <LoadingSpinner
+          size={spinnerSize}
+          border={spinnerBorder}
+          color={spinnerColor}
+        />
+      ) : (
+        children
+      )}
     </button>
   );
 };
@@ -25,6 +71,10 @@ Button.propTypes = {
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   className: PropTypes.string,
+  isLoading: PropTypes.bool,
+  spinnerSize: PropTypes.number,
+  spinnerBorder: PropTypes.number,
+  spinnerColor: PropTypes.string,
 };
 
 export default Button;

--- a/packages/ui/src/components/common/button/Button.module.css
+++ b/packages/ui/src/components/common/button/Button.module.css
@@ -6,6 +6,9 @@
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.3s ease-in-out;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .button:disabled {

--- a/packages/ui/src/components/common/loadingspinner/LoadingSpinner.jsx
+++ b/packages/ui/src/components/common/loadingspinner/LoadingSpinner.jsx
@@ -1,0 +1,21 @@
+import styles from "./LoadingSpinner.module.css";
+import { PropTypes } from "prop-types";
+
+const LoadingSpinner = ({ size = 20, border = 4, color = "white" }) => {
+  const spinnerStyle = {
+    width: `${size}px`,
+    height: `${size}px`,
+    borderWidth: `${border}px`,
+    borderColor: `${color} ${color} transparent ${color}`,
+  };
+
+  return <div className={styles.spinner} style={spinnerStyle}></div>;
+};
+
+LoadingSpinner.propTypes = {
+  size: PropTypes.number,
+  color: PropTypes.string,
+  border: PropTypes.number,
+};
+
+export default LoadingSpinner;

--- a/packages/ui/src/components/common/loadingspinner/LoadingSpinner.module.css
+++ b/packages/ui/src/components/common/loadingspinner/LoadingSpinner.module.css
@@ -1,0 +1,14 @@
+.spinner {
+  border-style: solid;
+  border-radius: 50%;
+  animation: spin 1.2s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -17,6 +17,7 @@ function Dashboard() {
   const { userData, loading, fetchUserData } = useContext(UserContext);
   const { isAuthenticated, logout } = useContext(AuthContext);
   const [isGuest, setIsGuest] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const apiKeyTableData = useMemo(() => {
     let data = [];
     if (userData) {
@@ -43,7 +44,9 @@ function Dashboard() {
   }
 
   const handleLogout = () => {
+    setIsLoading(true);
     logout();
+    setIsLoading(false);
   };
 
   return (
@@ -105,6 +108,7 @@ function Dashboard() {
             variant="danger"
             className={styles["logout-btn"]}
             onClick={handleLogout}
+            isLoading={isLoading}
           >
             {BUTTON_TEXT.signOut}
           </Button>


### PR DESCRIPTION
## Description
Closes #651  
- Implemented a reusable custom **loading spinner** to provide clear visual feedback during processing.
- We can modify the size, border and colour of the Spinner using props.
- Integrated the spinner into the **Sign In**, **Sign Up**, and **Sign Out** flows to enhance user experience and indicate ongoing operations.

### How to Use
**To use the spinner in any part of the application**:
 1. **With the Button component**
  - Just pass the `isLoading` prop to show the spinner.
  - Can optionally adjust the size, border or colour

```js
<Button
  variant="primary"
  isLoading={true}         // Should be controlled by component state
  spinnerSize={24}         // Optional: size in pixels
  spinnerBorder={4}        // Optional: border width in pixels
  spinnerColor="white"     // Optional: CSS color value
>
  Submit
</Button>
```

2. **Directly as a standalone spinner**

```js
import LoadingSpinner from "../common/loadingspinner/LoadingSpinner";
<LoadingSpinner size={30} border={5} color="gray" />
 ```

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
- The following video shows the loading spinner in action: during validation errors, on successful form submission, and while maintaining consistent button width even on window resize.

https://github.com/user-attachments/assets/41bb0bcd-8e53-402e-aa75-6300c86054bd

- All test cases have passed
![Screenshot From 2025-05-14 23-11-53](https://github.com/user-attachments/assets/b2f57734-b9e8-4163-9db0-1cbf76feb0bf)

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
