### PR TITLE
Improve footer logo and documentation button navigation

### DIFF
--- a/packages/ui/__tests__/components/Footer.test.jsx
+++ b/packages/ui/__tests__/components/Footer.test.jsx
@@ -28,8 +28,8 @@ describe("Footer Component", () => {
         <Footer />
       </BrowserRouter>
     );
-    const logoLink = screen.getByTestId("footer-logo-link");
-    fireEvent.click(logoLink);
+    const logoButton = screen.getByTestId("footer-logo-button");
+    fireEvent.click(logoButton);
     expect(window.location.pathname).toBe("/");
   });
 

--- a/packages/ui/__tests__/components/Footer.test.jsx
+++ b/packages/ui/__tests__/components/Footer.test.jsx
@@ -22,6 +22,17 @@ describe("Footer Component", () => {
     expect(logoText).toBeInTheDocument();
   });
 
+  it("clicking OpenLogo navigates to the Home page", () => {
+    render(
+      <BrowserRouter>
+        <Footer />
+      </BrowserRouter>
+    );
+    const logoLink = screen.getByTestId("footer-logo-link");
+    fireEvent.click(logoLink);
+    expect(window.location.pathname).toBe("/");
+  });
+
   it("Render all footer navigations", () => {
     render(
       <BrowserRouter>

--- a/packages/ui/__tests__/components/HeroSection.test.jsx
+++ b/packages/ui/__tests__/components/HeroSection.test.jsx
@@ -2,12 +2,17 @@ import { expect, describe, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import HeroSection from "../../src/components/hero/HeroSection";
 import { BUTTON_TEXT, HERO_SECTION } from "../../src/utils/Constants";
+import { BrowserRouter } from "react-router-dom";
 
 const onPrimaryButtonClick = vi.fn();
 
 describe("HeroSection Component", () => {
   it("Tagline and summary visible", () => {
-    render(<HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />);
+    render(
+      <BrowserRouter>
+        <HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />
+      </BrowserRouter>
+    );
 
     const tagline = screen.getByText(HERO_SECTION.tagLine);
     const summary = screen.getByText(HERO_SECTION.summary);
@@ -16,7 +21,11 @@ describe("HeroSection Component", () => {
   });
 
   it("Buttons visible", () => {
-    render(<HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />);
+    render(
+      <BrowserRouter>
+        <HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />
+      </BrowserRouter>
+    );
 
     const documentationButton = screen.getByText(BUTTON_TEXT.documentation);
     const getStartedButton = screen.getByText(BUTTON_TEXT.getStarted);
@@ -26,8 +35,25 @@ describe("HeroSection Component", () => {
     expect(getStartedButton.tagName).toBe("BUTTON");
   });
 
+  it("clicking the Documentation button navigates to the Document Page", () => {
+    render(
+      <BrowserRouter>
+        <HeroSection />
+      </BrowserRouter>
+    );
+    const DocumentationButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.documentation,
+    });
+    fireEvent.click(DocumentationButton);
+    expect(window.location.pathname).toBe("/docs");
+  });
+
   it("Illustration visible", () => {
-    render(<HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />);
+    render(
+      <BrowserRouter>
+        <HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />
+      </BrowserRouter>
+    );
 
     const logoImage = screen.getByAltText(HERO_SECTION.illustractionSrcAlt);
     expect(logoImage).toBeInTheDocument();
@@ -35,7 +61,11 @@ describe("HeroSection Component", () => {
   });
 
   it("Auth modal visibility before and after the click", () => {
-    render(<HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />);
+    render(
+      <BrowserRouter>
+        <HeroSection onPrimaryButtonClick={onPrimaryButtonClick} />
+      </BrowserRouter>
+    );
 
     const anyDialog = screen.queryByText(BUTTON_TEXT.cross);
     expect(anyDialog).not.toBeInTheDocument();
@@ -46,10 +76,12 @@ describe("HeroSection Component", () => {
 
   it("shows Go To Dashboard button when authenticated", () => {
     render(
-      <HeroSection
-        onPrimaryButtonClick={onPrimaryButtonClick}
-        isAuthenticated={true}
-      />
+      <BrowserRouter>
+        <HeroSection
+          onPrimaryButtonClick={onPrimaryButtonClick}
+          isAuthenticated={true}
+        />
+      </BrowserRouter>
     );
 
     const gotoDashboardButton = screen.getByRole("button", {

--- a/packages/ui/src/components/footer/Footer.jsx
+++ b/packages/ui/src/components/footer/Footer.jsx
@@ -9,14 +9,20 @@ function Footer() {
   return (
     <div data-testid="footer" className={`container ${styles.block}`}>
       <footer className={styles["footer-container"]}>
-        <div className={styles["footer-logo"]}>
-          <img
-            alt={BRANDING.imageSrc}
-            src={BRANDING.imageSrc}
-            width={30}
-            height={30}
-          />
-          <h4>{BRANDING.brandName}</h4>
+        <div>
+          <Link
+            to="/"
+            className={styles["footer-logo"]}
+            data-testid="footer-logo-link"
+          >
+            <img
+              alt={BRANDING.imageSrc}
+              src={BRANDING.imageSrc}
+              width={30}
+              height={30}
+            />
+            <h4>{BRANDING.brandName}</h4>
+          </Link>
         </div>
         <div className={styles["footer-items"]}>
           {FOOTER_ITEMS.map((item) => (

--- a/packages/ui/src/components/footer/Footer.jsx
+++ b/packages/ui/src/components/footer/Footer.jsx
@@ -10,10 +10,10 @@ function Footer() {
     <div data-testid="footer" className={`container ${styles.block}`}>
       <footer className={styles["footer-container"]}>
         <div>
-          <Link
-            to="/"
+          <button
             className={styles["footer-logo"]}
-            data-testid="footer-logo-link"
+            data-testid="footer-logo-button"
+            onClick={() => navigate("/")}
           >
             <img
               alt={BRANDING.imageSrc}
@@ -22,7 +22,7 @@ function Footer() {
               height={30}
             />
             <h4>{BRANDING.brandName}</h4>
-          </Link>
+          </button>
         </div>
         <div className={styles["footer-items"]}>
           {FOOTER_ITEMS.map((item) => (

--- a/packages/ui/src/components/footer/Footer.module.css
+++ b/packages/ui/src/components/footer/Footer.module.css
@@ -24,6 +24,7 @@
   gap: 0.5rem;
   align-items: center;
   font-size: 1.85rem;
+  text-decoration: none;
 }
 
 .footer-items {

--- a/packages/ui/src/components/footer/Footer.module.css
+++ b/packages/ui/src/components/footer/Footer.module.css
@@ -24,7 +24,10 @@
   gap: 0.5rem;
   align-items: center;
   font-size: 1.85rem;
-  text-decoration: none;
+  cursor: pointer;
+  border: none;
+  background-color: var(--white);
+  user-select: none;
 }
 
 .footer-items {

--- a/packages/ui/src/components/hero/HeroSection.jsx
+++ b/packages/ui/src/components/hero/HeroSection.jsx
@@ -2,8 +2,10 @@ import PropTypes from "prop-types";
 import Button from "../common/button/Button";
 import { HERO_SECTION, BUTTON_TEXT } from "../../utils/Constants";
 import styles from "./HeroSection.module.css";
+import { useNavigate } from "react-router-dom";
 
 const HeroSection = ({ onPrimaryButtonClick, isAuthenticated }) => {
+  const navigate = useNavigate();
   return (
     <div className={styles["hero-section"]}>
       <div className={styles["left-section"]}>
@@ -16,6 +18,7 @@ const HeroSection = ({ onPrimaryButtonClick, isAuthenticated }) => {
             type="button"
             variant="secondary"
             className={styles["button-width"]}
+            onClick={() => navigate("/docs")}
           >
             {BUTTON_TEXT.documentation}
           </Button>


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
closes: #665

- Clicking the footer logo navigates to the Home page ("/")
- Clicking the Documentation button in HeroSection navigates to the Document page ("/docs")
- Added necessary test cases

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

https://github.com/user-attachments/assets/7f9a6d1f-e0d2-456b-b23b-0714db9b7adc



## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
