### PR TITLE
Fix: Issue #669 - Prevent message input from growing beyond the viewport on vertical resize in the Contact Us form

### DIFF
--- a/packages/ui/src/components/contact/ContactForm.module.css
+++ b/packages/ui/src/components/contact/ContactForm.module.css
@@ -13,6 +13,8 @@
 .text-area {
   width: 100%;
   height: 100px;
+  min-height: 100px;
+  max-height: 250px;
   padding: 12px;
   font-size: 1rem;
   font-family: inherit;


### PR DESCRIPTION
## Summary
Fixes Issue 669 where the message input field in the Contact Us form grows beyond the viewport when the browser window is resized vertically.
closes #669 

## Description

1. Updated the CSS for the message input field to prevent it from growing beyond the viewport size.
2. Ensured that the form remains fully responsive and functional across different screen sizes and resolutions.

## What type of PR is this?
- [x] 🐛 Bug Fix

## Previous state
![Screenshot 2025-05-20 222445](https://github.com/user-attachments/assets/68d1aa8b-d69c-4f67-b7b6-2e1b0b791540)

## Current state
![Screenshot 2025-05-20 222532](https://github.com/user-attachments/assets/eebda8fc-1010-4e5b-af0d-6d7412244d81)

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes