### PR TITLE
Fix Issue #668 - Preserve Form Data on API Error in Sign-Up Process

### DIFF
--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -7,6 +7,7 @@ import {
 } from "../../../src/utils/Constants";
 import { BrowserRouter } from "react-router-dom";
 import { AuthContext } from "../../../src/contexts/Contexts";
+import { ToastProvider } from "../../../src/contexts/ToastContext";
 
 const mockedMakeRequest = vi.fn();
 vi.mock("../../../src/hooks/useApi", () => ({
@@ -26,7 +27,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} onClose={vi.fn()} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -47,7 +50,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={toggleFormMock} />
+          <ToastProvider>
+            <SignUpForm toggleForm={toggleFormMock} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -62,7 +67,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -77,7 +84,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -112,70 +121,15 @@ describe("SignUpForm UI and Functionality Tests", () => {
     });
   });
 
-  it("resets form correctly after successful submission", async () => {
-    const authContext = mockAuthContext(true);
-    mockedMakeRequest.mockResolvedValue(true);
-    render(
-      <BrowserRouter>
-        <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
-        </AuthContext.Provider>
-      </BrowserRouter>
-    );
-    const nameInput = screen.getByLabelText("Name");
-    const emailInput = screen.getByLabelText("Email");
-    const passwordInput = screen.getByLabelText("Password");
-    const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const signUpButton = screen.getByRole("button", {
-      name: SIGNUP.submitButton,
-    });
-
-    expect(signUpButton).toBeDisabled();
-
-    fireEvent.change(nameInput, { target: { value: "John Doe" } });
-    fireEvent.change(emailInput, { target: { value: "xyz@example.com" } });
-    fireEvent.change(passwordInput, { target: { value: "Password@123" } });
-    fireEvent.change(confirmPasswordInput, {
-      target: { value: "Password@123" },
-    });
-
-    fireEvent.click(signUpButton);
-
-    await waitFor(() => {
-      expect(nameInput.value).toBe(SIGNUP.initialValues.name);
-      expect(emailInput.value).toBe(SIGNUP.initialValues.email);
-      expect(passwordInput.value).toBe(SIGNUP.initialValues.password);
-      expect(confirmPasswordInput.value).toBe(
-        SIGNUP.initialValues.confirmPassword
-      );
-    });
-
-    const nameError = screen.queryByText("Name is required!");
-    expect(nameError).not.toBeInTheDocument();
-    const emailError = screen.queryByText("Email is required");
-    expect(emailError).not.toBeInTheDocument();
-    const passwordError = screen.queryByText(
-      PASSWORD_VALIDATION_MESSAGES.required
-    );
-    expect(passwordError).not.toBeInTheDocument();
-    const confirmPasswordError = screen.queryByText(
-      "Confirm password is required!"
-    );
-    expect(confirmPasswordError).not.toBeInTheDocument();
-
-    expect(signUpButton).toBeDisabled();
-    expect(document.activeElement).toBe(document.body);
-  });
-
   it("does not reset form after failed submission", async () => {
     mockedMakeRequest.mockResolvedValue(false);
-
     const authContext = mockAuthContext(false);
-
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -212,12 +166,16 @@ describe("SignUpForm UI and Functionality Tests", () => {
   });
 
   it("connectivity test passed", async () => {
+    const authContext = mockAuthContext(true);
+    const onCloseMock = vi.fn();
     mockedMakeRequest.mockResolvedValue(true);
-    const authContext = mockAuthContext(false);
+
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} onClose={onCloseMock} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -241,19 +199,11 @@ describe("SignUpForm UI and Functionality Tests", () => {
     fireEvent.click(signUpButton);
 
     await waitFor(() => {
-      expect(nameInput.value).toBe(SIGNUP.initialValues.name);
-      expect(emailInput.value).toBe(SIGNUP.initialValues.email);
-      expect(passwordInput.value).toBe(SIGNUP.initialValues.password);
-      expect(confirmPasswordInput.value).toBe(
-        SIGNUP.initialValues.confirmPassword
-      );
-    });
-
-    await waitFor(() => {
       expect(mockedMakeRequest).toHaveBeenCalled();
+      expect(onCloseMock).toHaveBeenCalled();
     });
-    expect(signUpButton).toBeDisabled();
   });
+
 
   it("connectivity test failed", async () => {
     mockedMakeRequest.mockResolvedValue(false);
@@ -261,7 +211,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
-          <SignUpForm toggleForm={vi.fn()} />
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} />
+          </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -305,7 +257,16 @@ describe("SignUpForm UI and Functionality Tests", () => {
   });
 
   it("disables input fields and submit button when loading", async () => {
-    render(<SignUpForm toggleForm={vi.fn()} />);
+    const authContext = mockAuthContext(false);
+    render(
+      <BrowserRouter>
+        <AuthContext.Provider value={authContext}>
+          <ToastProvider>
+            <SignUpForm toggleForm={vi.fn()} onClose={vi.fn()} />
+          </ToastProvider>
+        </AuthContext.Provider>
+      </BrowserRouter>
+    );
 
     const nameInput = screen.getByLabelText("Name");
     const emailInput = screen.getByLabelText("Email");

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -112,8 +112,9 @@ describe("SignUpForm UI and Functionality Tests", () => {
     });
   });
 
-  it("resets form correctly after submission", async () => {
-    const authContext = mockAuthContext(false);
+  it("resets form correctly after successful submission", async () => {
+    const authContext = mockAuthContext(true);
+    mockedMakeRequest.mockResolvedValue(true);
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
@@ -165,6 +166,51 @@ describe("SignUpForm UI and Functionality Tests", () => {
     expect(signUpButton).toBeDisabled();
     expect(document.activeElement).toBe(document.body);
   });
+
+  it("does not reset form after failed submission", async () => {
+    mockedMakeRequest.mockResolvedValue(false);
+
+    const authContext = mockAuthContext(false);
+
+    render(
+      <BrowserRouter>
+        <AuthContext.Provider value={authContext}>
+          <SignUpForm toggleForm={vi.fn()} />
+        </AuthContext.Provider>
+      </BrowserRouter>
+    );
+
+    const nameInput = screen.getByLabelText("Name");
+    const emailInput = screen.getByLabelText("Email");
+    const passwordInput = screen.getByLabelText("Password");
+    const confirmPasswordInput = screen.getByLabelText("Confirm Password");
+    const signUpButton = screen.getByRole("button", {
+      name: SIGNUP.submitButton,
+    });
+
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "testuser@example.com" } });
+    fireEvent.change(passwordInput, { target: { value: "Password@123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "Password@123" },
+    });
+
+    expect(signUpButton).toBeEnabled();
+
+    fireEvent.click(signUpButton);
+
+    await waitFor(() => {
+      expect(mockedMakeRequest).toHaveBeenCalled();
+    });
+
+    expect(nameInput.value).toBe("Test User");
+    expect(emailInput.value).toBe("testuser@example.com");
+    expect(passwordInput.value).toBe("Password@123");
+    expect(confirmPasswordInput.value).toBe("Password@123");
+
+    expect(signUpButton).toBeEnabled();
+  });
+
   it("connectivity test passed", async () => {
     mockedMakeRequest.mockResolvedValue(true);
     const authContext = mockAuthContext(false);
@@ -208,6 +254,7 @@ describe("SignUpForm UI and Functionality Tests", () => {
     });
     expect(signUpButton).toBeDisabled();
   });
+
   it("connectivity test failed", async () => {
     mockedMakeRequest.mockResolvedValue(false);
     const authContext = mockAuthContext(false);
@@ -238,18 +285,16 @@ describe("SignUpForm UI and Functionality Tests", () => {
     fireEvent.click(signUpButton);
 
     await waitFor(() => {
-      expect(nameInput.value).toBe(SIGNUP.initialValues.name);
-      expect(emailInput.value).toBe(SIGNUP.initialValues.email);
-      expect(passwordInput.value).toBe(SIGNUP.initialValues.password);
-      expect(confirmPasswordInput.value).toBe(
-        SIGNUP.initialValues.confirmPassword
-      );
+      expect(nameInput.value).toBe("Test");
+      expect(emailInput.value).toBe("test@gmail.com");
+      expect(passwordInput.value).toBe("Test@1234");
+      expect(confirmPasswordInput.value).toBe("Test@1234");
     });
 
     await waitFor(() => {
       expect(mockedMakeRequest).toHaveBeenCalled();
     });
-    expect(signUpButton).toBeDisabled();
+    expect(signUpButton).not.toBeDisabled();
   });
 
   const delayedResolve = () =>

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -6,8 +6,10 @@ import { SIGNUP, BUTTON_TEXT } from "../../utils/Constants";
 import styles from "./SignForm.module.css";
 import { validate } from "../../utils/Helpers";
 import { useApi } from "../../hooks/useApi";
+import { useToast } from "../../hooks/useToast.js";
 
-function SignUp({ toggleForm }) {
+function SignUp({ toggleForm, onClose }) {
+  const toast = useToast();
   const [formValues, setFormValues] = useState(SIGNUP.initialValues);
   const [formErrors, setFormErrors] = useState({});
   const [isSubmit, setIsSubmit] = useState(false);
@@ -59,6 +61,10 @@ function SignUp({ toggleForm }) {
     if (success) {
       setFormValues(SIGNUP.initialValues);
       setIsSubmit(true);
+      setFocusedField(null);
+      toggleForm();
+      onClose();
+      toast.success("Sign up successfully");
     }
     setIsLoading(false);
   };
@@ -110,6 +116,7 @@ function SignUp({ toggleForm }) {
 
 SignUp.propTypes = {
   toggleForm: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
 };
 
 export default SignUp;

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -50,7 +50,6 @@ function SignUp({ toggleForm }) {
 
   const handleSubmit = async (submitEvent) => {
     submitEvent.preventDefault();
-    setFormValues(SIGNUP.initialValues);
     setFormErrors({});
     setIsSubmit(false);
     setFocusedField(null);


### PR DESCRIPTION
## Summary
Fix Issue 668 - Preserve Form Data on API Error in Sign-Up Process
closes #668 

## Description
Only reinitialize the form once API call response is successful.  

## What type of PR is this? (Check all applicable)
- [x] 🐛 Bug Fix

## Previous State
https://github.com/user-attachments/assets/ffaeca9d-2e5f-4dcf-ac23-018c46b84213

## Current State
https://github.com/user-attachments/assets/f0657130-9d92-496b-aa21-0c166e3d9e52



## Checklist
- [ ] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
