### PR TITLE
feat: implemented delete user account

### DIFF
--- a/packages/app/__tests__/controllers/users/deleteaccount.js
+++ b/packages/app/__tests__/controllers/users/deleteaccount.js
@@ -53,5 +53,9 @@ describe("Delete User Account", () => {
       .send(mockInput);
 
     expect(response.status).toBe(200);
+
+    const setCookieHeader = response.headers["set-cookie"];
+    expect(setCookieHeader).toBeDefined();
+    expect(setCookieHeader[0]).toMatch(/jwt=;/);
   });
 });

--- a/packages/app/controllers/users.js
+++ b/packages/app/controllers/users.js
@@ -117,6 +117,7 @@ async function deleteUserAccountController(req, res, next) {
     const userService = new UserService();
     const { userId } = req.userData;
     await userService.deleteUserAccount(userId);
+    res.clearCookie("jwt");
     res.status(200).json({
       status: 200,
     });

--- a/packages/ui/__tests__/components/dashboard/settings/DeleteAccount.test.jsx
+++ b/packages/ui/__tests__/components/dashboard/settings/DeleteAccount.test.jsx
@@ -7,6 +7,7 @@ import {
 } from "../../../../src/utils/Constants";
 import { UserContext } from "../../../../src/contexts/Contexts";
 import DeleteAccountConfirmationModal from "../../../../src/components/dashboard/settingpage/DeleteAccountConfirmationModal";
+import { ToastProvider } from "../../../../src/contexts/ToastContext.jsx";
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => ({
@@ -33,7 +34,12 @@ describe("DeleteAccountConfirmationModal Component", () => {
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -47,25 +53,34 @@ describe("DeleteAccountConfirmationModal Component", () => {
   });
 
   it("does not render when isOpen is false", () => {
-    const { container } = render(
+    render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal
-            isOpen={false}
-            onClose={mockOnClose}
-          />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={false}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
 
-    expect(container).toBeEmptyDOMElement();
+    expect(
+      screen.queryByTestId("delete-account-modal")
+    ).not.toBeInTheDocument();
   });
 
   it("handles email input correctly", () => {
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -79,7 +94,12 @@ describe("DeleteAccountConfirmationModal Component", () => {
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -97,7 +117,12 @@ describe("DeleteAccountConfirmationModal Component", () => {
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -115,7 +140,12 @@ describe("DeleteAccountConfirmationModal Component", () => {
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -129,10 +159,21 @@ describe("DeleteAccountConfirmationModal Component", () => {
   });
 
   it("handles successful account deletion", async () => {
+    mockMakeRequest.mockResolvedValue(true);
+
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { href: vi.fn() };
+
     render(
       <BrowserRouter>
         <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
-          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+          <ToastProvider>
+            <DeleteAccountConfirmationModal
+              isOpen={true}
+              onClose={mockOnClose}
+            />
+          </ToastProvider>
         </UserContext.Provider>
       </BrowserRouter>
     );
@@ -147,8 +188,10 @@ describe("DeleteAccountConfirmationModal Component", () => {
 
     await waitFor(() => {
       expect(mockMakeRequest).toHaveBeenCalled();
-      expect(window.location.href).not.toContain(import.meta.env.VITE_APP_URL);
-      expect(screen.getByTestId("error-msg")).toBeInTheDocument();
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(window.location.href).toBe("/");
     });
+
+    window.location = originalLocation;
   });
 });

--- a/packages/ui/__tests__/components/dashboard/settings/DeleteAccount.test.jsx
+++ b/packages/ui/__tests__/components/dashboard/settings/DeleteAccount.test.jsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import {
+  DELETE_ACCOUNT_CONFIRMATION_MODAL,
+  MOCK_USER_DATA,
+} from "../../../../src/utils/Constants";
+import { UserContext } from "../../../../src/contexts/Contexts";
+import DeleteAccountConfirmationModal from "../../../../src/components/dashboard/settingpage/DeleteAccountConfirmationModal";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => ({
+  ...(await vi.importActual("react-router-dom")),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockMakeRequest = vi.fn();
+vi.mock("../../../../src/hooks/useApi.js", () => ({
+  useApi: () => ({
+    makeRequest: mockMakeRequest,
+    errorMsg: "",
+  }),
+}));
+
+describe("DeleteAccountConfirmationModal Component", () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the modal with correct title and description", () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    expect(
+      screen.getByText(DELETE_ACCOUNT_CONFIRMATION_MODAL.title)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(DELETE_ACCOUNT_CONFIRMATION_MODAL.subText)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when isOpen is false", () => {
+    const { container } = render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal
+            isOpen={false}
+            onClose={mockOnClose}
+          />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("handles email input correctly", () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByLabelText("Email");
+    fireEvent.change(emailInput, { target: { value: MOCK_USER_DATA.email } });
+    expect(emailInput.value).toBe(MOCK_USER_DATA.email);
+  });
+
+  it("disables delete button when email doesn't match user email", () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByLabelText("Email");
+    const deleteButton = screen.getByRole("button", {
+      name: DELETE_ACCOUNT_CONFIRMATION_MODAL.primaryButtonText,
+    });
+
+    fireEvent.change(emailInput, { target: { value: "wrong@example.com" } });
+    expect(deleteButton).toBeDisabled();
+  });
+
+  it("enables delete button when email matches user email", () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByLabelText("Email");
+    const deleteButton = screen.getByRole("button", {
+      name: DELETE_ACCOUNT_CONFIRMATION_MODAL.primaryButtonText,
+    });
+
+    fireEvent.change(emailInput, { target: { value: MOCK_USER_DATA.email } });
+    expect(deleteButton).not.toBeDisabled();
+  });
+
+  it("calls onClose when cancel button is clicked", () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    const cancelButton = screen.getByRole("button", {
+      name: DELETE_ACCOUNT_CONFIRMATION_MODAL.secondaryButtonText,
+    });
+
+    fireEvent.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("handles successful account deletion", async () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ userData: MOCK_USER_DATA }}>
+          <DeleteAccountConfirmationModal isOpen={true} onClose={mockOnClose} />
+        </UserContext.Provider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByLabelText("Email");
+    const deleteButton = screen.getByRole("button", {
+      name: DELETE_ACCOUNT_CONFIRMATION_MODAL.primaryButtonText,
+    });
+
+    fireEvent.change(emailInput, { target: { value: MOCK_USER_DATA.email } });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockMakeRequest).toHaveBeenCalled();
+      expect(window.location.href).not.toContain(import.meta.env.VITE_APP_URL);
+      expect(screen.getByTestId("error-msg")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.jsx
@@ -7,8 +7,11 @@ import { useContext, useState } from "react";
 import { useApi } from "../../../hooks/useApi";
 import { UserContext } from "../../../contexts/Contexts";
 import { DELETE_ACCOUNT_CONFIRMATION_MODAL } from "../../../utils/Constants";
+import { useToast } from "../../../hooks/useToast.js";
 
 function DeleteAccountConfirmationModal({ isOpen, onClose }) {
+  const toast = useToast();
+
   const [email, setEmail] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
   const { userData } = useContext(UserContext);
@@ -31,7 +34,11 @@ function DeleteAccountConfirmationModal({ isOpen, onClose }) {
       const success = await makeRequest();
       if (success) {
         setEmail("");
-        window.location.href = "/";
+        onClose();
+        toast.success("Account deleted successfully");
+        setTimeout(() => {
+          window.location.href = "/";
+        }, 500);
       }
     } finally {
       setIsDeleting(false);
@@ -39,7 +46,7 @@ function DeleteAccountConfirmationModal({ isOpen, onClose }) {
   };
 
   return (
-    <Modal onClose={onClose} isOpen={isOpen}>
+    <Modal data-testid="delete-account-modal" onClose={onClose} isOpen={isOpen}>
       <div>
         <div className={`"error-container" ${errorMsg ? "has-error" : ""}`}>
           <p data-testid="error-msg" className="input-error">

--- a/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.jsx
@@ -1,0 +1,88 @@
+import Button from "../../common/button/Button";
+import Modal from "../../common/modal/Modal";
+import PropTypes from "prop-types";
+import styles from "./DeleteAccountConfirmationModal.module.css";
+import CustomInput from "../../common/input/CustomInput";
+import { useContext, useState } from "react";
+import { useApi } from "../../../hooks/useApi";
+import { UserContext } from "../../../contexts/Contexts";
+import { DELETE_ACCOUNT_CONFIRMATION_MODAL } from "../../../utils/Constants";
+
+function DeleteAccountConfirmationModal({ isOpen, onClose }) {
+  const [email, setEmail] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { userData } = useContext(UserContext);
+
+  const { makeRequest, errorMsg } = useApi({
+    method: "DELETE",
+    url: "/users/me",
+    data: {
+      userData,
+    },
+  });
+
+  const handleChange = (e) => {
+    setEmail(e.target.value);
+  };
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+    try {
+      const success = await makeRequest();
+      if (success) {
+        setEmail("");
+        window.location.href = "/";
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Modal onClose={onClose} isOpen={isOpen}>
+      <div>
+        <div className={`"error-container" ${errorMsg ? "has-error" : ""}`}>
+          <p data-testid="error-msg" className="input-error">
+            {errorMsg}
+          </p>
+        </div>
+        <div>
+          <h2 className={styles["modal-title"]}>
+            {DELETE_ACCOUNT_CONFIRMATION_MODAL.title}
+          </h2>
+          <p className={styles["modal-description"]}>
+            {DELETE_ACCOUNT_CONFIRMATION_MODAL.subText}
+          </p>
+          <CustomInput
+            type="email"
+            name="email"
+            label="Email"
+            value={email}
+            onChange={handleChange}
+          />
+        </div>
+        <div className={styles["modal-button-wrapper"]}>
+          <Button type="button" variant="secondary" onClick={onClose}>
+            {DELETE_ACCOUNT_CONFIRMATION_MODAL.secondaryButtonText}
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            isLoading={isDeleting}
+            disabled={isDeleting || !email || userData.email !== email}
+            onClick={handleDeleteAccount}
+          >
+            {DELETE_ACCOUNT_CONFIRMATION_MODAL.primaryButtonText}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+DeleteAccountConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default DeleteAccountConfirmationModal;

--- a/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.module.css
+++ b/packages/ui/src/components/dashboard/settingpage/DeleteAccountConfirmationModal.module.css
@@ -1,0 +1,22 @@
+.modal-title {
+  text-align: center;
+  font-size: 1.8rem;
+  color: var(--black);
+  margin-bottom: 1rem;
+}
+
+.modal-description {
+  font-size: 1rem;
+  color: var(--description);
+  font-weight: 500;
+  text-align: center;
+  margin: 10px 0;
+}
+
+.modal-button-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}

--- a/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
@@ -2,8 +2,27 @@ import styles from "./SettingCard.module.css";
 import Button from "../../common/button/Button";
 import { SETTING } from "../../../utils/Constants";
 import PropTypes from "prop-types";
+import { useState } from "react";
+import DeleteAccountConfirmationModal from "./DeleteAccountConfirmationModal";
 
 function SettingCard({ isGuest }) {
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] =
+    useState(false);
+
+  const handleDeleteConfirmation = () => {
+    setShowDeleteConfirmationModal(true);
+  };
+
+  const handleActionItem = (action) => {
+    switch (action) {
+      case "delete":
+        handleDeleteConfirmation();
+        break;
+      default:
+        console.log("Action not recognized");
+    }
+  };
+
   return (
     <>
       {SETTING.map((setting, index) => (
@@ -18,11 +37,18 @@ function SettingCard({ isGuest }) {
             }
             className={styles["action-button"]}
             disabled={isGuest}
+            onClick={() => handleActionItem(setting.action)}
           >
             {setting.buttontitle}
           </Button>
         </div>
       ))}
+      {showDeleteConfirmationModal && (
+        <DeleteAccountConfirmationModal
+          isOpen={showDeleteConfirmationModal}
+          onClose={() => setShowDeleteConfirmationModal(false)}
+        />
+      )}
     </>
   );
 }

--- a/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
+++ b/packages/ui/src/components/dashboard/settingpage/SettingCard.jsx
@@ -14,12 +14,10 @@ function SettingCard({ isGuest }) {
   };
 
   const handleActionItem = (action) => {
-    switch (action) {
-      case "delete":
-        handleDeleteConfirmation();
-        break;
-      default:
-        console.log("Action not recognized");
+    if (action === "delete") {
+      handleDeleteConfirmation();
+    } else {
+      console.log("Action not recognized");
     }
   };
 

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -348,12 +348,14 @@ export const SETTING = [
     title: "Download account data",
     subtitle: "Download your account data and move to other device with ease.",
     buttontitle: "Download",
+    action: "download",
   },
   {
     title: "Delete account",
     subtitle:
       "This will permanently delete your account and all associated data.",
     buttontitle: "Delete Account",
+    action: "delete",
   },
 ];
 
@@ -626,6 +628,7 @@ export const DASHBOARD_CARDS_TITLE = [
   "Setting",
 ];
 export const MOCK_USER_DATA = {
+  userId: "68239354add509808d8ee401",
   name: "John Doe",
   email: "john@example.com",
   role: "USER",
@@ -654,4 +657,12 @@ export const NOT_FOUND_PAGE = {
 export const VERIFICATION = {
   title: "Verifying",
   message: "Please wait, while we verify your email.",
+};
+
+export const DELETE_ACCOUNT_CONFIRMATION_MODAL = {
+  title: "Confirm Deletion",
+  subText:
+    "Are you sure you want to delete your account? This action cannot be undone.",
+  primaryButtonText: "Delete",
+  secondaryButtonText: "Cancel",
 };


### PR DESCRIPTION
## Description
Fixes #671

Frontend:

- Implemented Delete Account confirmation modal with:
  - Email confirmation input
  - Validation to enable Delete only when email matches
  - Cancel & Delete buttons with appropriate behavior
- On successful deletion, redirects to `/`

Backend:
- Updated the delete account controller to clear the `jwt` cookie after successful deletion using `res.clearCookie("jwt")`

## What type of PR is this? (Check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)

Demo:

Note: The font size of modal heading is taken from `SignIn` modal itself.

https://github.com/user-attachments/assets/f49ea37d-23d8-4ed6-9d27-34d5ad802510



Frontend:

![Screenshot 2025-05-23 230402](https://github.com/user-attachments/assets/b2dbf2f9-ff55-4c10-8b3c-0e54991dc204)

Backend:

![Screenshot 2025-05-23 230432](https://github.com/user-attachments/assets/7c987f03-3ff5-477e-b774-6b119278437d)

Coverage:

![Screenshot 2025-05-23 225624](https://github.com/user-attachments/assets/1060ed72-5423-4d83-9ba7-2da70366d904)

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes