### PR TITLE
Fix Footer Branding Text and Toast Test running Infinite loop

### DIFF
--- a/packages/ui/__tests__/components/Toast.test.jsx
+++ b/packages/ui/__tests__/components/Toast.test.jsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+} from "@testing-library/react";
 import Toast from "../../src/components/toast/Toast.jsx";
 
 describe("Toast Component", () => {
@@ -11,8 +17,9 @@ describe("Toast Component", () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
+    vi.clearAllTimers();
     vi.useRealTimers();
+    cleanup();
   });
 
   it("renders the toast with message", () => {
@@ -31,13 +38,13 @@ describe("Toast Component", () => {
     render(
       <Toast
         message="Test auto close"
-        duration={3000}
+        duration={1000}
         onClose={onCloseMock}
         id="2"
       />
     );
     act(() => {
-      vi.advanceTimersByTime(3300);
+      vi.advanceTimersByTime(1300);
     });
     expect(onCloseMock).toHaveBeenCalledWith("2");
   });
@@ -46,7 +53,7 @@ describe("Toast Component", () => {
     render(
       <Toast
         message="Hover pause test"
-        duration={5000}
+        duration={1000}
         onClose={onCloseMock}
         id="3"
       />
@@ -56,14 +63,14 @@ describe("Toast Component", () => {
 
     act(() => {
       fireEvent.mouseEnter(toast);
-      vi.advanceTimersByTime(6000);
+      vi.advanceTimersByTime(1500);
     });
 
     expect(onCloseMock).not.toHaveBeenCalled();
 
     act(() => {
       fireEvent.mouseLeave(toast);
-      vi.advanceTimersByTime(5300);
+      vi.advanceTimersByTime(1300);
     });
 
     expect(onCloseMock).toHaveBeenCalledWith("3");

--- a/packages/ui/src/components/footer/Footer.module.css
+++ b/packages/ui/src/components/footer/Footer.module.css
@@ -23,6 +23,7 @@
   flex-direction: row;
   gap: 0.5rem;
   align-items: center;
+  color: var(--black);
   font-size: 1.85rem;
   cursor: pointer;
   border: none;


### PR DESCRIPTION
## Description
#684 Fix: Footer of the website currently missing Branding Text "Openlogo" & also fixed Toast.Test.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
![Footer Fixed](https://github.com/user-attachments/assets/2157e0ed-f6b4-48c5-8afb-a160a7f8b459)


## Checklist
- [X] I have performed a self-review of my code  
- [X] I have commented my code, particularly in hard-to-understand areas  
- [X] I have added tests that prove my fix is effective or that my feature works  
- [X] New and existing unit tests pass locally with my changes
