### PR TITLE
fix: auth UI state issues & dynamic footer year

### DIFF
--- a/packages/ui/__tests__/components/Footer.test.jsx
+++ b/packages/ui/__tests__/components/Footer.test.jsx
@@ -53,8 +53,10 @@ describe("Footer Component", () => {
       </BrowserRouter>
     );
 
-    const copyrightText = screen.getByText(/© 2025/i);
-    expect(copyrightText).toBeInTheDocument();
+    const copyrightElement = screen.getByText(
+      new RegExp(`© ${new Date().getFullYear()}`, "i")
+    );
+    expect(copyrightElement).toBeInTheDocument();
     const poweredByLink = screen.getByText(BRANDING.poweredByText);
     expect(poweredByLink).toHaveAttribute("href", BRANDING.poweredByLink);
     expect(poweredByLink).toHaveAttribute("target", "_blank");

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -28,7 +28,7 @@ describe("SignUpForm UI and Functionality Tests", () => {
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
           <ToastProvider>
-            <SignUpForm toggleForm={vi.fn()} onClose={vi.fn()} />
+            <SignUpForm toggleForm={vi.fn()} />
           </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
@@ -167,14 +167,13 @@ describe("SignUpForm UI and Functionality Tests", () => {
 
   it("connectivity test passed", async () => {
     const authContext = mockAuthContext(true);
-    const onCloseMock = vi.fn();
     mockedMakeRequest.mockResolvedValue(true);
 
     render(
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
           <ToastProvider>
-            <SignUpForm toggleForm={vi.fn()} onClose={onCloseMock} />
+            <SignUpForm toggleForm={vi.fn()} />
           </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>
@@ -200,7 +199,6 @@ describe("SignUpForm UI and Functionality Tests", () => {
 
     await waitFor(() => {
       expect(mockedMakeRequest).toHaveBeenCalled();
-      expect(onCloseMock).toHaveBeenCalled();
     });
   });
 
@@ -261,7 +259,7 @@ describe("SignUpForm UI and Functionality Tests", () => {
       <BrowserRouter>
         <AuthContext.Provider value={authContext}>
           <ToastProvider>
-            <SignUpForm toggleForm={vi.fn()} onClose={vi.fn()} />
+            <SignUpForm toggleForm={vi.fn()} />
           </ToastProvider>
         </AuthContext.Provider>
       </BrowserRouter>

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -64,7 +64,6 @@ const SignIn = ({ toggleForm, onClose }) => {
 
   const handleSubmit = async (submitEvent) => {
     submitEvent.preventDefault();
-    setIsSubmit(true);
     setIsLoading(true);
     const success = await makeRequest();
     if (success) {
@@ -77,7 +76,6 @@ const SignIn = ({ toggleForm, onClose }) => {
         navigate("/dashboard");
       }
 
-      setIsSubmit(false);
       setFocusedField(null);
       toast.success("Sign in successfully");
     }
@@ -157,7 +155,7 @@ const SignIn = ({ toggleForm, onClose }) => {
         <Button
           type="submit"
           variant="primary"
-          disabled={!isFormValid || isSubmit}
+          disabled={!isFormValid || isSubmit || isLoading}
         >
           {isForgotPassword ? BUTTON_TEXT.submit : BUTTON_TEXT.signIn}
         </Button>

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -8,11 +8,10 @@ import { validate } from "../../utils/Helpers";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../hooks/useToast.js";
 
-function SignUp({ toggleForm, onClose }) {
+function SignUp({ toggleForm }) {
   const toast = useToast();
   const [formValues, setFormValues] = useState(SIGNUP.initialValues);
   const [formErrors, setFormErrors] = useState({});
-  const [isSubmit, setIsSubmit] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
   const [focusedField, setFocusedField] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -53,17 +52,14 @@ function SignUp({ toggleForm, onClose }) {
   const handleSubmit = async (submitEvent) => {
     submitEvent.preventDefault();
     setFormErrors({});
-    setIsSubmit(false);
     setFocusedField(null);
     setIsLoading(true);
 
     const success = await makeRequest();
     if (success) {
       setFormValues(SIGNUP.initialValues);
-      setIsSubmit(true);
       setFocusedField(null);
       toggleForm();
-      onClose();
       toast.success("Sign up successfully");
     }
     setIsLoading(false);
@@ -100,7 +96,7 @@ function SignUp({ toggleForm, onClose }) {
         <Button
           type="submit"
           variant="primary"
-          disabled={!isFormValid || isSubmit || isLoading}
+          disabled={!isFormValid || isLoading}
           isLoading={isLoading}
         >
           {BUTTON_TEXT.signUp}

--- a/packages/ui/src/components/footer/Footer.jsx
+++ b/packages/ui/src/components/footer/Footer.jsx
@@ -37,7 +37,7 @@ function Footer() {
           ))}
         </div>
         <div className={styles["footer-copyright"]}>
-          © 2025 |&nbsp;
+          © {new Date().getFullYear()} |&nbsp;
           <a
             href={BRANDING.poweredByLink}
             target="_blank"


### PR DESCRIPTION
## Description
Fixes #689 

This PR addresses several UI and logic issues in the authentication flow and footer component:
- Dynamic Footer Year: The footer year is now dynamically rendered using JavaScript’s `new Date().getFullYear()` instead of being hardcoded to "2025".
- Sign Up Button Disabled State & Toggle Sign in: After a user completes the sign-up process, the "Sign Up" button is correctly re-enabled when attempting to sign up again with a different email, without needing to close and reopen the modal. Also, now after the signup, it toggles to signin form.
- Sign-In Modal CTA Handling: When a user attempts to sign in with an unverified account, the correct error message is displayed, but the sign-in button is now re-enabled to allow the user to retry after correcting their input, without needing to close and reopen the modal.

## What type of PR is this? (Check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
![signin test](https://github.com/user-attachments/assets/94f01928-89d3-4687-9fd5-e639d3a3c051)
![signup test](https://github.com/user-attachments/assets/7d5e909c-0b27-4e82-bd7f-a9449824e2a0)
![footer test](https://github.com/user-attachments/assets/b1aa591e-3548-4457-8c2b-0e76f2f2058d)

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes