### PR TITLE
Admin route navigation fixed

### DIFF
--- a/packages/ui/__tests__/utils/ProtectedRoute.test.jsx
+++ b/packages/ui/__tests__/utils/ProtectedRoute.test.jsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AuthContext, UserContext } from "../../src/contexts/Contexts";
 import { MemoryRouter, useNavigate } from "react-router-dom";
 import ProtectedRoute from "../../src/utils/ProtectedRoute";
+import { ToastProvider } from "../../src/contexts/ToastContext.jsx";
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
@@ -42,11 +43,13 @@ describe("ProtectedRoute", () => {
     render(
       <AuthContext.Provider value={authContext}>
         <UserContext.Provider value={userContext}>
-          <MemoryRouter>
-            <ProtectedRoute adminOnly={false}>
-              <p data-testid="protected-content">Protected Content</p>
-            </ProtectedRoute>
-          </MemoryRouter>
+          <ToastProvider>
+            <MemoryRouter>
+              <ProtectedRoute adminOnly={false}>
+                <p data-testid="protected-content">Protected Content</p>
+              </ProtectedRoute>
+            </MemoryRouter>
+          </ToastProvider>
         </UserContext.Provider>
       </AuthContext.Provider>
     );
@@ -62,11 +65,13 @@ describe("ProtectedRoute", () => {
     render(
       <AuthContext.Provider value={authContext}>
         <UserContext.Provider value={userContext}>
-          <MemoryRouter>
-            <ProtectedRoute adminOnly={false}>
-              <p data-testid="protected-content">Protected Content</p>
-            </ProtectedRoute>
-          </MemoryRouter>
+          <ToastProvider>
+            <MemoryRouter>
+              <ProtectedRoute adminOnly={false}>
+                <p data-testid="protected-content">Protected Content</p>
+              </ProtectedRoute>
+            </MemoryRouter>
+          </ToastProvider>
         </UserContext.Provider>
       </AuthContext.Provider>
     );
@@ -79,16 +84,18 @@ describe("ProtectedRoute", () => {
 
   it("should allow admin access to admin routes", () => {
     const authContext = mockAuthContext(true);
-    const userContext = mockUserContext({ userType: "ADMIN" }, false);
+    const userContext = mockUserContext({ role: "ADMIN" }, false);
 
     render(
       <AuthContext.Provider value={authContext}>
         <UserContext.Provider value={userContext}>
-          <MemoryRouter>
-            <ProtectedRoute adminOnly={true}>
-              <p data-testid="admin-content">Admin Content</p>
-            </ProtectedRoute>
-          </MemoryRouter>
+          <ToastProvider>
+            <MemoryRouter>
+              <ProtectedRoute adminOnly={true}>
+                <p data-testid="admin-content">Admin Content</p>
+              </ProtectedRoute>
+            </MemoryRouter>
+          </ToastProvider>
         </UserContext.Provider>
       </AuthContext.Provider>
     );
@@ -104,11 +111,13 @@ describe("ProtectedRoute", () => {
     render(
       <AuthContext.Provider value={authContext}>
         <UserContext.Provider value={userContext}>
-          <MemoryRouter>
-            <ProtectedRoute adminOnly={true}>
-              <p data-testid="admin-content">Admin Content</p>
-            </ProtectedRoute>
-          </MemoryRouter>
+          <ToastProvider>
+            <MemoryRouter>
+              <ProtectedRoute adminOnly={true}>
+                <p data-testid="admin-content">Admin Content</p>
+              </ProtectedRoute>
+            </MemoryRouter>
+          </ToastProvider>
         </UserContext.Provider>
       </AuthContext.Provider>
     );

--- a/packages/ui/src/utils/ProtectedRoute.jsx
+++ b/packages/ui/src/utils/ProtectedRoute.jsx
@@ -1,27 +1,29 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Navigate, useLocation } from "react-router-dom";
 import { AuthContext, UserContext } from "../contexts/Contexts";
+import LoadingSpinner from "../components/common/loadingspinner/LoadingSpinner.jsx";
+import { useToast } from "../hooks/useToast.js";
 
 function ProtectedRoute({ adminOnly = false, children }) {
   const location = useLocation();
   const { isAuthenticated } = useContext(AuthContext);
-  const { userData, loading, fetchUserData } = useContext(UserContext);
-  const [hasFetched, setHasFetched] = useState(false);
+  const { userData, loading, fetchUserData, error } = useContext(UserContext);
+  const hasFetchedRef = useRef(false);
+  const toast = useToast();
 
   useEffect(() => {
-    if (adminOnly && isAuthenticated && !loading && !userData && !hasFetched) {
-      setHasFetched(true);
+    if (
+      adminOnly &&
+      isAuthenticated &&
+      !loading &&
+      !userData &&
+      !hasFetchedRef.current
+    ) {
+      hasFetchedRef.current = true;
       fetchUserData();
     }
-  }, [
-    adminOnly,
-    loading,
-    userData,
-    hasFetched,
-    fetchUserData,
-    isAuthenticated,
-  ]);
+  }, [adminOnly, isAuthenticated, userData, loading, fetchUserData]);
 
   if (!isAuthenticated) {
     return <Navigate to="/" replace state={{ from: location.pathname }} />;
@@ -31,16 +33,17 @@ function ProtectedRoute({ adminOnly = false, children }) {
     return children;
   }
 
-  if (!loading && !userData) {
-    alert("Something went wrong!");
+  if (error) {
+    console.error("Failed to fetch user data:", error);
+    toast.error("Failed to fetch user data ! Try Again");
     return <Navigate to="/" replace />;
   }
 
-  if (loading) {
-    return <div>Loading...</div>;
+  if (loading || !userData) {
+    return <LoadingSpinner color="blue" />;
   }
 
-  if (userData.userType !== "ADMIN") {
+  if (userData.role !== "ADMIN") {
     return <Navigate to="/" replace />;
   }
 


### PR DESCRIPTION
## Description
Closes #702 
Fixes the issue of admin not able to navigate to /admin route and was shown error alert instead. Also added custom error toast and LoadingSpinner

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
https://github.com/user-attachments/assets/7039ac38-2a78-4c13-8d6d-b9ccef7b1d20


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
