### PR TITLE
685 forgot password api integration with email confirmation

### DIFF
--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import CustomInput from "../common/input/CustomInput";
 import Button from "../common/button/Button";
-import { BUTTON_TEXT, MESSAGES, SIGNIN } from "../../utils/Constants";
+import { BUTTON_TEXT, SIGNIN } from "../../utils/Constants";
 import styles from "./SignForm.module.css";
 import { validate } from "../../utils/Helpers";
 import { useApi } from "../../hooks/useApi";
@@ -21,18 +21,19 @@ const SignIn = ({ toggleForm, onClose }) => {
   const [isForgotPassword, setIsForgotPassword] = useState(false);
   const { setIsAuthenticated } = useContext(AuthContext);
   const [isLoading, setIsLoading] = useState(false);
+  const [localErrorMsg, setLocalErrorMsg] = useState("");
   const { makeRequest, errorMsg } = useApi({
     method: "post",
-    url: isForgotPassword ? `/auth/forgot-password` : `/auth/signin`,
-    data: formData,
+    url: isForgotPassword ? `/auth/password/forgot` : `/auth/signin`,
+    data: isForgotPassword ? { email: formData.email } : formData,
   });
-  const { makeRequest: makeGuestRequest, errorMsg: guestErrorMsg } = useApi({
+  const { makeRequest: makeGuestRequest } = useApi({
     method: "post",
     url: `/auth/signin?type=guest`,
   });
   useEffect(() => {
-    if (errorMsg || guestErrorMsg) toast.error(errorMsg || guestErrorMsg);
-  }, [errorMsg, guestErrorMsg, toast]);
+    setLocalErrorMsg(errorMsg);
+  }, [errorMsg]);
 
   useEffect(() => {
     if (focusedField !== "email") {
@@ -52,9 +53,12 @@ const SignIn = ({ toggleForm, onClose }) => {
   }, [focusedField, formData]);
 
   useEffect(() => {
-    const errors = validate({ email: formData.email });
+    const fieldsToValidate = isForgotPassword
+      ? { email: formData.email }
+      : formData;
+    const errors = validate(fieldsToValidate);
     setIsFormValid(Object.keys(errors).length === 0);
-  }, [formData]);
+  }, [formData, isForgotPassword]);
 
   const handleChange = (event) => {
     const { name, value } = event.target;
@@ -67,6 +71,7 @@ const SignIn = ({ toggleForm, onClose }) => {
     const success = await makeRequest();
     if (success) {
       if (isForgotPassword) {
+        toast.success("Password reset link sent to your email");
         setIsForgotPassword(false);
       } else {
         setFormData(SIGNIN.initialValues);
@@ -76,8 +81,9 @@ const SignIn = ({ toggleForm, onClose }) => {
       }
 
       setFocusedField(null);
-      toast.success(MESSAGES.SIGN_IN_SUCCESS);
+      toast.success("Sign in successfully");
     }
+
     setIsLoading(false);
   };
   const handleGuestSignIn = async (submitEvent) => {
@@ -89,10 +95,10 @@ const SignIn = ({ toggleForm, onClose }) => {
       setIsSubmit(false);
       onClose();
       navigate("/dashboard");
-      toast.success(MESSAGES.GUEST_SIGN_IN_SUCCESS);
     }
   };
   const handleToggleForgotPassword = () => {
+    setLocalErrorMsg("");
     setFormErrors({});
     setFocusedField(null);
     setIsSubmit(false);
@@ -107,6 +113,13 @@ const SignIn = ({ toggleForm, onClose }) => {
       <form className={styles.form} onSubmit={handleSubmit}>
         <img src="/logo-images.png" alt="openlogo" className={styles.logo} />
         <h2 className={styles.title}>{SIGNIN.title}</h2>
+
+        <div
+          className={`"error-container" ${localErrorMsg ? "has-error" : ""}`}
+        >
+          <p className="input-error">{localErrorMsg}</p>
+        </div>
+
         <div className={styles["form-width"]}>
           {SIGNIN["fields"]
             .filter((field) => !(isForgotPassword && field.name === "password"))

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -53,9 +53,8 @@ const SignIn = ({ toggleForm, onClose }) => {
   }, [focusedField, formData]);
 
   useEffect(() => {
-    const fieldsToValidate = isForgotPassword
-      ? { email: formData.email }
-      : formData;
+    const fieldsToValidate = { email: formData.email };
+
     const errors = validate(fieldsToValidate);
     setIsFormValid(Object.keys(errors).length === 0);
   }, [formData, isForgotPassword]);

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import CustomInput from "../common/input/CustomInput";
 import Button from "../common/button/Button";
-import { BUTTON_TEXT, SIGNIN } from "../../utils/Constants";
+import { BUTTON_TEXT, MESSAGES, SIGNIN } from "../../utils/Constants";
 import styles from "./SignForm.module.css";
 import { validate } from "../../utils/Helpers";
 import { useApi } from "../../hooks/useApi";
@@ -22,18 +22,26 @@ const SignIn = ({ toggleForm, onClose }) => {
   const { setIsAuthenticated } = useContext(AuthContext);
   const [isLoading, setIsLoading] = useState(false);
   const [localErrorMsg, setLocalErrorMsg] = useState("");
+
   const { makeRequest, errorMsg } = useApi({
     method: "post",
     url: isForgotPassword ? `/auth/password/forgot` : `/auth/signin`,
     data: isForgotPassword ? { email: formData.email } : formData,
   });
-  const { makeRequest: makeGuestRequest } = useApi({
+
+  const { makeRequest: makeGuestRequest, errorMsg: guestErrorMsg } = useApi({
     method: "post",
     url: `/auth/signin?type=guest`,
   });
+
   useEffect(() => {
     setLocalErrorMsg(errorMsg);
-  }, [errorMsg]);
+    if (errorMsg) toast.error(errorMsg);
+  }, [errorMsg, toast]);
+
+  useEffect(() => {
+    if (guestErrorMsg) toast.error(guestErrorMsg);
+  }, [guestErrorMsg, toast]);
 
   useEffect(() => {
     if (focusedField !== "email") {
@@ -54,7 +62,6 @@ const SignIn = ({ toggleForm, onClose }) => {
 
   useEffect(() => {
     const fieldsToValidate = { email: formData.email };
-
     const errors = validate(fieldsToValidate);
     setIsFormValid(Object.keys(errors).length === 0);
   }, [formData, isForgotPassword]);
@@ -77,14 +84,14 @@ const SignIn = ({ toggleForm, onClose }) => {
         setIsAuthenticated(true);
         onClose();
         navigate("/dashboard");
+        toast.success(MESSAGES.SIGN_IN_SUCCESS);
       }
 
       setFocusedField(null);
-      toast.success("Sign in successfully");
     }
-
     setIsLoading(false);
   };
+
   const handleGuestSignIn = async (submitEvent) => {
     submitEvent.preventDefault();
     setIsSubmit(true);
@@ -94,16 +101,16 @@ const SignIn = ({ toggleForm, onClose }) => {
       setIsSubmit(false);
       onClose();
       navigate("/dashboard");
+      toast.success(MESSAGES.GUEST_SIGN_IN_SUCCESS);
     }
   };
+
   const handleToggleForgotPassword = () => {
     setLocalErrorMsg("");
     setFormErrors({});
     setFocusedField(null);
     setIsSubmit(false);
-
     setFormData(SIGNIN.initialValues);
-
     setIsForgotPassword(!isForgotPassword);
   };
 
@@ -160,7 +167,6 @@ const SignIn = ({ toggleForm, onClose }) => {
           type="submit"
           variant="primary"
           disabled={!isFormValid || isSubmit || isLoading}
-          isLoading={isLoading || isSubmit}
         >
           {isForgotPassword ? BUTTON_TEXT.submit : BUTTON_TEXT.signIn}
         </Button>
@@ -176,6 +182,7 @@ const SignIn = ({ toggleForm, onClose }) => {
     </>
   );
 };
+
 SignIn.propTypes = {
   toggleForm: PropTypes.func.isRequired,
   onClose: PropTypes.func,


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
closes #685 
-User clicks "Forgot Password" → switches to forgot password mode
-User enters email and clicks "Submit"
-API call is made to /auth/password/forgot
-Success message "Password reset link sent to your email"
-User returns back to the sigin dashboard.


## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
[forgetPasswordAPI.webm](https://github.com/user-attachments/assets/4d5af692-10df-44cb-8ca7-5d9d01bcc45d)
![t1](https://github.com/user-attachments/assets/f0de60bc-eb16-4895-b9e6-933d56c94985)
![t2](https://github.com/user-attachments/assets/c5385dee-3b1a-482a-a27a-ab5fd048445f)




## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
