### PR TITLE
Corrected background image path in HeroSection for production

### DIFF
--- a/packages/ui/src/components/hero/HeroSection.module.css
+++ b/packages/ui/src/components/hero/HeroSection.module.css
@@ -3,7 +3,7 @@
   flex-direction: row;
   align-items: center;
   gap: 6rem;
-  background-image: url("hero-background.png");
+  background-image: url("/hero-background.png");
   padding: 6rem 0;
   background-position: center;
 }


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
 closes #746 
This PR fixes the issue where the hero section background image was not loading in production.
The image path in HeroSection.module.css was previously set as a relative path:
```
background-image: url("hero-background.png");
```
It has been updated to a root-relative path:
```
background-image: url("/hero-background.png");
```

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="1920" height="1030" alt="hero-section" src="https://github.com/user-attachments/assets/6017e2c4-1792-4284-a451-b91c1d09b91a" />


## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  