### PR TITLE
Fix: Correct res.clearCookie options for signout

### DIFF
--- a/packages/app/__tests__/controllers/auth/signout.js
+++ b/packages/app/__tests__/controllers/auth/signout.js
@@ -22,8 +22,8 @@ describe("SIGNOUT API", () => {
       .set("Cookie", ["jwt=token"])
       .send();
     expect(response.status).toBe(205);
-    expect(response.headers["set-cookie"]).toEqual([
-      "jwt=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-    ]);
+    const setCookieHeader = response.headers["set-cookie"];
+    expect(setCookieHeader).toBeDefined();
+    expect(setCookieHeader[0]).toMatch(/jwt=;/);
   });
 });

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -159,7 +159,12 @@ function signoutController(req, res, next) {
       });
     }
 
-    res.clearCookie("jwt");
+    res.clearCookie("jwt", {
+      sameSite: "none",
+      secure: true,
+      httpOnly: true,
+      domain: ".openlogo.fyi",
+    });
     return res.status(205).send();
   } catch (err) {
     next(err);

--- a/packages/ui/__tests__/components/auth/ResetPassword.test.jsx
+++ b/packages/ui/__tests__/components/auth/ResetPassword.test.jsx
@@ -63,8 +63,10 @@ describe("ResetPassword Component Tests", async () => {
     await waitFor(() => {
       const newPasswordInput = screen.getByLabelText("New Password");
       const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-      const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
-      
+      const submitButton = screen.getByRole("button", {
+        name: BUTTON_TEXT.submit,
+      });
+
       expect(newPasswordInput).toBeInTheDocument();
       expect(confirmPasswordInput).toBeInTheDocument();
       expect(submitButton).toBeInTheDocument();
@@ -83,7 +85,9 @@ describe("ResetPassword Component Tests", async () => {
     );
 
     await waitFor(() => {
-      const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+      const submitButton = screen.getByRole("button", {
+        name: BUTTON_TEXT.submit,
+      });
       expect(submitButton).toBeDisabled();
     });
   });
@@ -106,10 +110,14 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
-    fireEvent.change(confirmPasswordInput, { target: { value: "password123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "password123" },
+    });
 
     expect(submitButton).toBeEnabled();
   });
@@ -133,10 +141,14 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
-    fireEvent.change(confirmPasswordInput, { target: { value: "password123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "password123" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
@@ -164,10 +176,14 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
-    fireEvent.change(confirmPasswordInput, { target: { value: "password123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "password123" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
@@ -209,12 +225,12 @@ describe("ResetPassword Component Tests", async () => {
         </ToastProvider>
       </BrowserRouter>
     );
-    
+
     await waitFor(() => {
       const errorMessages = screen.getAllByText("Invalid or missing token.");
       expect(errorMessages.length).toBeGreaterThan(0);
     });
-    
+
     const newPasswordInput = screen.queryByLabelText("New Password");
     const confirmPasswordInput = screen.queryByLabelText("Confirm Password");
     expect(newPasswordInput).not.toBeInTheDocument();
@@ -264,7 +280,7 @@ describe("ResetPassword Component Tests", async () => {
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
     fireEvent.focus(confirmPasswordInput);
     fireEvent.change(confirmPasswordInput, { target: { value: "abc" } });
-    
+
     expect(confirmPasswordInput.value).toBe("abc");
   });
 
@@ -309,7 +325,9 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
     fireEvent.change(confirmPasswordInput, { target: { value: "wrong" } });
@@ -331,20 +349,22 @@ describe("ResetPassword Component Tests", async () => {
         </ToastProvider>
       </BrowserRouter>
     );
-    
+
     await waitFor(() => {
       const newPasswordInput = screen.getByLabelText("New Password");
       expect(newPasswordInput).toBeInTheDocument();
     });
-    
+
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
-    
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
+
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
     fireEvent.change(confirmPasswordInput, { target: { value: "different" } });
     fireEvent.click(submitButton);
-    
+
     expect(mockedResetPasswordRequest).not.toHaveBeenCalled();
     await waitFor(() => {
       const errorMessage = screen.getByText(/confirm password/i);
@@ -371,10 +391,14 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
-    fireEvent.change(confirmPasswordInput, { target: { value: "password123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "password123" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
@@ -405,16 +429,20 @@ describe("ResetPassword Component Tests", async () => {
 
     const newPasswordInput = screen.getByLabelText("New Password");
     const confirmPasswordInput = screen.getByLabelText("Confirm Password");
-    const submitButton = screen.getByRole("button", { name: BUTTON_TEXT.submit });
+    const submitButton = screen.getByRole("button", {
+      name: BUTTON_TEXT.submit,
+    });
 
     fireEvent.change(newPasswordInput, { target: { value: "password123" } });
-    fireEvent.change(confirmPasswordInput, { target: { value: "password123" } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: "password123" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockedResetPasswordRequest).toHaveBeenCalled();
       expect(mockToast.error).toHaveBeenCalledWith("Failed to reset password.");
-      
+
       const errorMessages = screen.getAllByText("Failed to reset password.");
       expect(errorMessages.length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
closes #750 
- This PR fixes the issue where the JWT cookie was not being cleared on the client side during sign out.
- Previously, res.clearCookie('jwt') was failing because the options provided in sign out did not precisely match the options used in sign in when the cookie was originally set. Browsers require exact matches to clear a cookie.
## What type of PR is this? (Check all applicable)


- [x] 🐛 Bug Fix

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
**Sign out Working Demo**

https://github.com/user-attachments/assets/b5dd09c3-15a7-4e63-a1b6-32c7cd5ca7f7



## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
