### PR TITLE
Fix: Correct res.clearCookie options for Delete Account

### DIFF
--- a/packages/app/controllers/users.js
+++ b/packages/app/controllers/users.js
@@ -117,7 +117,12 @@ async function deleteUserAccountController(req, res, next) {
     const userService = new UserService();
     const { userId } = req.userData;
     await userService.deleteUserAccount(userId);
-    res.clearCookie("jwt");
+    res.clearCookie("jwt", {
+      sameSite: "none",
+      secure: true,
+      httpOnly: true,
+      domain: ".openlogo.fyi",
+    });
     res.status(200).json({
       status: 200,
     });


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
closes #752 
- This PR fixes the issue where the JWT cookie was not being cleared on the client side after Account got deleted.
- Previously, `res.clearCookie('jwt')` was failing because the options provided in delete account did not precisely match the options used in sign in when the cookie was originally set. Browsers require exact matches to clear a cookie.

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
**Delete Account Working Demo**

https://github.com/user-attachments/assets/48905fb2-4f3f-475a-aec7-38d63cae76cc

**Delete Account Backend Tests**
<img width="1121" height="302" alt="deleteAccount-tests" src="https://github.com/user-attachments/assets/abb42aa5-2c35-4b25-aa35-f6f41fdcad37" />


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
