### PR TITLE
fix: logo api documentation mismatch

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1603,7 +1603,7 @@ class Auth401,Input400,User403,Server500 error
 > <details>
 > <summary>Query parameters</summary>
 >
-> - `domainKey`: Prefix of the domain name to filter logos (required)
+> - `key`: Prefix of the domain name to filter logos (required)
 > </details>
 >
 > <details>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -300,7 +300,7 @@ class Success200 success
 class Input422,Email400,Server500 error
 class Success201 warning
 
-``` 
+```
 </details>
 
 ---
@@ -374,7 +374,7 @@ class GuestCheck,InputValid,UserExists,CheckVerified,PasswordMatch decision
 class Success200 success
 class Input422,User404,Verify403 error
 
-``` 
+```
 </details>
 
 ---
@@ -420,7 +420,7 @@ class Start,Success205 startEnd
 class CheckCookie decision
 class Success205 success
 class Cookie400 error
-``` 
+```
 </details>
 
 ---
@@ -492,7 +492,7 @@ class ValidateToken,TokenExists,DeletedExists,CheckExpiry,UserExists,AlreadyVeri
 class Success200,Already200 success
 class Token422,Token400,Expired403,User404,Verify500,Server500 error
 
-``` 
+```
 </details>
 
 ---
@@ -559,7 +559,7 @@ class InputValid,UserExists,TokenCreated decision
 class Success200 success
 class Input422,User404,Server500 error
 
-``` 
+```
 </details>
 
 ---
@@ -614,7 +614,7 @@ class ValidateToken,TokenExists,CheckExpiry decision
 class Success200 success
 class Token422,User404,Expired403 error
 
-``` 
+```
 </details>
 
 ---
@@ -687,7 +687,7 @@ class CheckSession,InputValid,UpdateSuccess,TokenValid decision
 class Success200 success
 class Session401,Input422,Password400,Token403 error
 
-``` 
+```
 </details>
 
 ---
@@ -744,7 +744,7 @@ class Auth decision
 class Success200 success
 class Auth401 error
 
-``` 
+```
 </details>
 
 
@@ -831,7 +831,7 @@ class Success200 success
 class Auth401,User404,FormatError500 error
 class Partial206 warning
 
-``` 
+```
 </details>
 
 ---
@@ -917,7 +917,7 @@ class Auth401,Input422,User404,Server500 error
 >   "statusCode": 200
 > }
 > ```
-> 
+>
 > **Response:** `200 OK` - Account deleted successfully</br>
 > **Response:** `401 Unauthorized` - Not authenticated</br>
 > **Response:** `404 Not Found` - User not found
@@ -995,7 +995,7 @@ class SoftDelete,UpdateUser,ClearCookies process
 >    }
 > }
 > ```
-> 
+>
 > **Response:** `200 OK` - API key generated successfully</br>
 > **Response:** `400 Bad Request` - Invalid input data</br>
 > **Response:** `401 Unauthorized` - Not authenticated</br>
@@ -1061,7 +1061,7 @@ class Limit403 warning
 >   "statusCode":200
 > }
 > ```
-> 
+>
 > **Response:** `200 OK` - API key revoked successfully</br>
 > **Response:** `401 Unauthorized` - Not authenticated</br>
 > **Response:** `404 Not Found` - API key not found
@@ -1132,7 +1132,7 @@ class Auth401,Key404,Server500 error
 >   "statusCode": 200
 > }
 > ```
-> 
+>
 > **Response:** `200 OK` - Password updated successfully</br>
 > **Response:** `400 Bad Request` - Invalid input data</br>
 > **Response:** `401 Unauthorized` - Not authenticated or invalid current password
@@ -1543,7 +1543,7 @@ class Auth401,Input400,User403,Server500 error
 > <details>
 > <summary>Query parameters</summary>
 >
-> - `domain`: The domain name of the company (required)
+> - `key`: The domain name of the company (required)
 > - `API_KEY`: API key for authentication (required)
 > </details>
 >
@@ -1571,7 +1571,7 @@ class Auth401,Input400,User403,Server500 error
 > <details>
 > <summary>Query parameters</summary>
 >
-> - `domainKey`: Prefix of the domain name to filter logos (required)
+> - `key`: Prefix of the domain name to filter logos (required)
 > - `API_KEY`: API key for authentication (required)
 > </details>
 >

--- a/docs/Postman Collection/postman_collection.json
+++ b/docs/Postman Collection/postman_collection.json
@@ -3114,7 +3114,7 @@
 					},
 					"response": [
 						{
-							"name": "DomainKey is Required",
+							"name": "key is Required",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
@@ -3138,7 +3138,7 @@
 									"expires": "Invalid Date"
 								}
 							],
-							"body": "{\r\n    \"message\": \"domainKey is required\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
+							"body": "{\r\n    \"message\": \"key is required\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
 						},
 						{
 							"name": "API KEY is Required",
@@ -3146,7 +3146,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/search?domainKey=Google",
+									"raw": "{{openlogo_base_url}}/logo/search?key=Google",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3156,7 +3156,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										}
 									]
@@ -3179,7 +3179,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/search?domainKey=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EED",
+									"raw": "{{openlogo_base_url}}/logo/search?key=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EED",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3189,7 +3189,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										},
 										{
@@ -3216,7 +3216,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/search?domainKey=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
+									"raw": "{{openlogo_base_url}}/logo/search?key=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3226,7 +3226,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										},
 										{
@@ -3253,7 +3253,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo?domain=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
+									"raw": "{{openlogo_base_url}}/logo?key=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3262,7 +3262,7 @@
 									],
 									"query": [
 										{
-											"key": "domain",
+											"key": "key",
 											"value": "Google"
 										},
 										{
@@ -3283,7 +3283,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo?domain=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
+									"raw": "{{openlogo_base_url}}/logo?key=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3292,7 +3292,7 @@
 									],
 									"query": [
 										{
-											"key": "domain",
+											"key": "key",
 											"value": "Google"
 										},
 										{
@@ -3313,7 +3313,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo?domain=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
+									"raw": "{{openlogo_base_url}}/logo?key=Google&API_KEY=AB63AF54437B47F287D9F2600AFD3EEC",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3322,7 +3322,7 @@
 									],
 									"query": [
 										{
-											"key": "domain",
+											"key": "key",
 											"value": "Google"
 										},
 										{

--- a/docs/Postman Collection/postman_collection.json
+++ b/docs/Postman Collection/postman_collection.json
@@ -3370,7 +3370,7 @@
 					},
 					"response": [
 						{
-							"name": "DomainKey Required",
+							"name": "key Required",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
@@ -3388,15 +3388,15 @@
 							"_postman_previewlanguage": null,
 							"header": null,
 							"cookie": [],
-							"body": "{\r\n    \"message\": \"domainKey is required\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
+							"body": "{\r\n    \"message\": \"key is required\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
 						},
 						{
-							"name": "Empty DomainKey",
+							"name": "Empty key",
 							"originalRequest": {
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/demo-search?domainKey=",
+									"raw": "{{openlogo_base_url}}/logo/demo-search?key=",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3406,7 +3406,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": ""
 										}
 									]
@@ -3415,7 +3415,7 @@
 							"_postman_previewlanguage": null,
 							"header": null,
 							"cookie": [],
-							"body": "{\r\n    \"message\": \"\\\"domainKey\\\" is not allowed to be empty\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
+							"body": "{\r\n    \"message\": \"\\\"key\\\" is not allowed to be empty\",\r\n    \"statusCode\": 422,\r\n    \"error\": \"Unprocessable Entity\"\r\n}"
 						},
 						{
 							"name": "Logo Not Found",
@@ -3423,7 +3423,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/demo-search?domainKey=Google",
+									"raw": "{{openlogo_base_url}}/logo/demo-search?key=Google",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3433,7 +3433,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										}
 									]
@@ -3450,7 +3450,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/demo-search?domainKey=Google",
+									"raw": "{{openlogo_base_url}}/logo/demo-search?key=Google",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3460,7 +3460,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										}
 									]
@@ -3477,7 +3477,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/demo-search?domainKey=Google",
+									"raw": "{{openlogo_base_url}}/logo/demo-search?key=Google",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3487,7 +3487,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										}
 									]
@@ -3504,7 +3504,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{openlogo_base_url}}/logo/demo-search?domainKey=Google",
+									"raw": "{{openlogo_base_url}}/logo/demo-search?key=Google",
 									"host": [
 										"{{openlogo_base_url}}"
 									],
@@ -3514,7 +3514,7 @@
 									],
 									"query": [
 										{
-											"key": "domainKey",
+											"key": "key",
 											"value": "Google"
 										}
 									]

--- a/packages/app/__tests__/controllers/logo/demo-search.js
+++ b/packages/app/__tests__/controllers/logo/demo-search.js
@@ -9,7 +9,7 @@ describe("GET /api/logo/demo-search", () => {
     jest.clearAllMocks();
   });
 
-  it("422 - Missing domainKey query param", async () => {
+  it("422 - Missing key query param", async () => {
     const res = await request(app).get("/api/logo/demo-search");
 
     expect(res.status).toBe(422);
@@ -20,14 +20,12 @@ describe("GET /api/logo/demo-search", () => {
     });
   });
 
-  it("404 - No companies found for domainKey", async () => {
+  it("404 - No companies found for key", async () => {
     jest
       .spyOn(ImageService.prototype, "fetchCompanyList")
       .mockResolvedValue([]);
 
-    const res = await request(app).get(
-      "/api/logo/demo-search?domainKey=unknown"
-    );
+    const res = await request(app).get("/api/logo/demo-search?key=unknown");
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({
@@ -51,7 +49,7 @@ describe("GET /api/logo/demo-search", () => {
       .spyOn(ImageService.prototype, "getDataList")
       .mockResolvedValue(mockDataList);
 
-    const res = await request(app).get("/api/logo/demo-search?domainKey=Go");
+    const res = await request(app).get("/api/logo/demo-search?key=Go");
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -67,7 +65,7 @@ describe("GET /api/logo/demo-search", () => {
         throw new Error("Boom!");
       });
 
-    const res = await request(app).get("/api/logo/demo-search?domainKey=Go");
+    const res = await request(app).get("/api/logo/demo-search?key=Go");
 
     expect(res.status).toBe(500);
   });

--- a/packages/app/schemas/catalog.js
+++ b/packages/app/schemas/catalog.js
@@ -1,47 +1,47 @@
 const Joi = require("joi");
 
 const getLogoQuerySchema = Joi.object({
-  domain: Joi.string()
+  key: Joi.string()
     .regex(/^[A-Za-z0-9&:.-/]+$/)
     .required()
     .messages({
-      "any.required": "Domain is required",
-      "string.pattern.base": "Invalid domain",
+      "any.required": "key is required",
+      "string.pattern.base": "Invalid key",
     }),
   API_KEY: Joi.string().guid({ version: "uuidv4" }).required().messages({
     "any.required": "API key is required",
   }),
 }).custom((value, helpers) => {
-  const { domain } = value;
-  const company = domain
+  const { key } = value;
+  const company = key
     .replace(/^(https?:\/\/)?(www\.)?/, "")
     .replace(/(\.[A-Za-z]{2,})+$/, "")
     .toUpperCase();
   if (company == "") {
-    return helpers.error("Domain cannot be empty");
+    return helpers.error("key cannot be empty");
   }
   return { ...value, company };
 });
 
 const getSearchQuerySchema = Joi.object({
-  domainKey: Joi.string()
+  key: Joi.string()
     .regex(/^[A-Za-z0-9&-/:.]+$/)
     .required()
     .messages({
-      "any.required": "domainKey is required",
-      "string.pattern.base": "Invalid domainKey",
+      "any.required": "key is required",
+      "string.pattern.base": "Invalid key",
     }),
   API_KEY: Joi.string().guid({ version: "uuidv4" }).required().messages({
     "any.required": "API key is required",
   }),
 }).custom((value, helpers) => {
-  const { domainKey } = value;
-  const companyNameBeginsWith = domainKey
+  const { key } = value;
+  const companyNameBeginsWith = key
     .replace(/^(https?:\/\/)?(www\.)?/, "")
     .match(/([A-Za-z0-9-]+)/)[1]
     .toUpperCase();
   if (companyNameBeginsWith === "") {
-    return helpers.error("domainKey cannot be empty");
+    return helpers.error("key cannot be empty");
   }
   return { ...value, companyNameBeginsWith };
 });

--- a/packages/app/schemas/catalog.js
+++ b/packages/app/schemas/catalog.js
@@ -47,21 +47,21 @@ const getSearchQuerySchema = Joi.object({
 });
 
 const getDemoSearchQuerySchema = Joi.object({
-  domainKey: Joi.string()
+  key: Joi.string()
     .regex(/^[A-Za-z0-9&/:.-]+$/)
     .required()
     .messages({
-      "any.required": "domainKey is required",
-      "string.pattern.base": "Invalid domainKey",
+      "any.required": "key is required",
+      "string.pattern.base": "Invalid key",
     }),
 }).custom((value, helpers) => {
-  const { domainKey } = value;
-  const companyNameBeginsWith = domainKey
+  const { key } = value;
+  const companyNameBeginsWith = key
     .replace(/^(https?:\/\/)?(www\.)?/, "")
     .match(/([A-Za-z0-9-]+)/)[1]
     .toUpperCase();
   if (companyNameBeginsWith === "") {
-    return helpers.error("domainKey cannot be empty");
+    return helpers.error("key cannot be empty");
   }
   return { ...value, companyNameBeginsWith };
 });

--- a/packages/ui/src/components/demo/Demo.jsx
+++ b/packages/ui/src/components/demo/Demo.jsx
@@ -16,7 +16,7 @@ const Demo = ({ openAuthModal }) => {
     method: "GET",
     url: "/logo/demo-search",
     params: {
-      domainKey: searchTerm,
+      key: searchTerm,
     },
   });
   const showResults = searchTerm.length > 1;


### PR DESCRIPTION
## Description
closes #783 

- Fixed the parameter schema expected in the `/logo` and `/logo/search/` api to match the documentation 
- now the `/logo` and `/logo/search` endpoints clearly accepts `key` and `API_KEY` as their query parameter.
- Updated the documentation according to that

## What type of PR is this? 

- [x] 🐛 Bug Fix
- [x] 📄 Documentation Update

## Screenshots 
- Getting the image url in logo search api 
<img width="1503" height="566" alt="image" src="https://github.com/user-attachments/assets/dff6e3af-80cb-4f7e-bb59-bbd97bb1b960" />

-  Getting logo not found in /logo api ( same as current stage,  #784 is already opened for that )

<img width="1566" height="350" alt="image" src="https://github.com/user-attachments/assets/921c6ac4-357d-40f7-a4d3-74983a8e804d" />

- Demo search working as expected
<img width="2599" height="832" alt="image" src="https://github.com/user-attachments/assets/1d35d1d3-04ba-494a-9587-adf5fbec9e17" />

## Test Cases
<img width="1758" height="407" alt="image" src="https://github.com/user-attachments/assets/56a76c06-3b77-47df-99ae-f303d2c1d0ad" />
<img width="1758" height="407" alt="image" src="https://github.com/user-attachments/assets/3048feb6-9c0e-4aa2-b3bd-de474e80ccf6" />




## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
