### PR TITLE
removes unnecessary usage of mocks for validateChangePassword

### DIFF
--- a/packages/ui/__tests__/components/changePassword.test.jsx
+++ b/packages/ui/__tests__/components/changePassword.test.jsx
@@ -23,13 +23,7 @@ vi.mock("../../src/hooks/useToast", () => ({
   }),
 }));
 
-vi.mock("../../src/utils/Helpers", () => ({
-  validateChangePassword: vi.fn(() => ({})),
-}));
-
 let mockApiReturn;
-
-import { validateChangePassword } from "../../src/utils/Helpers";
 
 describe("ChangePassword", () => {
   beforeEach(() => {
@@ -43,7 +37,6 @@ describe("ChangePassword", () => {
     };
 
     mockUseApi.mockImplementation(() => mockApiReturn);
-    validateChangePassword.mockImplementation(() => ({}));
   });
 
   it("renders form fields and button", () => {
@@ -59,10 +52,6 @@ describe("ChangePassword", () => {
   });
 
   it("validates fields on focus", async () => {
-    validateChangePassword.mockReturnValue({
-      currPassword: CHANGE_PASSWORD.currRequired,
-      newPassword: "",
-    });
     render(<ChangePassword isGuest={false} />);
     const currPasswordInput = screen.getByLabelText(/current password/i);
     fireEvent.focus(currPasswordInput);
@@ -86,13 +75,12 @@ describe("ChangePassword", () => {
     mockMakeRequest.mockResolvedValue({ statusCode: 200 });
     mockApiReturn.loading = false;
     mockApiReturn.errorMsg = "";
-    validateChangePassword.mockReturnValue({});
     render(<ChangePassword isGuest={false} />);
     const currInput = screen.getByLabelText(/current password/i);
     const newInput = screen.getByLabelText(/new password/i);
     const button = screen.getByRole("button", { name: /change password/i });
-    fireEvent.change(currInput, { target: { value: "oldpass" } });
-    fireEvent.change(newInput, { target: { value: "newpass123" } });
+    fireEvent.change(currInput, { target: { value: "Oldpass@123" } });
+    fireEvent.change(newInput, { target: { value: "Newpass@121" } });
     fireEvent.click(button);
     await waitFor(() => {
       expect(mockToastSuccess).toHaveBeenCalledWith(
@@ -106,12 +94,11 @@ describe("ChangePassword", () => {
     mockApiReturn.errorMsg = "Incorrect current password";
     render(<ChangePassword isGuest={false} />);
     const currPassword = screen.getByLabelText(/current password/i);
-    fireEvent.change(currPassword, { target: { value: "wrongpass" } });
+    fireEvent.change(currPassword, { target: { value: "wrongpass@123" } });
     const newPassword = screen.getByLabelText(/new password/i);
     fireEvent.change(newPassword, {
-      target: { value: "newpass123" },
+      target: { value: "Newpass@123" },
     });
-    validateChangePassword.mockReturnValue({});
     const button = screen.getByRole("button");
     fireEvent.click(button);
     await waitFor(() => {
@@ -120,9 +107,6 @@ describe("ChangePassword", () => {
   });
 
   it("does not submit form when validation errors exist", async () => {
-    validateChangePassword.mockReturnValue({
-      currPassword: CHANGE_PASSWORD.currRequired,
-    });
     render(<ChangePassword isGuest={false} />);
     const button = screen.getByRole("button");
     fireEvent.click(button);

--- a/packages/ui/__tests__/components/changePassword.test.jsx
+++ b/packages/ui/__tests__/components/changePassword.test.jsx
@@ -94,7 +94,7 @@ describe("ChangePassword", () => {
     mockApiReturn.errorMsg = "Incorrect current password";
     render(<ChangePassword isGuest={false} />);
     const currPassword = screen.getByLabelText(/current password/i);
-    fireEvent.change(currPassword, { target: { value: "wrongpass@123" } });
+    fireEvent.change(currPassword, { target: { value: "Wrongpass@123" } });
     const newPassword = screen.getByLabelText(/new password/i);
     fireEvent.change(newPassword, {
       target: { value: "Newpass@123" },


### PR DESCRIPTION
## Description
This PR fixes existing test file for changePassword by removing unecessary usage of mocks for validateChangePassword 
allowing the actual validation logic to be tested .

## What type of PR is this? (Check all applicable)
- [x] ✅ Test

## Screenshot
<img width="732" height="112" alt="image" src="https://github.com/user-attachments/assets/fed9d090-78c2-43a6-8523-8b01246fb9e9" />


<img width="882" height="776" alt="image" src="https://github.com/user-attachments/assets/1daae0f7-9611-4772-aab2-192cb3302239" />


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
