### PR TITLE
fix: demo logo shows broken image on search

### DIFF
--- a/packages/app/services/images.js
+++ b/packages/app/services/images.js
@@ -32,8 +32,7 @@ class ImageServices {
       domainName = image.company_name;
     }
 
-    const version = new Date(company.updated_at).getTime();
-    const imageUrl = `${this.s3BucketKey}/${default_extension}/${domainName}.${default_extension}?v=${version}`;
+    const imageUrl = `${default_extension}/${domainName}.${default_extension}`;
     const cloudFrontUrl =
       await this.imageRepository.fetchCloudFrontURL(imageUrl);
     return cloudFrontUrl;


### PR DESCRIPTION
## Description

Closes Issue: #796 

Corrected the incorrect file path that was used to generate the CloudFront signed URL and resulted in AccessDenied errors.

- updated imageUrl used to generate the signed url from cloudfront 
- removed `?v=version` from urls

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix

## Screenshots (if applicable)

<img width="1613" height="523" alt="image" src="https://github.com/user-attachments/assets/8720f921-d1d2-4b8e-8ad8-919f090525c2" />

<img width="851" height="194" alt="image" src="https://github.com/user-attachments/assets/047def15-1e25-4bdd-bdaa-e672d4249eaf" />


## Checklist
- [x] I have performed a self-review of my code 
- [x] New and existing unit tests pass locally with my changes
