### PR TITLE
fix: remove description field from logoRequestForm

### DIFF
--- a/packages/ui/__tests__/components/LogoRequestForm.test.jsx
+++ b/packages/ui/__tests__/components/LogoRequestForm.test.jsx
@@ -45,22 +45,14 @@ beforeEach(() => {
 
 const fillFormWithValidData = async () => {
   const companyUrlInput = screen.getByLabelText("Company Url");
-  const companyDescriptionInput = screen.getByPlaceholderText(
-    "Type company description here ..."
-  );
 
   await act(async () => {
     fireEvent.change(companyUrlInput, {
       target: { value: "https://validurl.com" },
     });
-    fireEvent.change(companyDescriptionInput, {
-      target: {
-        value: "This is a test message that is long enough for validation",
-      },
-    });
   });
 
-  return { companyUrlInput, companyDescriptionInput };
+  return { companyUrlInput };
 };
 
 describe("LogoRequestForm", () => {
@@ -74,10 +66,6 @@ describe("LogoRequestForm", () => {
     expect(logoRequestTitle).toBeInTheDocument();
     const companyUrlInput = screen.getByLabelText("Company Url");
     expect(companyUrlInput).toBeInTheDocument();
-    const companyDescriptionInput = screen.getByPlaceholderText(
-      "Type company description here ..."
-    );
-    expect(companyDescriptionInput).toBeInTheDocument();
   });
 
   describe("shows validation errors for input fields", () => {
@@ -113,194 +101,148 @@ describe("LogoRequestForm", () => {
       });
     });
 
-    it("display validation error for empty company description", async () => {
+    it("enables submit button only when form is valid", async () => {
       render(
         <ToastProvider>
           <LogoRequestForm closeModal={() => {}} />
         </ToastProvider>
       );
-      const companyDescriptionInput = screen.getByPlaceholderText(
-        "Type company description here ..."
-      );
-      await act(async () => {
-        fireEvent.focus(companyDescriptionInput);
+      const sendRequestButton = screen.getByRole("button", {
+        name: BUTTON_TEXT.sendRequest,
       });
-      await waitFor(() => {
-        const companyDescriptionMisssing = screen.getByText(
-          "Company Description is required"
-        );
-        expect(companyDescriptionMisssing).toBeInTheDocument();
-      });
-    });
-
-    it("display validation error for short company description", async () => {
-      render(
-        <ToastProvider>
-          <LogoRequestForm closeModal={() => {}} />
-        </ToastProvider>
-      );
-      const companyDescriptionInput = screen.getByPlaceholderText(
-        "Type company description here ..."
-      );
-      await act(async () => {
-        fireEvent.change(companyDescriptionInput, {
-          target: { value: "random company.." },
-        });
-      });
-      await waitFor(() => {
-        const companyDescriptionError = screen.getByText(
-          "Description should be at least 20 characters"
-        );
-        expect(companyDescriptionError).toBeInTheDocument();
-      });
-    });
-  });
-
-  it("enables submit button only when form is valid", async () => {
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={() => {}} />
-      </ToastProvider>
-    );
-    const sendRequestButton = screen.getByRole("button", {
-      name: BUTTON_TEXT.sendRequest,
-    });
-    expect(sendRequestButton).toBeDisabled();
-    await fillFormWithValidData();
-    await waitFor(() => {
-      expect(sendRequestButton).not.toBeDisabled();
-    });
-    const urlInput = screen.getByLabelText("Company Url");
-    await act(async () => {
-      fireEvent.change(urlInput, { target: { value: "http:/example.com" } });
-    });
-    await waitFor(() => {
       expect(sendRequestButton).toBeDisabled();
+      await fillFormWithValidData();
+      await waitFor(() => {
+        expect(sendRequestButton).not.toBeDisabled();
+      });
+      const urlInput = screen.getByLabelText("Company Url");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "http:/example.com" } });
+      });
+      await waitFor(() => {
+        expect(sendRequestButton).toBeDisabled();
+      });
     });
-  });
 
-  it("shows loading state while submitting the form ", async () => {
-    mockUseApi.mockReturnValue({
-      makeRequest: mockMakeRequest,
-      loading: true,
-      isSuccess: false,
-      errorMsg: null,
-      data: null,
-    });
+    it("shows loading state while submitting the form ", async () => {
+      mockUseApi.mockReturnValue({
+        makeRequest: mockMakeRequest,
+        loading: true,
+        isSuccess: false,
+        errorMsg: null,
+        data: null,
+      });
 
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={() => {}} />
-      </ToastProvider>
-    );
-    await waitFor(() => {
-      const loadingButton = screen.getByTestId("spinner").closest("button");
-      expect(loadingButton).toBeInTheDocument();
-      expect(loadingButton).toBeDisabled();
-    });
-  });
-
-  it("shows success message when form is submitted successfully", async () => {
-    mockUseApi.mockReturnValue({
-      makeRequest: mockMakeRequest,
-      loading: false,
-      isSuccess: true,
-      errorMsg: null,
-      data: {
-        message: "Logo request created successfully",
-      },
-    });
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={() => {}} />
-      </ToastProvider>
-    );
-    await waitFor(() => {
-      expect(mockToastSuccess).toHaveBeenCalledWith(
-        "Logo request created successfully"
+      render(
+        <ToastProvider>
+          <LogoRequestForm closeModal={() => {}} />
+        </ToastProvider>
       );
-    });
-  });
-
-  it("shows error message when form submission fails", async () => {
-    mockUseApi.mockReturnValue({
-      makeRequest: mockMakeRequest,
-      loading: false,
-      isSuccess: false,
-      errorMsg: "An error occurred",
-      data: null,
+      await waitFor(() => {
+        const loadingButton = screen.getByTestId("spinner").closest("button");
+        expect(loadingButton).toBeInTheDocument();
+        expect(loadingButton).toBeDisabled();
+      });
     });
 
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={() => {}} />
-      </ToastProvider>
-    );
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith("An error occurred");
-    });
-  });
-
-  it("calls closeModal after successful submission and timeout", async () => {
-    vi.useFakeTimers();
-    const mockCloseModal = vi.fn(() => {});
-
-    mockUseApi.mockReturnValue({
-      makeRequest: mockMakeRequest,
-      loading: false,
-      isSuccess: true,
-      errorMsg: null,
-      data: {
-        message: "Logo request created successfully",
-      },
-    });
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={mockCloseModal} />
-      </ToastProvider>
-    );
-    expect(mockCloseModal).toHaveBeenCalledTimes(0);
-
-    await act(async () => {
-      vi.advanceTimersByTime(500);
+    it("shows success message when form is submitted successfully", async () => {
+      mockUseApi.mockReturnValue({
+        makeRequest: mockMakeRequest,
+        loading: false,
+        isSuccess: true,
+        errorMsg: null,
+        data: {
+          message: "Logo request created successfully",
+        },
+      });
+      render(
+        <ToastProvider>
+          <LogoRequestForm closeModal={() => {}} />
+        </ToastProvider>
+      );
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalledWith(
+          "Logo request created successfully"
+        );
+      });
     });
 
-    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+    it("shows error message when form submission fails", async () => {
+      mockUseApi.mockReturnValue({
+        makeRequest: mockMakeRequest,
+        loading: false,
+        isSuccess: false,
+        errorMsg: "An error occurred",
+        data: null,
+      });
 
-    vi.useRealTimers();
-  });
-
-  it("clears form after successful submission", async () => {
-    vi.useFakeTimers();
-
-    mockUseApi.mockReturnValue({
-      makeRequest: mockMakeRequest,
-      loading: false,
-      isSuccess: true,
-      errorMsg: null,
-      data: {
-        message: "Logo request created successfully",
-      },
+      render(
+        <ToastProvider>
+          <LogoRequestForm closeModal={() => {}} />
+        </ToastProvider>
+      );
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("An error occurred");
+      });
     });
 
-    render(
-      <ToastProvider>
-        <LogoRequestForm closeModal={() => {}} />
-      </ToastProvider>
-    );
+    it("calls closeModal after successful submission and timeout", async () => {
+      vi.useFakeTimers();
+      const mockCloseModal = vi.fn(() => {});
 
-    const companyUrlInput = screen.getByLabelText("Company Url");
-    const companyDescriptionInput = screen.getByPlaceholderText(
-      "Type company description here ..."
-    );
+      mockUseApi.mockReturnValue({
+        makeRequest: mockMakeRequest,
+        loading: false,
+        isSuccess: true,
+        errorMsg: null,
+        data: {
+          message: "Logo request created successfully",
+        },
+      });
+      render(
+        <ToastProvider>
+          <LogoRequestForm closeModal={mockCloseModal} />
+        </ToastProvider>
+      );
+      expect(mockCloseModal).toHaveBeenCalledTimes(0);
 
-    await act(async () => {
-      vi.advanceTimersByTime(500);
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(mockCloseModal).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
     });
 
-    expect(companyUrlInput.value).toBe("");
-    expect(companyDescriptionInput.value).toBe("");
+    it("clears form after successful submission", async () => {
+      vi.useFakeTimers();
 
-    vi.useRealTimers();
+      mockUseApi.mockReturnValue({
+        makeRequest: mockMakeRequest,
+        loading: false,
+        isSuccess: true,
+        errorMsg: null,
+        data: {
+          message: "Logo request created successfully",
+        },
+      });
+
+      render(
+        <ToastProvider>
+          <LogoRequestForm closeModal={() => {}} />
+        </ToastProvider>
+      );
+
+      const companyUrlInput = screen.getByLabelText("Company Url");
+
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(companyUrlInput.value).toBe("");
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/packages/ui/src/components/demo/LogoRequestForm.jsx
+++ b/packages/ui/src/components/demo/LogoRequestForm.jsx
@@ -110,20 +110,6 @@ const LogoRequestForm = ({ closeModal }) => {
             onFocus={() => setActiveFormField("companyUrl")}
             onBlur={() => setActiveFormField(null)}
           />
-          <textarea
-            name="companyDescription"
-            placeholder="Type company description here ..."
-            value={requestFormValues.companyDescription}
-            onChange={handleInputChange}
-            className={styles["logo-form-textarea"]}
-            onFocus={() => setActiveFormField("companyDescription")}
-            onBlur={() => setActiveFormField(null)}
-          ></textarea>
-          <p
-            className={`${styles["input-error"]} ${requestFormErrors.companyDescription ? styles["has-error"] : ""}`}
-          >
-            {requestFormErrors.companyDescription}
-          </p>
         </div>
         <Button
           type="submit"

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -482,7 +482,6 @@ export const LOGOREQUEST = {
   title: "Request Logo",
   initialValues: {
     companyUrl: "",
-    companyDescription: "",
   },
 };
 


### PR DESCRIPTION
## Description
#792 
The Logo request functionality on home page does not send the company description field to the database, nor is it visible to the operator handling the request. Hence to make the functionality more consistent and not to take non useful data from clients this description field is removed from the modal and subsequent tests also.


## What type of PR is this? (Check all applicable)
- [x] 🐛 Bug Fix

## Screenshots (if applicable)

https://github.com/user-attachments/assets/8894522e-1488-40c4-809f-3c6824604a1e



## Checklist
- [x] I have performed a self-review of my code  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
