### PR TITLE
fix: discolored textareas, fix: remove unnecessary styles from logoRe…

### DIFF
--- a/packages/ui/src/components/contact/ContactForm.module.css
+++ b/packages/ui/src/components/contact/ContactForm.module.css
@@ -31,6 +31,30 @@
   color: var(--description);
 }
 
+.text-area::-webkit-scrollbar {
+  width: 8px;
+}
+
+.text-area::-webkit-scrollbar-track {
+  background: var(--white);
+  border-radius: 4px;
+}
+
+.text-area::-webkit-scrollbar-thumb {
+  background: var(--primary);
+  border-radius: 4px;
+}
+
+.text-area::-webkit-scrollbar-thumb:hover {
+  background: #6c63ff;
+}
+
+.text-area {
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--white);
+  resize: none;
+}
+
 .title {
   font-size: 2rem;
   color: var(--black);

--- a/packages/ui/src/components/contact/ContactForm.module.css
+++ b/packages/ui/src/components/contact/ContactForm.module.css
@@ -28,7 +28,9 @@
   transition:
     border 0.3s ease-in-out,
     box-shadow 0.3s ease-in-out;
-  color: var(--description);
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--white);
+  resize: none;
 }
 
 .text-area::-webkit-scrollbar {
@@ -47,12 +49,6 @@
 
 .text-area::-webkit-scrollbar-thumb:hover {
   background: #6c63ff;
-}
-
-.text-area {
-  scrollbar-width: thin;
-  scrollbar-color: var(--primary) var(--white);
-  resize: none;
 }
 
 .title {

--- a/packages/ui/src/components/contact/ContactForm.module.css
+++ b/packages/ui/src/components/contact/ContactForm.module.css
@@ -18,12 +18,12 @@
   padding: 12px;
   font-size: 1rem;
   font-family: inherit;
+  color: var(--description);
   background-color: var(--white);
   border: var(--border);
   margin-bottom: 8px;
   border-radius: var(--bradius);
   outline: none;
-  resize: vertical;
   line-height: 1.5;
   transition:
     border 0.3s ease-in-out,
@@ -48,7 +48,7 @@
 }
 
 .text-area::-webkit-scrollbar-thumb:hover {
-  background: #6c63ff;
+  background: var(--primary-hover);
 }
 
 .title {

--- a/packages/ui/src/components/demo/LogoRequestForm.module.css
+++ b/packages/ui/src/components/demo/LogoRequestForm.module.css
@@ -18,27 +18,6 @@
   align-items: flex-start;
 }
 
-.logo-form-textarea {
-  width: 100%;
-  height: 100px;
-  min-height: 100px;
-  max-height: 250px;
-  padding: 12px;
-  font-size: 1rem;
-  font-family: inherit;
-  background-color: var(--white);
-  border: var(--border);
-  margin-bottom: 8px;
-  border-radius: var(--bradius);
-  outline: none;
-  resize: vertical;
-  line-height: 1.5;
-  transition:
-    border 0.3s ease-in-out,
-    box-shadow 0.3s ease-in-out;
-  color: var(--description);
-}
-
 .input-error {
   color: var(--error);
   font-size: 0.8rem;
@@ -58,16 +37,4 @@
   opacity: 1;
   max-height: 50px;
   padding: 1px;
-}
-
-.logo-form-textarea::placeholder {
-  color: var(--label-color);
-}
-
-.logo-form-textarea:focus::placeholder {
-  color: var(--primary);
-}
-
-.logo-form-textarea:focus {
-  border-color: var(--primary);
 }

--- a/packages/ui/src/components/operator/OperatorDashboard.module.css
+++ b/packages/ui/src/components/operator/OperatorDashboard.module.css
@@ -147,7 +147,9 @@
   font-size: 1rem;
   resize: vertical;
   background-color: var(--white);
-  color: var(--description);
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--white);
+  resize: none;
 }
 
 .response-field textarea:focus {
@@ -171,12 +173,6 @@
 
 .response-field textarea::-webkit-scrollbar-thumb:hover {
   background: #6c63ff;
-}
-
-.response-field textarea {
-  scrollbar-width: thin;
-  scrollbar-color: var(--primary) var(--white);
-  resize: none;
 }
 
 .modal-actions {

--- a/packages/ui/src/components/operator/OperatorDashboard.module.css
+++ b/packages/ui/src/components/operator/OperatorDashboard.module.css
@@ -155,6 +155,30 @@
   border-color: var(--primary);
 }
 
+.response-field textarea::-webkit-scrollbar {
+  width: 8px;
+}
+
+.response-field textarea::-webkit-scrollbar-track {
+  background: var(--white);
+  border-radius: 4px;
+}
+
+.response-field textarea::-webkit-scrollbar-thumb {
+  background: var(--primary);
+  border-radius: 4px;
+}
+
+.response-field textarea::-webkit-scrollbar-thumb:hover {
+  background: #6c63ff;
+}
+
+.response-field textarea {
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--white);
+  resize: none;
+}
+
 .modal-actions {
   display: flex;
   justify-content: center;

--- a/packages/ui/src/components/operator/OperatorDashboard.module.css
+++ b/packages/ui/src/components/operator/OperatorDashboard.module.css
@@ -143,9 +143,9 @@
   margin: 0 auto;
   border: 1px solid var(--border-color);
   border-radius: var(--bradius);
+  color: var(--description);
   font-family: inherit;
   font-size: 1rem;
-  resize: vertical;
   background-color: var(--white);
   scrollbar-width: thin;
   scrollbar-color: var(--primary) var(--white);
@@ -172,7 +172,7 @@
 }
 
 .response-field textarea::-webkit-scrollbar-thumb:hover {
-  background: #6c63ff;
+  background: var(--primary-hover);
 }
 
 .modal-actions {


### PR DESCRIPTION
## Description
#805 

1. This PR will fix the discolored text area scrollbars on the Contact Us modal and operator dashboard response modal.
2. It will also remove unnecessary textarea stylings from the previously present textarea on the request-logo modal

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix

## Screenshots (if applicable)

1. Fixed Contact Us Modal scrollbar behavior

https://github.com/user-attachments/assets/7355d66c-0085-4a43-b024-da1a4487d53b


2. Fixed Operator Response Modal scrollbar behavior

https://github.com/user-attachments/assets/20bd810a-3c99-48ab-b8b2-99dbeb99f62c


## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] New and existing unit tests pass locally with my changes

