### PR TITLE
fix: prettier not ignore paths

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-node_modules
-dist
-build
-*.min.js
-packages/*/dist/
-packages/*/coverage/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coverage": "pnpm --parallel --filter ui --filter app coverage",
     "lint": "pnpm --parallel --filter ui --filter app lint",
     "check": "pnpm --filter ui check && pnpm --filter app check",
-    "format": "pnpm --filter ui format && pnpm --filter app format",
+    "format": "pnpm --parallel --filter ui --filter app format",
     "lint:fix": "pnpm --filter ui \"lint:fix\" && pnpm --filter app \"lint:fix\"",
     "prepare": "husky"
   },

--- a/packages/app/.prettierignore
+++ b/packages/app/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+build
+*.min.js
+dist/
+coverage/

--- a/packages/ui/.prettierignore
+++ b/packages/ui/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+build
+*.min.js
+dist/
+coverage/


### PR DESCRIPTION
## Description
Fixes #808

This fix solves the issue in least destructive manner hence the prettierignore files was copied into both the packages, this also provides us with more control over behavior of prettier in different packages.

The cli also contains a `--parallel` flag to speed up the format script.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
