### PR TITLE
fix: frontend inconsistecies from #815

### DIFF
--- a/packages/app/__tests__/controllers/operator/respond-messages.js
+++ b/packages/app/__tests__/controllers/operator/respond-messages.js
@@ -91,7 +91,7 @@ describe("RESPOND MESSAGES API", () => {
     });
   });
 
-  it("422 - Reply must be 500 or fewer characters", async () => {
+  it("422 - Reply must be 100 or fewer characters", async () => {
     const id = new mongoose.Types.ObjectId();
     const response = await request(app)
       .put(`${ENDPOINTS.MESSAGES}/${id}`)
@@ -102,7 +102,7 @@ describe("RESPOND MESSAGES API", () => {
     expect(response.status).toBe(422);
     expect(response.body).toEqual({
       error: STATUS_CODES[422],
-      message: "Reply must be 500 or fewer characters",
+      message: "Reply must be 100 or fewer characters",
       statusCode: 422,
     });
   });

--- a/packages/app/__tests__/controllers/operator/update-requests.js
+++ b/packages/app/__tests__/controllers/operator/update-requests.js
@@ -74,7 +74,7 @@ describe("PUT : /api/requests/:requestId", () => {
       statusCode: 422,
     });
   });
-  it("422 - Comment must be 500 or fewer characters", async () => {
+  it("422 - Comment must be 100 or fewer characters", async () => {
     const dummyRequestId = new mongoose.Types.ObjectId();
     const response = await request(app)
       .put(`${ENDPOINTS.REQUESTS}/${dummyRequestId}`)
@@ -86,7 +86,7 @@ describe("PUT : /api/requests/:requestId", () => {
     expect(response.status).toBe(422);
     expect(response.body).toEqual({
       error: STATUS_CODES[422],
-      message: "Comment must be 500 or fewer characters",
+      message: "Comment must be 100 or fewer characters",
       statusCode: 422,
     });
   });

--- a/packages/app/schemas/operator.js
+++ b/packages/app/schemas/operator.js
@@ -38,12 +38,12 @@ const revertToCustomerPayloadSchema = Joi.object().keys({
     .trim()
     .required()
     .min(20)
-    .max(500)
+    .max(100)
     .regex(/^[^!@#$%^&*(){}[\]\\;'"<>/`~|0-9]*$/)
     .messages({
       "string.base": "Reply must be a string",
       "string.min": "Reply should be at least 20 characters",
-      "string.max": "Reply must be 500 or fewer characters",
+      "string.max": "Reply must be 100 or fewer characters",
       "any.required": "Reply is required",
       "string.pattern.base":
         "Reply should only contain alphabets, comma, period., question mark?",
@@ -87,12 +87,12 @@ const contactUsPayloadSchema = Joi.object().keys({
     .trim()
     .required()
     .min(20)
-    .max(500)
+    .max(100)
     .regex(/^[^!@#$%^&*(){}[\];'"<>/`~|0-9]*$/)
     .messages({
       "string.base": "Message must be string",
       "string.min": "Message should be at least be 20 characters",
-      "string.max": "Message must be 500 or fewer characters",
+      "string.max": "Message must be 100 or fewer characters",
       "any.required": "Message is required",
       "string.pattern.base":
         "Message should only contain alphabets, comma (,), period (.), question mark (?)",

--- a/packages/app/schemas/request.js
+++ b/packages/app/schemas/request.js
@@ -25,10 +25,10 @@ const updateRequestSchema = Joi.object({
       "any.only": "Status must be one of PENDING, REJECTED, or RESOLVED",
       "any.required": "Status is required",
     }),
-  comment: Joi.string().trim().allow(null).min(5).max(500).messages({
+  comment: Joi.string().trim().allow(null).min(5).max(100).messages({
     "string.base": "Comment must be a string",
     "string.min": "Comment should be at least 5 characters",
-    "string.max": "Comment must be 500 or fewer characters",
+    "string.max": "Comment must be 100 or fewer characters",
   }),
 });
 

--- a/packages/ui/__tests__/components/UserInfo.test.jsx
+++ b/packages/ui/__tests__/components/UserInfo.test.jsx
@@ -71,7 +71,7 @@ describe("UserInfo Component", () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      const nameErrorText = screen.getByText("Name is required!");
+      const nameErrorText = screen.getByText("Name is required");
       expect(nameErrorText).toBeInTheDocument();
     });
 
@@ -79,7 +79,7 @@ describe("UserInfo Component", () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      const nameErrorText = screen.queryByText("Name is required!");
+      const nameErrorText = screen.queryByText("Name is required");
       expect(nameErrorText).not.toBeInTheDocument();
     });
   });

--- a/packages/ui/__tests__/components/auth/Signin.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signin.test.jsx
@@ -190,6 +190,11 @@ describe("SignInForm UI and Functionality Tests", () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
+      const spinner = screen.getByTestId("spinner");
+      expect(spinner).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
       expect(emailInput).toBeDisabled();
       expect(passwordInput).toBeDisabled();
       expect(submitButton).toBeDisabled();

--- a/packages/ui/__tests__/components/contact/ContactForm.test.jsx
+++ b/packages/ui/__tests__/components/contact/ContactForm.test.jsx
@@ -263,9 +263,10 @@ describe("ContactForm Component", () => {
     );
 
     await waitFor(() => {
-      const loadingButton = screen.getByText("Sending");
-      expect(loadingButton).toBeInTheDocument();
-      expect(loadingButton).toBeDisabled();
+      const spinner = screen.getByTestId("spinner");
+      expect(spinner).toBeInTheDocument();
+      const button = spinner.closest("button");
+      expect(button).toBeDisabled();
     });
   });
 

--- a/packages/ui/__tests__/components/operatordashboard/OperatorDashboard.test.jsx
+++ b/packages/ui/__tests__/components/operatordashboard/OperatorDashboard.test.jsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  within,
+} from "@testing-library/react";
 import OperatorDashboard from "../../../src/components/operator/OperatorDashboard";
 import { instance as apiInstance } from "../../../src/api/api_instance";
 import { ToastProvider } from "../../../src/contexts/ToastContext";
@@ -184,7 +190,14 @@ describe("Operator Page", () => {
         value: validTestText,
       },
     });
-    fireEvent.click(screen.getByText(BUTTON_TEXT.sendResponse));
+    const sendBtn = screen.getByRole("button", {
+      name: BUTTON_TEXT.sendResponse,
+    });
+    fireEvent.click(sendBtn);
+    await waitFor(() => {
+      expect(sendBtn).toBeDisabled();
+      expect(within(sendBtn).getByTestId("spinner")).toBeInTheDocument();
+    });
     await waitFor(() => {
       expect(apiInstance.put).toHaveBeenNthCalledWith(1, "/messages/1", {
         reply: validTestText,
@@ -212,7 +225,14 @@ describe("Operator Page", () => {
         value: validTestText,
       },
     });
-    fireEvent.click(screen.getByText(BUTTON_TEXT.confirmRejection));
+    const confirmBtn = screen.getByRole("button", {
+      name: BUTTON_TEXT.confirmRejection,
+    });
+    fireEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(confirmBtn).toBeDisabled();
+      expect(within(confirmBtn).getByTestId("spinner")).toBeInTheDocument();
+    });
     await waitFor(() => {
       expect(apiInstance.put).toHaveBeenNthCalledWith(2, "/messages/1", {
         reply: validTestText,

--- a/packages/ui/__tests__/page/documentation/CodeBlock.test.jsx
+++ b/packages/ui/__tests__/page/documentation/CodeBlock.test.jsx
@@ -11,7 +11,7 @@ const mockCodeExamples = {
   java: "System.out.println('Hello, Java!');",
 };
 
-const Harness = ({ initial = "javascript" }) => {
+const CodeBlockTestComponent = ({ initial = "javascript" }) => {
   const [lang, setLang] = useState(initial);
   return (
     <CodeBlock
@@ -23,13 +23,13 @@ const Harness = ({ initial = "javascript" }) => {
   );
 };
 
-Harness.propTypes = {
+CodeBlockTestComponent.propTypes = {
   initial: PropTypes.string,
 };
 
 describe("CodeBlock component", () => {
   it("Defaults to JavaScript on initial render", () => {
-    render(<Harness />);
+    render(<CodeBlockTestComponent />);
 
     const javascriptCode = screen.getByText(mockCodeExamples.javascript);
     expect(javascriptCode).toBeInTheDocument();
@@ -37,14 +37,7 @@ describe("CodeBlock component", () => {
 
   it("Copies code to clipboard on button click, change icon", async () => {
     const clipboardSpy = vi.spyOn(navigator.clipboard, "writeText");
-    render(
-      <CodeBlock
-        id="test"
-        codeExamples={mockCodeExamples}
-        selectedLanguage="javascript"
-        setSelectedLanguage={vi.fn()}
-      />
-    );
+    render(<CodeBlockTestComponent />);
 
     const copyButton = screen.getByRole("img", { name: /tick-copy-code/i });
     expect(copyButton.src).toContain(CODEBLOCK.copycodeicon);
@@ -57,7 +50,7 @@ describe("CodeBlock component", () => {
   });
 
   it("Changes displayed code when clicking on language icon", () => {
-    render(<Harness />);
+    render(<CodeBlockTestComponent />);
 
     const pythonButton = screen.getByRole("button", { name: /python logo/i });
     fireEvent.click(pythonButton);
@@ -71,14 +64,7 @@ describe("CodeBlock component", () => {
   });
 
   it("Renders buttons for all available languages", () => {
-    render(
-      <CodeBlock
-        id="test"
-        codeExamples={mockCodeExamples}
-        selectedLanguage="javascript"
-        setSelectedLanguage={vi.fn()}
-      />
-    );
+    render(<CodeBlockTestComponent />);
 
     Object.keys(mockCodeExamples).forEach((lang) => {
       const button = screen.getByRole("button", {

--- a/packages/ui/__tests__/page/documentation/CodeBlock.test.jsx
+++ b/packages/ui/__tests__/page/documentation/CodeBlock.test.jsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import CodeBlock from "../../../src/page/documentation/CodeBlock";
 import { CODEBLOCK } from "../../../src/utils/Constants";
+import { useState } from "react";
+import PropTypes from "prop-types";
 
 const mockCodeExamples = {
   javascript: "console.log('Hello, JavaScript!');",
@@ -9,9 +11,25 @@ const mockCodeExamples = {
   java: "System.out.println('Hello, Java!');",
 };
 
+const Harness = ({ initial = "javascript" }) => {
+  const [lang, setLang] = useState(initial);
+  return (
+    <CodeBlock
+      id="test"
+      codeExamples={mockCodeExamples}
+      selectedLanguage={lang}
+      setSelectedLanguage={setLang}
+    />
+  );
+};
+
+Harness.propTypes = {
+  initial: PropTypes.string,
+};
+
 describe("CodeBlock component", () => {
   it("Defaults to JavaScript on initial render", () => {
-    render(<CodeBlock id="test" codeExamples={mockCodeExamples} />);
+    render(<Harness />);
 
     const javascriptCode = screen.getByText(mockCodeExamples.javascript);
     expect(javascriptCode).toBeInTheDocument();
@@ -19,7 +37,14 @@ describe("CodeBlock component", () => {
 
   it("Copies code to clipboard on button click, change icon", async () => {
     const clipboardSpy = vi.spyOn(navigator.clipboard, "writeText");
-    render(<CodeBlock id="test" codeExamples={mockCodeExamples} />);
+    render(
+      <CodeBlock
+        id="test"
+        codeExamples={mockCodeExamples}
+        selectedLanguage="javascript"
+        setSelectedLanguage={vi.fn()}
+      />
+    );
 
     const copyButton = screen.getByRole("img", { name: /tick-copy-code/i });
     expect(copyButton.src).toContain(CODEBLOCK.copycodeicon);
@@ -32,7 +57,7 @@ describe("CodeBlock component", () => {
   });
 
   it("Changes displayed code when clicking on language icon", () => {
-    render(<CodeBlock id="test" codeExamples={mockCodeExamples} />);
+    render(<Harness />);
 
     const pythonButton = screen.getByRole("button", { name: /python logo/i });
     fireEvent.click(pythonButton);
@@ -46,7 +71,14 @@ describe("CodeBlock component", () => {
   });
 
   it("Renders buttons for all available languages", () => {
-    render(<CodeBlock id="test" codeExamples={mockCodeExamples} />);
+    render(
+      <CodeBlock
+        id="test"
+        codeExamples={mockCodeExamples}
+        selectedLanguage="javascript"
+        setSelectedLanguage={vi.fn()}
+      />
+    );
 
     Object.keys(mockCodeExamples).forEach((lang) => {
       const button = screen.getByRole("button", {

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -21,7 +21,6 @@ const SignIn = ({ toggleForm, onClose }) => {
   const [isForgotPassword, setIsForgotPassword] = useState(false);
   const { setIsAuthenticated } = useContext(AuthContext);
   const [isLoading, setIsLoading] = useState(false);
-  const [localErrorMsg, setLocalErrorMsg] = useState("");
 
   const { makeRequest, errorMsg } = useApi({
     method: "post",
@@ -35,7 +34,6 @@ const SignIn = ({ toggleForm, onClose }) => {
   });
 
   useEffect(() => {
-    setLocalErrorMsg(errorMsg);
     if (errorMsg) toast.error(errorMsg);
   }, [errorMsg, toast]);
 
@@ -106,7 +104,6 @@ const SignIn = ({ toggleForm, onClose }) => {
   };
 
   const handleToggleForgotPassword = () => {
-    setLocalErrorMsg("");
     setFormErrors({});
     setFocusedField(null);
     setIsSubmit(false);
@@ -119,12 +116,6 @@ const SignIn = ({ toggleForm, onClose }) => {
       <form className={styles.form} onSubmit={handleSubmit}>
         <img src="/logo-images.png" alt="openlogo" className={styles.logo} />
         <h2 className={styles.title}>{SIGNIN.title}</h2>
-
-        <div
-          className={`"error-container" ${localErrorMsg ? "has-error" : ""}`}
-        >
-          <p className="input-error">{localErrorMsg}</p>
-        </div>
 
         <div className={styles["form-width"]}>
           {SIGNIN["fields"]
@@ -166,6 +157,7 @@ const SignIn = ({ toggleForm, onClose }) => {
         <Button
           type="submit"
           variant="primary"
+          isLoading={isLoading}
           disabled={!isFormValid || isSubmit || isLoading}
         >
           {isForgotPassword ? BUTTON_TEXT.submit : BUTTON_TEXT.signIn}

--- a/packages/ui/src/components/contact/ContactForm.jsx
+++ b/packages/ui/src/components/contact/ContactForm.jsx
@@ -14,7 +14,7 @@ function ContactForm({ closeModal }) {
   const [formErrors, setFormErrors] = useState({});
   const [focusedField, setFocusedField] = useState(null);
   const [isFormValid, setIsFormValid] = useState(false);
-  const { makeRequest, loading, data, errorMsg } = useApi({
+  const { makeRequest, data, loading, errorMsg } = useApi({
     url: `/messages/contact-us`,
     method: "POST",
     data: formValues,
@@ -146,9 +146,10 @@ function ContactForm({ closeModal }) {
         <Button
           type="submit"
           variant="primary"
-          disabled={!isFormValid || loading}
+          disabled={!isFormValid}
+          isLoading={loading}
         >
-          {loading ? "Sending" : BUTTON_TEXT.sendMessage}
+          {BUTTON_TEXT.sendMessage}
         </Button>
       </form>
     </Modal>

--- a/packages/ui/src/components/contact/ContactForm.jsx
+++ b/packages/ui/src/components/contact/ContactForm.jsx
@@ -23,8 +23,12 @@ function ContactForm({ closeModal }) {
   const toast = useToast();
 
   useEffect(() => {
-    if (errorMsg) {
-      toast.error(errorMsg);
+    if (errorMsg || data?.message) {
+      if (errorMsg) {
+        toast.error(errorMsg);
+      } else if (data?.message) {
+        toast.success(data.message);
+      }
       const timeout = setTimeout(() => {
         setFormErrors({});
         setFocusedField(null);
@@ -33,20 +37,7 @@ function ContactForm({ closeModal }) {
       }, 500);
       return () => clearTimeout(timeout);
     }
-  }, [errorMsg, toast, closeModal]);
-
-  useEffect(() => {
-    if (data?.message) {
-      toast.success(data.message);
-      const timeout = setTimeout(() => {
-        setFormErrors({});
-        setFocusedField(null);
-        setFormValues(CONTACT.initialValues);
-        closeModal();
-      }, 500);
-      return () => clearTimeout(timeout);
-    }
-  }, [data, toast, closeModal]);
+  }, [errorMsg, data, toast, closeModal]);
 
   useEffect(() => {
     if (!focusedField) {

--- a/packages/ui/src/components/operator/OperatorDashboard.jsx
+++ b/packages/ui/src/components/operator/OperatorDashboard.jsx
@@ -223,13 +223,7 @@ const Operator = () => {
   }
 
   let submitButtonText;
-  if (loading) {
-    if (responseAction === "respond") {
-      submitButtonText = "Sending Response...";
-    } else {
-      submitButtonText = "Rejecting...";
-    }
-  } else if (responseAction === "respond") {
+  if (responseAction === "respond") {
     submitButtonText = BUTTON_TEXT.sendResponse;
   } else {
     submitButtonText = BUTTON_TEXT.confirmRejection;
@@ -361,6 +355,7 @@ const Operator = () => {
             disabled={!isFormValid || loading}
             variant={responseAction === "respond" ? "primary" : "danger"}
             className={styles["send-button"]}
+            isLoading={loading}
           >
             {submitButtonText}
           </Button>

--- a/packages/ui/src/components/operatorcard/OperatorCard.module.css
+++ b/packages/ui/src/components/operatorcard/OperatorCard.module.css
@@ -122,6 +122,7 @@
   font-size: 1rem;
 }
 
+.message,
 .summary {
   color: var(--black);
   word-break: break-all;

--- a/packages/ui/src/components/userinfo/UserInfo.jsx
+++ b/packages/ui/src/components/userinfo/UserInfo.jsx
@@ -6,6 +6,7 @@ import CustomInput from "../common/input/CustomInput";
 import Button from "../common/button/Button";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../hooks/useToast";
+import { validate } from "../../utils/Helpers";
 
 function UserInfo({ name, email, isGuest }) {
   const toast = useToast();
@@ -32,28 +33,23 @@ function UserInfo({ name, email, isGuest }) {
     if (errorMsg) toast.error(errorMsg);
   }, [errorMsg, toast]);
 
-  const validate = (values) => {
-    const errors = {};
-
-    if (!values.name) {
-      errors.name = "Name is required!";
-    }
-    return errors;
-  };
-
   const handleUserInfoChange = (e) => {
     const { name, value } = e.target;
-
+    const validationErrors = validate({ ...formData, [name]: value });
+    if (Object.keys(validationErrors).length > 0) {
+      setFormErrors({
+        type: "error",
+        message: Object.values(validationErrors)[0],
+      });
+    } else {
+      setFormErrors({ type: "", message: "" });
+    }
     setFormData((prevFormData) => {
       return {
         ...prevFormData,
         isBtnDisabled: isGuest,
         [name]: value,
       };
-    });
-    setFormErrors({
-      type: "",
-      message: "",
     });
   };
 

--- a/packages/ui/src/components/userinfo/UserInfo.jsx
+++ b/packages/ui/src/components/userinfo/UserInfo.jsx
@@ -89,9 +89,6 @@ function UserInfo({ name, email, isGuest }) {
 
   return (
     <form className={styles["user-info-input-group"]}>
-      <div className={`"error-container" ${errorMsg ? "has-error" : ""}`}>
-        <p className="input-error">{errorMsg}</p>
-      </div>
       {USER_INFO_FIELDS.map((field) => (
         <CustomInput
           key={field.name}

--- a/packages/ui/src/page/documentation/CodeBlock.jsx
+++ b/packages/ui/src/page/documentation/CodeBlock.jsx
@@ -3,8 +3,12 @@ import PropTypes from "prop-types";
 import { CODEBLOCK } from "../../utils/Constants";
 import styles from "./Documentation.module.css";
 
-const CodeBlock = ({ id, codeExamples }) => {
-  const [selectedLanguage, setSelectedLanguage] = useState("javascript");
+const CodeBlock = ({
+  id,
+  codeExamples,
+  selectedLanguage,
+  setSelectedLanguage,
+}) => {
   const [copyMessage, setCopyMessage] = useState("");
 
   const copyToClipboard = (code) => {
@@ -60,6 +64,8 @@ const CodeBlock = ({ id, codeExamples }) => {
 CodeBlock.propTypes = {
   id: PropTypes.string.isRequired,
   codeExamples: PropTypes.objectOf(PropTypes.string).isRequired,
+  selectedLanguage: PropTypes.string.isRequired,
+  setSelectedLanguage: PropTypes.func.isRequired,
 };
 
 export default CodeBlock;

--- a/packages/ui/src/page/documentation/Documentation.jsx
+++ b/packages/ui/src/page/documentation/Documentation.jsx
@@ -13,7 +13,7 @@ const Documentation = () => {
   const baseAPI = getBaseApiUrl(currentDomain);
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
-
+  const [selectedLanguage, setSelectedLanguage] = useState("javascript");
   return (
     <section
       className="container"
@@ -41,7 +41,12 @@ const Documentation = () => {
                 emptyMessage="No data available"
               />
             </div>
-            <CodeBlock id="logo-example" codeExamples={feature.codeExample} />
+            <CodeBlock
+              id="logo-example"
+              codeExamples={feature.codeExample}
+              selectedLanguage={selectedLanguage}
+              setSelectedLanguage={setSelectedLanguage}
+            />
           </div>
         );
       })}

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -514,9 +514,9 @@ HttpRequest request = HttpRequest.newBuilder()
   .uri(URI.create("/api/logo/search?key={prefix}&API_KEY={YOUR_API_KEY}"))
   .header("Content-Type", "application/json")
   .GET()
-  .build();  
+  .build();
 // send GET request
-HttpResponse<String> response = client.send(request, 
+HttpResponse<String> response = client.send(request,
   HttpResponse.BodyHandlers.ofString());`,
 };
 
@@ -549,9 +549,9 @@ HttpRequest request = HttpRequest.newBuilder()
   .uri(URI.create("/api/logo?key={domain}&API_KEY={YOUR_API_KEY}"))
   .header("Content-Type", "application/json")
   .GET()
-  .build();  
+  .build();
 // send GET request
-HttpResponse<String> response = client.send(request, 
+HttpResponse<String> response = client.send(request,
   HttpResponse.BodyHandlers.ofString());`,
 };
 
@@ -700,7 +700,7 @@ export const MESSAGES = {
 export const MODAL_MESSAGES = {
   RESPOND: "Type your response here...",
   REJECT: "Reason for rejection...",
-  CHARACTER_LIMIT: "500",
+  CHARACTER_LIMIT: "100",
 };
 
 export const MOCK_OPERATOR_CARD_DATA = {

--- a/packages/ui/src/utils/Helpers.js
+++ b/packages/ui/src/utils/Helpers.js
@@ -214,8 +214,8 @@ export const validate = (values) => {
   );
   validateField(
     "message",
-    values.message && values.message.length > 500,
-    "Message should be less than 500 characters"
+    values.message && values.message.length > 100,
+    "Message should be less than 100 characters"
   );
   validateField("companyUrl", !values.companyUrl, "Company Url is required");
   validateField(


### PR DESCRIPTION
## Description
fixes #815 

Fixed the following frontend inconsistencies 
- Implemented Loading spinner in SignIn form, Forgot Password form, Respond/Reject message form, Get in touch form.
- In SignIn modal fixed the modal to show the error only in the toast when wrong credentials are entered.
- Now User Info form shows error in the toast not above the input field.
- Now Docs page change code language throughout whole code blocks consistently.

### File changes :
- Mutating from 500 words limit to 100 words 
[‎app/schemas/operator.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-44299cebbfbef36d4d49c3a8f061ded97c630d271c98b4b4f6795f7feeee6e2f), [‎app/schemas/request.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-22797940cffd0c5e9d21ff1acbe0dde66346327b00aa0960ee912cce11d81f97) - changed schema from accepting 500 to 100 words .
[‎ui/src/utils/Constants.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-823ee393f58a1256468c241c46b3473538cc82871298034e5dc043a5a712d758) - changed constants for accepting 100 words.
[‎ui/src/utils/Helpers.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-da4abfa5d28f3bbb7d9519020b4916110c6a353a6d6c3f7a068ce8325a8bf72b) - changed validateField function to validate on 100 words instead of 500.
[‎app/__tests__/controllers/operator/respond-messages.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-20924227d065b82095838f32dff240c6e72ebe72bbdf2bd6644242298cb819f6) , [‎app/__tests__/controllers/operator/update-requests.js](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-3b94ef1b0058e3993fbd8147df372ad4225539f721ab1e9d0ff851fc87fc15b5) - Backend test to return the error for 100 words instead of 500.

- For using toasts for error and updating loading state to spinner 
[‎ui/src/components/auth/Signin.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-08836673334e3f1f0791724c755ee0d66cddc1a53db88912026d0fffd8b5444a) - removed local error message  inside for and added the button parameter isLoading to show spinner.
[‎ui/src/components/contact/ContactForm.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-6aa3dacaa45b755f45a2d3e6039a44b192777d0cfbc250556c49e5375ad8f4d6) - fix the effect run on getting data or error and updated loading state.
[‎ui/src/components/operator/OperatorDashboard.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-a27eede5a7b5a06f362d0cfc6d690e5ff6dd13e2a854ada62fbe2c1e8ea69f53) - updated loading state as spinner
[‎ui/__tests__/components/auth/Signin.test.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-1b276de55b302b7ad0d18b67abc75b5341183ab9eb006673480b9ace4fb3a9e7) , [‎ui/__tests__/components/contact/ContactForm.test.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-597cba85470c61b5532ded4867d393a465b179ff69e6b75cc6a3337bee79ac60) , [‎ui/__tests__/components/operatordashboard/OperatorDashboard.test.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-3d9022887c87bce9eabbe81599c14ce9a97078314be7477e50bc17e4d6b42ce4) - tests for loading states
- Docs codeblock bug 
[‎ui/src/page/documentation/CodeBlock.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-6784845332233e5118c60b68e24a89f5c2f713d09de6c1adf68e86b8572370b0) , [‎ui/src/page/documentation/Documentation.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-b5d544da872c2d62b739d98b7ce94ff2cd186376f7c09665ad7fbc48be6cd1ca) - moved the select language state to parent component.
[‎ui/__tests__/page/documentation/CodeBlock.test.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-c214c897bd74cb8da2334e5a8e8e4881a6e7d4ef3863a467a31806b8c5b360f0) - codeblock test update.
- User Info form input field validation
[‎ui/src/components/userinfo/UserInfo.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-48ba87b4e6118a6648a8f76e013d2d44ad75a8204445d35342fa281855dc5462) - added userinfo form validation in client side.
[‎ui/__tests__/components/UserInfo.test.jsx](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-d40151559944f1f475e5e4318e473b68d1f51ab4175cea9dc269f654d1196d1f) - test typo mismatch update.
- Operator card styling fix
[‎ui/src/components/operatorcard/OperatorCard.module.css](https://github.com/TeamShiksha/openlogo/pull/817/files#diff-1aeafd762d1e52d34358a008b74425602e08d30da71bd627740be7be7e2615eb) 

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix
- [x] ✅ Test

## Screenshots (if applicable)
[fix_#185.webm](https://github.com/user-attachments/assets/60b0daf2-a589-42ec-a5ea-f14df02e6bbd)

<img width="1581" height="703" alt="Screenshot from 2025-08-26 22-58-21" src="https://github.com/user-attachments/assets/1425569c-2c35-437e-bda6-aa78ce0b4e41" />
<img width="1581" height="703" alt="Screenshot from 2025-08-26 22-58-47" src="https://github.com/user-attachments/assets/e9de8c90-a493-43e8-bf09-2a19904a4964" />


## Checklist
- [x] I have performed a self-review of my code  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
