### PR TITLE
fix(usage-count): prevent increment when logo fetch returns 404

### DIFF
--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -138,4 +138,24 @@ describe("getLogoController", () => {
     const response = await request(app).get(apiUrl).query(baseQuery);
     expect(response.status).toBe(500);
   });
+
+  it("should handle unexpected errors if usage count is null or undefined", async () => {
+    mockRepetedService(mockSubscription[0]);
+
+    jest
+      .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
+      .mockResolvedValue(imageUrl);
+
+    jest
+      .spyOn(SubscriptionService.prototype, "incrementUsageCount")
+      .mockResolvedValue(null);
+
+    const response = await request(app).get(apiUrl).query(baseQuery);
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: Messages.INTERNAL_SERVER_ERROR,
+      statusCode: 500,
+      error: STATUS_CODES[500],
+    });
+  });
 });

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -59,7 +59,15 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-    await subscriptionService.incrementUsageCount(userSubscription);
+    const updatedUsageCount =
+      await subscriptionService.incrementUsageCount(userSubscription);
+    if (!updatedUsageCount) {
+      return res.status(500).json({
+        message: Messages.INTERNAL_SERVER_ERROR,
+        statusCode: 500,
+        error: STATUS_CODES[500],
+      });
+    }
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -52,7 +52,6 @@ async function getLogoController(req, res, next) {
     }
 
     const imageUrl = await imageService.fetchImageByCompanyFree(company);
-    await subscriptionService.incrementUsageCount(userSubscription);
     if (!imageUrl) {
       return res.status(404).json({
         message: Messages.LOGO_NOT_FOUND,
@@ -60,7 +59,7 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-
+    await subscriptionService.incrementUsageCount(userSubscription);
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/ui/src/components/common/input/CustomInput.module.css
+++ b/packages/ui/src/components/common/input/CustomInput.module.css
@@ -52,7 +52,7 @@
 .group-input:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px var(--primary-focus); 
+  box-shadow: 0 0 0 2px var(--primary-focus);
 }
 
 /* Active label states */


### PR DESCRIPTION
## Description
Fixes #823 
This PR updates the GET /logo route so that the monthly usage count is only incremented when the response is successful (200). Previously, the count was incremented even when a 404 was returned, which incorrectly consumed the user’s quota for failed fetch attempts.

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix
- [ ] 👨‍💻 Code Refactor
- [ ]  🍕 Feature
- [ ] 🐛 Bug Fix
- [ ]  📄 Documentation Update
- [ ]  👨‍💻 Code Refactor
- [ ]  🔥 Performance Improvements
- [ ]  ✅ Test
- [ ]  🛠️ CI/CD
## Screenshots (if applicable)

https://github.com/user-attachments/assets/bb1166f5-dcbf-4234-88f0-d7f3eed2ee5e



## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
