### PR TITLE
add variant prop to button

### DIFF
--- a/packages/ui/src/components/currentplan/CurrentPlan.jsx
+++ b/packages/ui/src/components/currentplan/CurrentPlan.jsx
@@ -12,6 +12,7 @@ function CurrentPlan({ isGuest }) {
 
       <Button
         className={styles["upgrade-button"]}
+        variant={"primary"}
         disabled={keepBtnDisabled || isGuest}
         style={{ cursor: isGuest ? "default" : "pointer" }}
       >


### PR DESCRIPTION
## Description
Fixes https://github.com/TeamShiksha/openlogo/issues/827

This PR updates the `CurrentPlan` component to pass the `variant="primary"` prop to its `Button`.

Previously, the Button was rendered without a `variant`, which triggered a React prop-type warning and.  
With this fix, the Button now correctly uses the primary variant, ensuring consistent styles and removing the warning.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
