### PR TITLE
feat: add disclaimer with Terms and Privacy links to SignUp form

### DIFF
--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -302,7 +302,7 @@ it("renders the disclaimer with Terms and Privacy links", () => {
     </BrowserRouter>
   );
 
-  const disclaimer = screen.getByText(/By clicking Sign Up, you agree to our/i);
+  const disclaimer = screen.getByText(/By Signing Up, you agree to our/i);
   expect(disclaimer).toBeInTheDocument();
 
   const termsLink = screen.getByText("Terms of Service");

--- a/packages/ui/__tests__/components/auth/Signup.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signup.test.jsx
@@ -289,3 +289,53 @@ describe("SignUpForm UI and Functionality Tests", () => {
     });
   });
 });
+
+it("renders the disclaimer with Terms and Privacy links", () => {
+  const authContext = mockAuthContext(false);
+  render(
+    <BrowserRouter>
+      <AuthContext.Provider value={authContext}>
+        <ToastProvider>
+          <SignUpForm toggleForm={vi.fn()} onClose={vi.fn()} />
+        </ToastProvider>
+      </AuthContext.Provider>
+    </BrowserRouter>
+  );
+
+  const disclaimer = screen.getByText(/By clicking Sign Up, you agree to our/i);
+  expect(disclaimer).toBeInTheDocument();
+
+  const termsLink = screen.getByText("Terms of Service");
+  expect(termsLink).toBeInTheDocument();
+  expect(
+    termsLink.getAttribute("to") || termsLink.getAttribute("href")
+  ).toContain("terms");
+
+  const privacyLink = screen.getByText("Privacy Policy");
+  expect(privacyLink).toBeInTheDocument();
+  expect(
+    privacyLink.getAttribute("to") || privacyLink.getAttribute("href")
+  ).toContain("privacy");
+});
+
+it("navigates to Terms and Privacy sections on link click", () => {
+  const onCloseMock = vi.fn();
+  const authContext = mockAuthContext(false);
+  render(
+    <BrowserRouter>
+      <AuthContext.Provider value={authContext}>
+        <ToastProvider>
+          <SignUpForm toggleForm={vi.fn()} onClose={onCloseMock} />
+        </ToastProvider>
+      </AuthContext.Provider>
+    </BrowserRouter>
+  );
+
+  const termsLink = screen.getByText("Terms of Service");
+  fireEvent.click(termsLink);
+  expect(onCloseMock).toHaveBeenCalled();
+
+  const privacyLink = screen.getByText("Privacy Policy");
+  fireEvent.click(privacyLink);
+  expect(onCloseMock).toHaveBeenCalled();
+});

--- a/packages/ui/src/components/auth/SignForm.module.css
+++ b/packages/ui/src/components/auth/SignForm.module.css
@@ -89,3 +89,25 @@
 .cross:hover {
   opacity: 0.8;
 }
+
+.disclaimer-container {
+  margin: 0px 0 12px 4px;
+  display: flex;
+  align-items: flex-start;
+}
+
+.disclaimer-label {
+  font-size: 0.6rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.disclaimer-label a {
+  color: var(--primary);
+  text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.disclaimer-label a:hover {
+  color: var(--black);
+}

--- a/packages/ui/src/components/auth/SignForm.module.css
+++ b/packages/ui/src/components/auth/SignForm.module.css
@@ -91,15 +91,16 @@
 }
 
 .disclaimer-container {
-  margin: 0px 0 12px 4px;
+  margin: 0px 5px 12px 4px;
   display: flex;
   align-items: flex-start;
 }
 
 .disclaimer-label {
-  font-size: 0.6rem;
+  font-size: 0.8rem;
   color: #555;
   line-height: 1.5;
+  text-align: center;
 }
 
 .disclaimer-label a {

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -4,11 +4,13 @@ import Button from "../common/button/Button";
 import PropTypes from "prop-types";
 import { SIGNUP, BUTTON_TEXT, MESSAGES } from "../../utils/Constants";
 import styles from "./SignForm.module.css";
-import { validate } from "../../utils/Helpers";
+import { handleNavigation, validate } from "../../utils/Helpers";
 import { useApi } from "../../hooks/useApi";
 import { useToast } from "../../hooks/useToast.js";
+import { Link, useNavigate } from "react-router-dom";
 
-function SignUp({ toggleForm }) {
+function SignUp({ toggleForm, onClose }) {
+  const navigate = useNavigate();
   const toast = useToast();
   const [formValues, setFormValues] = useState(SIGNUP.initialValues);
   const [formErrors, setFormErrors] = useState({});
@@ -93,6 +95,31 @@ function SignUp({ toggleForm }) {
               disabled={isLoading}
             />
           ))}
+        </div>
+        <div className={styles["disclaimer-container"]}>
+          <label htmlFor="agree-terms" className={styles["disclaimer-label"]}>
+            By clicking Sign Up, you agree to our{" "}
+            <Link
+              to={SIGNUP.termsUrl}
+              onClick={(event) => {
+                onClose();
+                handleNavigation(event, SIGNUP.termsUrl, navigate);
+              }}
+            >
+              Terms of Service
+            </Link>{" "}
+            and that you have read our{" "}
+            <Link
+              to={SIGNUP.privacyUrl}
+              onClick={(event) => {
+                onClose();
+                handleNavigation(event, SIGNUP.privacyUrl, navigate);
+              }}
+            >
+              Privacy Policy
+            </Link>
+            .
+          </label>
         </div>
         <Button
           type="submit"

--- a/packages/ui/src/components/auth/Signup.jsx
+++ b/packages/ui/src/components/auth/Signup.jsx
@@ -98,7 +98,7 @@ function SignUp({ toggleForm, onClose }) {
         </div>
         <div className={styles["disclaimer-container"]}>
           <label htmlFor="agree-terms" className={styles["disclaimer-label"]}>
-            By clicking Sign Up, you agree to our{" "}
+            By Signing Up, you agree to our{" "}
             <Link
               to={SIGNUP.termsUrl}
               onClick={(event) => {

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -439,6 +439,8 @@ export const PRIVACY_AND_TERMS = [
 
 export const SIGNUP = {
   title: "Sign up for free",
+  termsUrl: "/privacy#terms",
+  privacyUrl: "/privacy#privacy",
   fields: [
     { type: "text", name: "name", label: "Name" },
     { type: "email", name: "email", label: "Email" },


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
#835 
This PR adds a legal disclaimer to the signup form, requiring users to acknowledge and agree to the Terms of Service and Privacy Policy before creating an account. The disclaimer includes direct links to the relevant sections, improving transparency and compliance.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->



https://github.com/user-attachments/assets/461eae57-6479-4330-a5d0-42533729cb03


<img width="669" height="27" alt="image" src="https://github.com/user-attachments/assets/95ee0277-9a63-4201-a4e0-c35e27089cf7" />


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
