### PR TITLE
feat: Allow operators to upload logos

### DIFF
--- a/packages/app/__tests__/controllers/catalog/addlogo.js
+++ b/packages/app/__tests__/controllers/catalog/addlogo.js
@@ -48,6 +48,86 @@ describe("POST /api/catalog/logo", () => {
     });
   });
 
+  it("200 - Admin should successfully upload a new logo", async () => {
+    const mockAdmin = new Users(MOCK_USERS[2]); // Admin user
+    const token = mockAdmin.generateJWT();
+    const mockBuffer = Buffer.from("test image");
+    const mockFileName = "GOOGLE.png";
+    const mockImageData = {
+      _id: "mock-image-id",
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn(ImageService.prototype, "getImageByCompanyName")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(ImageService.prototype, "uploadToS3")
+      .mockResolvedValue("logos/png/GOOGLE.png");
+    jest
+      .spyOn(ImageService.prototype, "createImageData")
+      .mockResolvedValue(mockImageData);
+
+    const res = await request(app)
+      .post("/api/catalog/logo")
+      .set("Cookie", `jwt=${token}`)
+      .field("companyUri", "https://validcompany.com/")
+      .attach("logo", mockBuffer, mockFileName);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      statusCode: 200,
+      message: Messages.UPLOAD_SUCCESS,
+      data: mockImageData,
+    });
+  });
+
+  it("200 - Operator should successfully upload a new logo", async () => {
+    const mockOperator = new Users(MOCK_USERS[3]); // Operator user
+    const token = mockOperator.generateJWT();
+    const mockBuffer = Buffer.from("test image");
+    const mockFileName = "YAHOO.png";
+    const mockImageData = {
+      _id: "mock-image-id-2",
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn(ImageService.prototype, "getImageByCompanyName")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(ImageService.prototype, "uploadToS3")
+      .mockResolvedValue("logos/png/YAHOO.png");
+    jest
+      .spyOn(ImageService.prototype, "createImageData")
+      .mockResolvedValue(mockImageData);
+
+    const res = await request(app)
+      .post("/api/catalog/logo")
+      .set("Cookie", `jwt=${token}`)
+      .field("companyUri", "https://yahoo.com/")
+      .attach("logo", mockBuffer, mockFileName);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe(Messages.UPLOAD_SUCCESS);
+  });
+
+  it("401 - Customer should be unauthorized to upload a logo", async () => {
+    const mockCustomer = new Users(MOCK_USERS[1]); // Customer user
+    const token = mockCustomer.generateJWT();
+    const mockBuffer = Buffer.from("test image");
+    const mockFileName = "customer-logo.png";
+
+    const res = await request(app)
+      .post("/api/catalog/logo")
+      .set("Cookie", `jwt=${token}`)
+      .field("companyUri", "https://customer.com/")
+      .attach("logo", mockBuffer, mockFileName);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe("Unauthorized");
+  });
+
   it("500 - createImageData fails", async () => {
     const mockAdmin = new Users(MOCK_USERS[2]); // Admin user
     const token = mockAdmin.generateJWT();

--- a/packages/app/__tests__/controllers/catalog/updatelogo.js
+++ b/packages/app/__tests__/controllers/catalog/updatelogo.js
@@ -21,6 +21,54 @@ describe("PUT /api/catalog/logo", () => {
     delete process.env.CLIENT_PROXY_URL;
   });
 
+  it("200 - Operator should update an image successfully", async () => {
+    const mockOperator = new Users(MOCK_USERS[3]); // Operator User
+    const token = mockOperator.generateJWT();
+    const mockBuffer = Buffer.from("test image");
+    const mockFileName = "MICROSOFT.png";
+    const mockImage = new Images(MOCK_IMAGES[1]);
+    const mockImageData = {
+      _id: mockImage._id.toString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn(ImageService.prototype, "getImageById")
+      .mockResolvedValue(mockImage);
+    jest
+      .spyOn(ImageService.prototype, "uploadToS3")
+      .mockResolvedValue("logos/png/MICROSOFT.png");
+    jest
+      .spyOn(ImageService.prototype, "updateImageById")
+      .mockResolvedValue(mockImageData);
+
+    const response = await request(app)
+      .put("/api/catalog/logo")
+      .set("Cookie", `jwt=${token}`)
+      .attach("logo", mockBuffer, mockFileName)
+      .field("id", mockImage._id.toString());
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe(Messages.UPLOAD_SUCCESS);
+  });
+
+  it("401 - Customer should be unauthorized to update a logo", async () => {
+    const mockCustomer = new Users(MOCK_USERS[1]); // Customer user
+    const token = mockCustomer.generateJWT();
+    const mockBuffer = Buffer.from("test image");
+    const mockFileName = "customer-logo.png";
+    const mockImage = new Images(MOCK_IMAGES[2]);
+
+    const response = await request(app)
+      .put("/api/catalog/logo")
+      .set("Cookie", `jwt=${token}`)
+      .attach("logo", mockBuffer, mockFileName)
+      .field("id", mockImage._id.toString());
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe("Unauthorized");
+  });
+
   it("422 - Image is required", async () => {
     const mockUserModel = new Users(MOCK_USERS[2]);
     const mockToken = mockUserModel.generateJWT();

--- a/packages/app/routes/catalog.js
+++ b/packages/app/routes/catalog.js
@@ -25,7 +25,7 @@ router.get(
 router.get("/logos", authMiddleware({ adminOnly: true }), getCatalogController);
 router.post(
   "/logo",
-  authMiddleware({ roles: [UserType.ADMIN, UserType.OPERATOR] }), // To allow the admin, oprator to upload the image
+  authMiddleware({ roles: [UserType.ADMIN, UserType.OPERATOR] }),
   upload.single("logo"),
   addCatalogController
 );

--- a/packages/app/routes/catalog.js
+++ b/packages/app/routes/catalog.js
@@ -8,6 +8,7 @@ const {
   addCatalogController,
   getAnalyticsController,
 } = require("../controllers/catalog");
+const { UserType } = require("../utils/constants");
 
 router.put(
   "/permission/:userId/roles/:role",
@@ -24,13 +25,13 @@ router.get(
 router.get("/logos", authMiddleware({ adminOnly: true }), getCatalogController);
 router.post(
   "/logo",
-  authMiddleware({ adminOnly: true }),
+  authMiddleware({ roles: [UserType.ADMIN, UserType.OPERATOR] }), // To allow the admin, oprator to upload the image
   upload.single("logo"),
   addCatalogController
 );
 router.put(
   "/logo",
-  authMiddleware({ adminOnly: true }),
+  authMiddleware({ roles: [UserType.ADMIN, UserType.OPERATOR] }),
   upload.single("logo"),
   updateCatalogController
 );


### PR DESCRIPTION
## Description
Resolves #834.

This PR updates the backend authorization logic to allow users with the OPERATOR role to upload and update logos in the catalog.

The changes are focused on the following:

Modified the authMiddleware on the POST /api/catalog/logo and PUT /api/catalog/logo routes in app/routes/catalog.js to include the OPERATOR role alongside the existing ADMIN role.

Added new test cases to the corresponding controller tests to verify the new permissions. The tests confirm that Operators can now access these endpoints and that Customers are correctly denied access, ensuring no security risks.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [x] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="1341" height="720" alt="screenshot-2025-09-13_20-51-55" src="https://github.com/user-attachments/assets/56ee6c83-cde6-41e3-b0cf-73e075c3e01c" />


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
