### PR TITLE
Bugfix/usage count

### DIFF
--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -122,3 +122,79 @@ describe("getLogoController", () => {
     });
   });
 });
+
+describe("getLogoController - Operations Order Test", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "Your_JWT_SECRET";
+    process.env.CLIENT_PROXY_URL = "http://localhost:3000";
+    process.env.KEY = "logos";
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+    delete process.env.CLIENT_PROXY_URL;
+    delete process.env.KEY;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const apiUrl = "/api/logo";
+
+  it("should ensure image is fetched before usage count is incremented - operations order test", async () => {
+    const operationsOrder = [];
+    const imageUrl = "https://cdn.myapp.com/png/GOOGLE.png?v=1755253230000";
+
+    const mockKeyRef = {
+      subscription_id: "test_subscription_id",
+      ...MOCK_KEYS[0],
+    };
+
+    jest.spyOn(KeyService.prototype, "getApiKey").mockResolvedValue(mockKeyRef);
+
+    const mockSubscription = {
+      usage_count: 5,
+      usage_limit: 100,
+      ...MOCK_SUBSCRIPTION[0],
+    };
+
+    jest
+      .spyOn(SubscriptionService.prototype, "getSubscription")
+      .mockResolvedValue(mockSubscription);
+
+    jest
+      .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
+      .mockImplementation(() => {
+        operationsOrder.push("image_fetched");
+        return imageUrl;
+      });
+
+    jest
+      .spyOn(SubscriptionService.prototype, "incrementUsageCount")
+      .mockImplementation(() => {
+        operationsOrder.push("usage_count_incremented");
+        return Promise.resolve();
+      });
+
+    const baseQuery = {
+      API_KEY: MOCK_KEYS[1].key,
+      key: "https://google.com",
+    };
+
+    const response = await request(app).get(apiUrl).query(baseQuery);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      statusCode: 200,
+      data: imageUrl,
+    });
+
+    expect(operationsOrder).toEqual([
+      "image_fetched",
+      "usage_count_incremented",
+    ]);
+    expect(operationsOrder[0]).toBe("image_fetched");
+    expect(operationsOrder[1]).toBe("usage_count_incremented");
+  });
+});

--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -139,7 +139,7 @@ describe("getLogoController", () => {
     expect(response.status).toBe(500);
   });
 
-  it("should handle unexpected errors if usage count is null or undefined", async () => {
+  it("should return 500 if incrementUsageCount returns a falsy value", async () => {
     mockRepetedService(mockSubscription[0]);
 
     jest
@@ -151,11 +151,10 @@ describe("getLogoController", () => {
       .mockResolvedValue(null);
 
     const response = await request(app).get(apiUrl).query(baseQuery);
+
     expect(response.status).toBe(500);
-    expect(response.body).toEqual({
-      message: Messages.INTERNAL_SERVER_ERROR,
-      statusCode: 500,
-      error: STATUS_CODES[500],
-    });
+    expect(response.body.message).toBe(
+      "Could not process request. Failed to update usage."
+    );
   });
 });

--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -138,4 +138,24 @@ describe("getLogoController", () => {
     const response = await request(app).get(apiUrl).query(baseQuery);
     expect(response.status).toBe(500);
   });
+
+  it("should handle unexpected errors if usage count is null or undefined", async () => {
+    mockRepetedService(mockSubscription[0]);
+
+    jest
+      .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
+      .mockResolvedValue(imageUrl);
+
+    jest
+      .spyOn(SubscriptionService.prototype, "incrementUsageCount")
+      .mockResolvedValue(null);
+
+    const response = await request(app).get(apiUrl).query(baseQuery);
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: Messages.INTERNAL_SERVER_ERROR,
+      statusCode: 500,
+      error: STATUS_CODES[500],
+    });
+  });
 });

--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -121,40 +121,4 @@ describe("getLogoController", () => {
       data: imageUrl,
     });
   });
-
-  it("500-unexpected error", async () => {
-    mockRepetedService(mockSubscription[0]);
-
-    jest
-      .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
-      .mockResolvedValue(imageUrl);
-
-    jest
-      .spyOn(SubscriptionService.prototype, "incrementUsageCount")
-      .mockImplementation(() => {
-        throw new Error("Boom!");
-      });
-
-    const response = await request(app).get(apiUrl).query(baseQuery);
-    expect(response.status).toBe(500);
-  });
-
-  it("should return 500 if incrementUsageCount returns a falsy value", async () => {
-    mockRepetedService(mockSubscription[0]);
-
-    jest
-      .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
-      .mockResolvedValue(imageUrl);
-
-    jest
-      .spyOn(SubscriptionService.prototype, "incrementUsageCount")
-      .mockResolvedValue(null);
-
-    const response = await request(app).get(apiUrl).query(baseQuery);
-
-    expect(response.status).toBe(500);
-    expect(response.body.message).toBe(
-      "Could not process request. Failed to update usage."
-    );
-  });
 });

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -59,7 +59,15 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-    await subscriptionService.incrementUsageCount(userSubscription);
+    const updatedUsageCount =
+      await subscriptionService.incrementUsageCount(userSubscription);
+    if (!updatedUsageCount) {
+      return res.status(500).json({
+        message: Messages.INTERNAL_SERVER_ERROR,
+        statusCode: 500,
+        error: STATUS_CODES[500],
+      });
+    }
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -60,21 +60,9 @@ async function getLogoController(req, res, next) {
       });
     }
 
-    try {
-      const updatedSubscription =
-        await subscriptionService.incrementUsageCount(userSubscription);
-      if (!updatedSubscription) {
-        throw new Error("Operation returned null/undefined");
-      }
-    } catch (err) {
+    subscriptionService.incrementUsageCount(userSubscription).catch((err) => {
       console.error("Failed to increment usage count:", err.message);
-      return res.status(500).json({
-        message: "Could not process request. Failed to update usage.",
-        statusCode: 500,
-        error: STATUS_CODES[500],
-      });
-    }
-
+    });
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -59,15 +59,22 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-    const updatedUsageCount =
-      await subscriptionService.incrementUsageCount(userSubscription);
-    if (!updatedUsageCount) {
+
+    try {
+      const updatedSubscription =
+        await subscriptionService.incrementUsageCount(userSubscription);
+      if (!updatedSubscription) {
+        throw new Error("Operation returned null/undefined");
+      }
+    } catch (err) {
+      console.error("Failed to increment usage count:", err.message);
       return res.status(500).json({
-        message: Messages.INTERNAL_SERVER_ERROR,
+        message: "Could not process request. Failed to update usage.",
         statusCode: 500,
         error: STATUS_CODES[500],
       });
     }
+
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -52,7 +52,6 @@ async function getLogoController(req, res, next) {
     }
 
     const imageUrl = await imageService.fetchImageByCompanyFree(company);
-    await subscriptionService.incrementUsageCount(userSubscription);
     if (!imageUrl) {
       return res.status(404).json({
         message: Messages.LOGO_NOT_FOUND,
@@ -60,7 +59,7 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-
+    await subscriptionService.incrementUsageCount(userSubscription);
     return res.status(200).json({
       statusCode: 200,
       data: imageUrl,

--- a/packages/ui/src/components/common/input/CustomInput.module.css
+++ b/packages/ui/src/components/common/input/CustomInput.module.css
@@ -52,7 +52,7 @@
 .group-input:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px var(--primary-focus); 
+  box-shadow: 0 0 0 2px var(--primary-focus);
 }
 
 /* Active label states */


### PR DESCRIPTION
## Description
Issue No: #823 
Continues the work from PR: #826 

This PR updates the logic in getLogoController so that the incrementUsageCount operation does not block the API response.

### Problem: 
Previously, we awaited the completion of the incrementUsageCount database operation. This unnecessarily increased the response time for the GET /logo route, and if the counting operation failed, the entire request would fail with a 500 error, even if the image URL had been successfully fetched for the user.

### Solution: 
In this PR, we have removed the await. Now, as soon as the image URL is available, we immediately send a 200 OK response to the user. The incrementUsageCount task is initiated in the background, and if any error occurs, it is only logged on the server without impacting the user's experience.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [x] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
https://github.com/user-attachments/assets/bb1166f5-dcbf-4234-88f0-d7f3eed2ee5e

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
