### PR TITLE
feat(operator-dashboard): add image upload option on the operator dashboard

### DIFF
--- a/packages/ui/src/components/operator/OperatorDashboard.jsx
+++ b/packages/ui/src/components/operator/OperatorDashboard.jsx
@@ -7,8 +7,10 @@ import { instance } from "../../api/api_instance";
 import { validate } from "../../utils/Helpers";
 import Button from "../common/button/Button";
 import { useToast } from "../../hooks/useToast";
-import { BUTTON_TEXT, MODAL_MESSAGES } from "../../utils/Constants";
+import { BUTTON_TEXT, MESSAGES, MODAL_MESSAGES } from "../../utils/Constants";
 import Dropdown from "../common/dropdown/Dropdown";
+import ImageUploadModal from "../catalog/ImageUploadModal";
+import { useApi } from "../../hooks/useApi";
 
 const createPayload = (searchType, responseText, responseAction) => {
   const status = responseAction === "respond" ? "RESOLVED" : "REJECTED";
@@ -44,6 +46,7 @@ const Operator = () => {
   const [focusedField, setFocusedField] = useState(null);
   const [isFormValid, setIsFormValid] = useState(false);
   const [responseAction, setResponseAction] = useState("respond");
+  const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const toast = useToast();
   const OperatorDashboardDropdownOptions = ["messages", "requests"];
 
@@ -209,6 +212,40 @@ const Operator = () => {
     setResponseText(e.target.value);
   };
 
+  const {
+    loading: uploadLoading,
+    makeRequest: uploadMakeRequest,
+    errorMsg: uploadErrorMsg,
+  } = useApi({
+    method: "POST",
+    url: `/catalog/logo`,
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+
+  useEffect(() => {
+    if (uploadErrorMsg) {
+      toast.error(uploadErrorMsg);
+    }
+  }, [uploadErrorMsg, toast]);
+
+  const handleImageUpload = async ({ file, companyUri }) => {
+    if (!file || !companyUri) return;
+
+    const formData = new FormData();
+    formData.append("logo", file);
+    formData.append("companyUri", companyUri);
+
+    try {
+      const success = await uploadMakeRequest({ data: formData });
+      if (success) {
+        setIsUploadModalOpen(false);
+        toast.success(MESSAGES.IMAGE_UPLOAD_SUCCESS);
+      }
+    } catch (err) {
+      console.error("Upload error:", err);
+    }
+  };
+
   let modalTitle;
   if (responseAction === "respond") {
     if (searchType === "messages") {
@@ -281,7 +318,23 @@ const Operator = () => {
           className={styles["type-selector"]}
         />
       </div>
-
+      <Button
+        onClick={() => {
+          setIsUploadModalOpen(true);
+        }}
+        variant="primary"
+        className={styles["catalog-add-image-btn"]}
+      >
+        Add image
+      </Button>
+      <ImageUploadModal
+        isOpen={isUploadModalOpen}
+        onClose={() => {
+          setIsUploadModalOpen(false);
+        }}
+        onUpload={handleImageUpload}
+        isLoading={uploadLoading}
+      />
       {contentToRender}
 
       {totalPages > 1 && (

--- a/packages/ui/src/components/operator/OperatorDashboard.module.css
+++ b/packages/ui/src/components/operator/OperatorDashboard.module.css
@@ -188,6 +188,11 @@
   width: 100%;
 }
 
+.catalog-add-image-btn {
+  width: 160px;
+  max-height: 45px;
+}
+
 @media (max-width: 768px) {
   .header {
     flex-direction: column;


### PR DESCRIPTION
## Description
This PR adds a button on the operator dashboard which lets the Operators upload images from their dashboard.
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
Closes #834 
## What type of PR is this? (Check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="1919" height="958" alt="image" src="https://github.com/user-attachments/assets/63b9ee90-f5fc-43b7-bdfc-4db5501bdf30" />

https://github.com/user-attachments/assets/da358699-9e14-4553-b2eb-23e2ffec0944


## Checklist
- [X] I have performed a self-review of my code  
- [X] I have commented my code, particularly in hard-to-understand areas  
- [X] I have added tests that prove my fix is effective or that my feature works  
- [X] New and existing unit tests pass locally with my changes
