### PR TITLE
Deletion tenure to prevent immediate re-registration

### DIFF
--- a/packages/app/__tests__/controllers/auth/signin.js
+++ b/packages/app/__tests__/controllers/auth/signin.js
@@ -45,9 +45,7 @@ describe("SIGNIN API", () => {
   });
 
   it("404 - Incorrect email or password", async () => {
-    jest
-      .spyOn(UserService.prototype, "getAnyUserByEmail")
-      .mockResolvedValue(null);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
 
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
@@ -69,9 +67,7 @@ describe("SIGNIN API", () => {
       generateJWT: jest.fn().mockReturnValue("jwt-token"),
     };
 
-    jest
-      .spyOn(UserService.prototype, "getAnyUserByEmail")
-      .mockResolvedValue(user);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(user);
 
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
@@ -94,9 +90,7 @@ describe("SIGNIN API", () => {
       generateJWT: jest.fn().mockReturnValue("jwt-token"),
     };
 
-    jest
-      .spyOn(UserService.prototype, "getAnyUserByEmail")
-      .mockResolvedValue(user);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(user);
 
     const INVAILD = "wrongpassword";
     const response = await request(app)
@@ -120,9 +114,7 @@ describe("SIGNIN API", () => {
       generateJWT: jest.fn().mockReturnValue("jwt-token"),
     };
 
-    jest
-      .spyOn(UserService.prototype, "getAnyUserByEmail")
-      .mockResolvedValue(user);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(user);
 
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)

--- a/packages/app/__tests__/controllers/auth/signin.js
+++ b/packages/app/__tests__/controllers/auth/signin.js
@@ -71,9 +71,10 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
+    const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: user.email, password: "password123" });
+      .send({ email: user.email, password: TESTPASSWORD });
 
     expect(response.status).toBe(403);
     expect(response.body).toEqual({
@@ -96,9 +97,10 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
+    const INVAILD = "wrongpassword";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: user.email, password: "wrongpassword" });
+      .send({ email: user.email, password: INVAILD });
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({
@@ -121,9 +123,10 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
+    const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: user.email, password: "password123" });
+      .send({ email: user.email, password: TESTPASSWORD });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ statusCode: 200 });

--- a/packages/app/__tests__/controllers/auth/signin.js
+++ b/packages/app/__tests__/controllers/auth/signin.js
@@ -73,7 +73,6 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
-    // const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
       .send({ email: user.email, password: dummyPassword });
@@ -125,7 +124,6 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
-    // const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
       .send({ email: user.email, password: dummyPassword });

--- a/packages/app/__tests__/controllers/auth/signin.js
+++ b/packages/app/__tests__/controllers/auth/signin.js
@@ -6,6 +6,8 @@ const { ENDPOINTS } = require("../../../utils/testconstants");
 const { MOCK_USERS } = require("../../../utils/mocks");
 const { Messages } = require("../../../utils/constants");
 const app = require("../../../server");
+const dummyPassword =
+  require("../../../utils/generatePassword").generatePassword();
 
 describe("SIGNIN API", () => {
   beforeAll(() => {
@@ -71,10 +73,10 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
-    const TESTPASSWORD = "password123";
+    // const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: user.email, password: TESTPASSWORD });
+      .send({ email: user.email, password: dummyPassword });
 
     expect(response.status).toBe(403);
     expect(response.body).toEqual({
@@ -123,10 +125,10 @@ describe("SIGNIN API", () => {
       .spyOn(UserService.prototype, "getAnyUserByEmail")
       .mockResolvedValue(user);
 
-    const TESTPASSWORD = "password123";
+    // const TESTPASSWORD = "password123";
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: user.email, password: TESTPASSWORD });
+      .send({ email: user.email, password: dummyPassword });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ statusCode: 200 });

--- a/packages/app/__tests__/controllers/auth/signin.js
+++ b/packages/app/__tests__/controllers/auth/signin.js
@@ -43,7 +43,10 @@ describe("SIGNIN API", () => {
   });
 
   it("404 - Incorrect email or password", async () => {
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+    jest
+      .spyOn(UserService.prototype, "getAnyUserByEmail")
+      .mockResolvedValue(null);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
       .send({ email: "email@example.com", password: "password" });
@@ -57,28 +60,45 @@ describe("SIGNIN API", () => {
   });
 
   it("403 - Email not verified", async () => {
+    const user = {
+      ...MOCK_USERS[0],
+      is_verified: false,
+      matchPassword: jest.fn().mockResolvedValue(true),
+      generateJWT: jest.fn().mockReturnValue("jwt-token"),
+    };
+
     jest
-      .spyOn(UserService.prototype, "getUserByEmail")
-      .mockResolvedValue(MOCK_USERS[0]);
+      .spyOn(UserService.prototype, "getAnyUserByEmail")
+      .mockResolvedValue(user);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: "johndoe@example.com", password: "password123" });
+      .send({ email: user.email, password: "password123" });
 
     expect(response.status).toBe(403);
     expect(response.body).toEqual({
       error: STATUS_CODES[403],
-      message: "Email not verified",
+      message: Messages.EMAIL_NOT_VERIFIED,
       statusCode: 403,
     });
   });
 
-  it("404 - Incorrect email or password", async () => {
+  it("404 - Incorrect password", async () => {
+    const user = {
+      ...MOCK_USERS[1],
+      is_verified: true,
+      is_deleted: false,
+      matchPassword: jest.fn().mockResolvedValue(false),
+      generateJWT: jest.fn().mockReturnValue("jwt-token"),
+    };
+
     jest
-      .spyOn(UserService.prototype, "getUserByEmail")
-      .mockImplementation(() => new Users(MOCK_USERS[1]));
+      .spyOn(UserService.prototype, "getAnyUserByEmail")
+      .mockResolvedValue(user);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: "johndoe1@example.com", password: "password122" });
+      .send({ email: user.email, password: "wrongpassword" });
 
     expect(response.status).toBe(404);
     expect(response.body).toEqual({
@@ -89,17 +109,24 @@ describe("SIGNIN API", () => {
   });
 
   it("200 - Signin successful", async () => {
+    const user = {
+      ...MOCK_USERS[1],
+      is_verified: true,
+      is_deleted: false,
+      matchPassword: jest.fn().mockResolvedValue(true),
+      generateJWT: jest.fn().mockReturnValue("jwt-token"),
+    };
+
     jest
-      .spyOn(UserService.prototype, "getUserByEmail")
-      .mockImplementation(() => new Users(MOCK_USERS[1]));
+      .spyOn(UserService.prototype, "getAnyUserByEmail")
+      .mockResolvedValue(user);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNIN)
-      .send({ email: "johndoe1@example.com", password: "password123" });
+      .send({ email: user.email, password: "password123" });
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      statusCode: 200,
-    });
+    expect(response.body).toEqual({ statusCode: 200 });
     expect(response.headers["set-cookie"]).toBeDefined();
   });
 

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -203,22 +203,28 @@ describe("SIGNUP API", () => {
     });
   });
 
-  it("500 - Failed creating user", async () => {
+  it("500 - Failed creating verification token", async () => {
+    // Changed title from "201" to "500"
     const mockRequest = { ...SIGNUP_PAYLOAD };
     jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(MOCK_SUBSCRIPTION[0]);
-    jest.spyOn(UserService.prototype, "createUser").mockResolvedValue(null);
+    jest
+      .spyOn(UserService.prototype, "createUser")
+      .mockResolvedValue(MOCK_USERS[1]);
+    jest
+      .spyOn(UserTokenService.prototype, "createUserToken")
+      .mockResolvedValue(null);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(500); // Changed from 201
     expect(response.body).toEqual({
-      error: STATUS_CODES[500],
       message: Messages.SOMETHING_WENT_WRONG,
-      statusCode: 500,
+      statusCode: 500, // Changed from 201
     });
   });
 
@@ -238,10 +244,10 @@ describe("SIGNUP API", () => {
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(500);
     expect(response.body).toEqual({
       message: Messages.SOMETHING_WENT_WRONG,
-      statusCode: 201,
+      statusCode: 500,
     });
   });
 
@@ -266,8 +272,8 @@ describe("SIGNUP API", () => {
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
-    expect(response.status).toBe(200);
-    expect(response.body.statusCode).toBe(200);
+    expect(response.status).toBe(201);
+    expect(response.body.statusCode).toBe(201);
     expect(sendEmail).toHaveBeenCalledWith({
       id: 2,
       subject: "Openlogo: Email Verification",
@@ -303,8 +309,8 @@ describe("SIGNUP API", () => {
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
-    expect(response.status).toBe(200);
-    expect(response.body.statusCode).toBe(200);
+    expect(response.status).toBe(201);
+    expect(response.body.statusCode).toBe(201);
   });
 
   it("400 - Deleted user within block period cannot signup", async () => {
@@ -361,7 +367,7 @@ describe("SIGNUP API", () => {
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
-    expect(response.status).toBe(200);
-    expect(response.body.statusCode).toBe(200);
+    expect(response.status).toBe(201);
+    expect(response.body.statusCode).toBe(201);
   });
 });

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -169,6 +169,11 @@ describe("SIGNUP API", () => {
       .spyOn(UserService.prototype, "getUserByEmail")
       .mockResolvedValue(existingUser);
 
+    jest
+      .spyOn(SubscriptionService.prototype, "createSubscription")
+      .mockResolvedValue({
+        _id: "sub123",
+      });
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -393,7 +393,7 @@ describe("SIGNUP API", () => {
     const daysLeft = Math.ceil(expiry.diff(dayjs(), "day", true));
 
     expect(response.body.message).toBe(
-      `Account exists. You may re-register after ${daysLeft} day${daysLeft > 1 ? "s" : ""}.`
+      `Account exists. You may re-register after ${daysLeft} days.`
     );
   });
 });

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -1,6 +1,6 @@
 const request = require("supertest");
 const { STATUS_CODES } = require("http");
-// const { UserToken } = require("../../../models");
+
 const {
   UserTokenService,
   UserService,

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -159,9 +159,15 @@ describe("SIGNUP API", () => {
 
   it("400 - Email already registered", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD, email: "testname@gmail.com" };
+
+    const existingUser = {
+      email: "testname@gmail.com",
+      is_deleted: false,
+    };
+
     jest
-      .spyOn(UserService.prototype, "canRegister")
-      .mockRejectedValue(new Error(Messages.EMAIL_EXISTS));
+      .spyOn(UserService.prototype, "getUserByEmail")
+      .mockResolvedValue(existingUser);
 
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
@@ -170,14 +176,14 @@ describe("SIGNUP API", () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       error: STATUS_CODES[400],
-      message: Messages.EMAIL_EXISTS,
+      message: "Account already exists.",
       statusCode: 400,
     });
   });
 
   it("500 - Failed creating subscription", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(null);
@@ -194,7 +200,7 @@ describe("SIGNUP API", () => {
 
   it("500 - Failed creating user", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(MOCK_SUBSCRIPTION[0]);
@@ -213,7 +219,7 @@ describe("SIGNUP API", () => {
 
   it("201 - Failed creating verificiation token", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(MOCK_SUBSCRIPTION[0]);
@@ -236,7 +242,7 @@ describe("SIGNUP API", () => {
 
   it("200 - User created successfully", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue({ _id: "mockSubId" });
@@ -272,7 +278,7 @@ describe("SIGNUP API", () => {
       ...SIGNUP_PAYLOAD,
       email: process.env.ADMINSEMAILS.split(",")[0],
     };
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue({ _id: "mockSubId" });
@@ -299,25 +305,38 @@ describe("SIGNUP API", () => {
   it("400 - Deleted user within block period cannot signup", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD, email: "deleted@example.com" };
 
-    const blockMessage = "Account exists. You may re-register after 5 days.";
+    // Deleted user within the 30-day tenure
+    const deletedUser = {
+      email: "deleted@example.com",
+      is_deleted: true,
+      deleted_at: new Date(), // today, within 30 days
+    };
+
     jest
-      .spyOn(UserService.prototype, "canRegister")
-      .mockRejectedValue(new Error(blockMessage));
+      .spyOn(UserService.prototype, "getUserByEmail")
+      .mockResolvedValue(deletedUser);
 
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
 
+    const tenureDays = 30;
+    const expiry = new Date(deletedUser.deleted_at);
+    expiry.setDate(expiry.getDate() + tenureDays);
+    const daysLeft = Math.ceil((expiry - new Date()) / (1000 * 60 * 60 * 24));
+
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(STATUS_CODES[400]);
     expect(response.body.statusCode).toBe(400);
-    expect(response.body.message).toBe(blockMessage);
+    expect(response.body.message).toBe(
+      `Account exists. You may re-register after ${daysLeft} days.`
+    );
   });
 
   it("200 - Deleted user block expired can signup", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD, email: "deleted@example.com" };
 
-    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue({ _id: "mockSubId" });

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -323,7 +323,7 @@ describe("SIGNUP API", () => {
     const tenureDays = 30;
     const expiry = new Date(deletedUser.deleted_at);
     expiry.setDate(expiry.getDate() + tenureDays);
-    const daysLeft = Math.ceil((expiry - new Date()) / (1000 * 60 * 60 * 24));
+    const daysLeft = Math.ceil((expiry - Date.now()) / (1000 * 60 * 60 * 24));
 
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(STATUS_CODES[400]);

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -15,6 +15,7 @@ const {
 } = require("../../../utils/mocks");
 const app = require("../../../server");
 const sendEmail = require("../../../utils/sendEmail");
+const dayjs = require("dayjs");
 jest.mock("../../../utils/sendEmail");
 const dummyPassword =
   require("../../../utils/generatePassword").generatePassword();
@@ -181,7 +182,7 @@ describe("SIGNUP API", () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       error: STATUS_CODES[400],
-      message: "Account already exists.",
+      message: Messages.EMAIL_EXISTS,
       statusCode: 400,
     });
   });
@@ -369,5 +370,30 @@ describe("SIGNUP API", () => {
 
     expect(response.status).toBe(201);
     expect(response.body.statusCode).toBe(201);
+  });
+
+  it("400 - Deleted user with 1 day left shows singular 'day'", async () => {
+    const mockRequest = { ...SIGNUP_PAYLOAD, email: "deleted@example.com" };
+
+    const deletedUser = {
+      email: "deleted@example.com",
+      is_deleted: true,
+      deleted_at: dayjs().subtract(29, "day").toDate(),
+    };
+
+    jest
+      .spyOn(UserService.prototype, "getUserByEmail")
+      .mockResolvedValue(deletedUser);
+
+    const response = await request(app)
+      .post(ENDPOINTS.SIGNUP)
+      .send(mockRequest);
+
+    const expiry = dayjs(deletedUser.deleted_at).add(30, "day");
+    const daysLeft = Math.ceil(expiry.diff(dayjs(), "day", true));
+
+    expect(response.body.message).toBe(
+      `Account exists. You may re-register after ${daysLeft} day${daysLeft > 1 ? "s" : ""}.`
+    );
   });
 });

--- a/packages/app/__tests__/controllers/auth/signup.js
+++ b/packages/app/__tests__/controllers/auth/signup.js
@@ -1,6 +1,6 @@
 const request = require("supertest");
 const { STATUS_CODES } = require("http");
-const { UserToken } = require("../../../models");
+// const { UserToken } = require("../../../models");
 const {
   UserTokenService,
   UserService,
@@ -14,6 +14,8 @@ const {
   MOCK_USERTOKENS,
 } = require("../../../utils/mocks");
 const app = require("../../../server");
+const sendEmail = require("../../../utils/sendEmail");
+jest.mock("../../../utils/sendEmail");
 const dummyPassword =
   require("../../../utils/generatePassword").generatePassword();
 
@@ -26,6 +28,7 @@ describe("SIGNUP API", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sendEmail.mockResolvedValue(true);
   });
 
   afterAll(() => {
@@ -157,8 +160,9 @@ describe("SIGNUP API", () => {
   it("400 - Email already registered", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD, email: "testname@gmail.com" };
     jest
-      .spyOn(UserService.prototype, "getUserByEmail")
-      .mockResolvedValue(MOCK_USERS[0]);
+      .spyOn(UserService.prototype, "canRegister")
+      .mockRejectedValue(new Error(Messages.EMAIL_EXISTS));
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
@@ -173,7 +177,7 @@ describe("SIGNUP API", () => {
 
   it("500 - Failed creating subscription", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(null);
@@ -190,7 +194,7 @@ describe("SIGNUP API", () => {
 
   it("500 - Failed creating user", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(MOCK_SUBSCRIPTION[0]);
@@ -209,7 +213,7 @@ describe("SIGNUP API", () => {
 
   it("201 - Failed creating verificiation token", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
       .mockResolvedValue(MOCK_SUBSCRIPTION[0]);
@@ -232,16 +236,58 @@ describe("SIGNUP API", () => {
 
   it("200 - User created successfully", async () => {
     const mockRequest = { ...SIGNUP_PAYLOAD };
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
-      .mockResolvedValue(true);
+      .mockResolvedValue({ _id: "mockSubId" });
     jest
       .spyOn(UserService.prototype, "createUser")
       .mockResolvedValue(MOCK_USERS[1]);
+    const mockToken = {
+      ...MOCK_USERTOKENS[0],
+      tokenURL: jest.fn().mockReturnValue("http://example.com/verify-token"),
+    };
     jest
       .spyOn(UserTokenService.prototype, "createUserToken")
-      .mockImplementation(() => new UserToken(MOCK_USERTOKENS[0]));
+      .mockResolvedValue(mockToken);
+
+    const response = await request(app)
+      .post(ENDPOINTS.SIGNUP)
+      .send(mockRequest);
+
+    expect(response.status).toBe(200);
+    expect(response.body.statusCode).toBe(200);
+    expect(sendEmail).toHaveBeenCalledWith({
+      id: 2,
+      subject: "Openlogo: Email Verification",
+      recipient: mockRequest.email,
+      body: {
+        url: "http://example.com/verify-token",
+      },
+    });
+  });
+
+  it("200 - Admin created successfully", async () => {
+    const mockRequest = {
+      ...SIGNUP_PAYLOAD,
+      email: process.env.ADMINSEMAILS.split(",")[0],
+    };
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
+    jest
+      .spyOn(SubscriptionService.prototype, "createSubscription")
+      .mockResolvedValue({ _id: "mockSubId" });
+    jest.spyOn(UserService.prototype, "getRole").mockReturnValue("ADMIN");
+    jest
+      .spyOn(UserService.prototype, "createUser")
+      .mockResolvedValue(MOCK_USERS[2]);
+    const mockToken = {
+      ...MOCK_USERTOKENS[0],
+      tokenURL: jest.fn().mockReturnValue("http://example.com/verify-token"),
+    };
+    jest
+      .spyOn(UserTokenService.prototype, "createUserToken")
+      .mockResolvedValue(mockToken);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);
@@ -250,22 +296,43 @@ describe("SIGNUP API", () => {
     expect(response.body.statusCode).toBe(200);
   });
 
-  it("200 - Admin created successfully", async () => {
-    const mockRequest = {
-      ...SIGNUP_PAYLOAD,
-      email: process.env.ADMINSEMAILS.split(",")[0],
-    };
-    jest.spyOn(UserService.prototype, "getUserByEmail").mockResolvedValue(null);
+  it("400 - Deleted user within block period cannot signup", async () => {
+    const mockRequest = { ...SIGNUP_PAYLOAD, email: "deleted@example.com" };
+
+    const blockMessage = "Account exists. You may re-register after 5 days.";
+    jest
+      .spyOn(UserService.prototype, "canRegister")
+      .mockRejectedValue(new Error(blockMessage));
+
+    const response = await request(app)
+      .post(ENDPOINTS.SIGNUP)
+      .send(mockRequest);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe(STATUS_CODES[400]);
+    expect(response.body.statusCode).toBe(400);
+    expect(response.body.message).toBe(blockMessage);
+  });
+
+  it("200 - Deleted user block expired can signup", async () => {
+    const mockRequest = { ...SIGNUP_PAYLOAD, email: "deleted@example.com" };
+
+    jest.spyOn(UserService.prototype, "canRegister").mockResolvedValue(true);
     jest
       .spyOn(SubscriptionService.prototype, "createSubscription")
-      .mockResolvedValue(true);
-    jest.spyOn(UserService.prototype, "getRole").mockReturnValue("ADMIN");
+      .mockResolvedValue({ _id: "mockSubId" });
     jest
       .spyOn(UserService.prototype, "createUser")
-      .mockResolvedValue(MOCK_USERS[2]);
+      .mockResolvedValue(MOCK_USERS[1]);
+
+    const mockToken = {
+      ...MOCK_USERTOKENS[0],
+      tokenURL: jest.fn().mockReturnValue("http://example.com/verify-token"),
+    };
     jest
       .spyOn(UserTokenService.prototype, "createUserToken")
-      .mockImplementation(() => new UserToken(MOCK_USERTOKENS[0]));
+      .mockResolvedValue(mockToken);
+
     const response = await request(app)
       .post(ENDPOINTS.SIGNUP)
       .send(mockRequest);

--- a/packages/app/__tests__/controllers/users/deleteaccount.js
+++ b/packages/app/__tests__/controllers/users/deleteaccount.js
@@ -20,13 +20,13 @@ describe("Delete User Account", () => {
   it("500 - Unexpected Error", async () => {
     const mockUserModel = new Users(MOCK_USERS[1]);
     const mockToken = mockUserModel.generateJWT();
-    const mockInput = {
-      userId: "mockUserId@123",
-    };
+    const mockInput = { userId: "mockUserId@123" };
+
+    // Spy on the actual function used in controller
     jest
-      .spyOn(UserService.prototype, "deleteUserAccount")
+      .spyOn(UserService.prototype, "markDeleteUser")
       .mockImplementation(() => {
-        throw new Error();
+        throw new Error("Unexpected error");
       });
 
     const response = await request(app)
@@ -37,15 +37,13 @@ describe("Delete User Account", () => {
     expect(response.status).toBe(500);
   });
 
-  it("200- User account deleted", async () => {
+  it("200 - User account deleted", async () => {
     const mockUserModel = new Users(MOCK_USERS[1]);
     const mockToken = mockUserModel.generateJWT();
-    const mockInput = {
-      userId: "mockUserId@123",
-    };
-    jest
-      .spyOn(UserService.prototype, "deleteUserAccount")
-      .mockReturnValue(true);
+    const mockInput = { userId: "mockUserId@123" };
+
+    // Spy on markDeleteUser function
+    jest.spyOn(UserService.prototype, "markDeleteUser").mockResolvedValue(true);
 
     const response = await request(app)
       .delete("/api/user/me")

--- a/packages/app/__tests__/services/users.js
+++ b/packages/app/__tests__/services/users.js
@@ -83,14 +83,14 @@ describe("User Service", () => {
   });
 
   it("deleting user returns false if user not found", async () => {
-    jest.spyOn(UsersRepository.prototype, "softDelete").mockResolvedValue(null);
+    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(null);
     const result = await userService.deleteUserAccount("nonexistent-id");
     expect(result).toBe(false);
   });
 
   it("delete user successfully", async () => {
     const user = new User(MOCK_USERS[0]);
-    jest.spyOn(UsersRepository.prototype, "softDelete").mockResolvedValue(user);
+    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(user);
     const result = await userService.deleteUserAccount(user.id);
     expect(result).toBe(true);
   });

--- a/packages/app/__tests__/services/users.js
+++ b/packages/app/__tests__/services/users.js
@@ -90,9 +90,10 @@ describe("User Service", () => {
 
   it("delete user successfully", async () => {
     const user = { ...MOCK_USERS[0], is_deleted: false, _id: "123" };
-    jest.spyOn(UsersRepository.prototype, "getById").mockResolvedValue(user);
-    jest.spyOn(UserService.prototype, "markDeleteUser").mockResolvedValue(true);
+    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(user);
+    const userService = new UserService();
     const result = await userService.deleteUserAccount(user._id);
+    console.log("Result:", result);
     expect(result).toBe(true);
   });
 

--- a/packages/app/__tests__/services/users.js
+++ b/packages/app/__tests__/services/users.js
@@ -82,22 +82,17 @@ describe("User Service", () => {
     expect(result).toEqual(key);
   });
 
-  it("delete user succesfully", async () => {
-    const user = new User(MOCK_USERS[0]);
-
-    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(user);
-
-    const result = await userService.deleteUserAccount(user.id);
-
-    expect(result).toBe(true);
+  it("deleting user returns false if user not found", async () => {
+    jest.spyOn(UsersRepository.prototype, "softDelete").mockResolvedValue(null);
+    const result = await userService.deleteUserAccount("nonexistent-id");
+    expect(result).toBe(false);
   });
 
-  it("deleting user returns false if user not found", async () => {
-    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(null);
-
-    const result = await userService.deleteUserAccount("nonexistent-id");
-
-    expect(result).toBe(false);
+  it("delete user successfully", async () => {
+    const user = new User(MOCK_USERS[0]);
+    jest.spyOn(UsersRepository.prototype, "softDelete").mockResolvedValue(user);
+    const result = await userService.deleteUserAccount(user.id);
+    expect(result).toBe(true);
   });
 
   it("finds a user with valid email who is registered", async () => {

--- a/packages/app/__tests__/services/users.js
+++ b/packages/app/__tests__/services/users.js
@@ -89,9 +89,10 @@ describe("User Service", () => {
   });
 
   it("delete user successfully", async () => {
-    const user = new User(MOCK_USERS[0]);
-    jest.spyOn(UsersRepository.prototype, "delete").mockResolvedValue(user);
-    const result = await userService.deleteUserAccount(user.id);
+    const user = { ...MOCK_USERS[0], is_deleted: false, _id: "123" };
+    jest.spyOn(UsersRepository.prototype, "getById").mockResolvedValue(user);
+    jest.spyOn(UserService.prototype, "markDeleteUser").mockResolvedValue(true);
+    const result = await userService.deleteUserAccount(user._id);
     expect(result).toBe(true);
   });
 

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -44,7 +44,7 @@ async function signupController(req, res, next) {
     let user = await userService.getUserByEmail(email);
 
     // If the user is active (not deleted), block signup
-    if (user && !user.is_deleted) {
+    if (user?.is_deleted === false) {
       return res.status(400).json({
         message: "Account already exists.",
         error: STATUS_CODES[400],
@@ -52,7 +52,7 @@ async function signupController(req, res, next) {
       });
     }
     // Handle soft-deleted users
-    if (user && user.deleted_at) {
+    if (user?.deleted_at) {
       const tenureDays = 30;
       const expiry = new Date(user.deleted_at);
       expiry.setDate(expiry.getDate() + tenureDays);

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -166,9 +166,9 @@ async function signinController(req, res, next) {
     /** @type {import("express").CookieOptions}  */
     const cookieOptions = {
       expires: oneDayValidityTimestamp,
-      // sameSite: "strict",
-      // httpOnly: true,
-      // domain: ".openlogo.fyi",
+      sameSite: "strict",
+      httpOnly: true,
+      domain: ".openlogo.fyi",
     };
 
     res.cookie("jwt", user.generateJWT(), cookieOptions);
@@ -199,9 +199,9 @@ function signoutController(req, res, next) {
 
     /** @type {import("express").CookieOptions}  */
     const cookieOptions = {
-      // sameSite: "strict",
-      // httpOnly: true,
-      // domain: ".openlogo.fyi",
+      sameSite: "strict",
+      httpOnly: true,
+      domain: ".openlogo.fyi",
     };
 
     res.clearCookie("jwt", cookieOptions);

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -13,7 +13,7 @@ const {
 } = require("../schemas/auth");
 const sendEmail = require("../utils/sendEmail");
 const { Messages } = require("../utils/constants");
-const User = require("../models/users");
+const dayjs = require("dayjs");
 /**
  * This controller validates the signup payload, checks if the email already exists,
  * creates a new subscription, registers a new user, and send a verification email.
@@ -36,10 +36,10 @@ async function signupController(req, res, next) {
     const { email } = value;
     let user = await userService.getUserByEmail(email);
 
-    // If the user is active (not deleted), block signup
+    // If the user is active block signup
     if (user?.is_deleted === false) {
       return res.status(400).json({
-        message: "Account already exists.",
+        message: Messages.EMAIL_EXISTS,
         error: STATUS_CODES[400],
         statusCode: 400,
       });
@@ -48,22 +48,16 @@ async function signupController(req, res, next) {
     // Handle soft-deleted users
     if (user?.deleted_at) {
       const tenureDays = 30;
-      const expiry = new Date(user.deleted_at);
-      expiry.setDate(expiry.getDate() + tenureDays);
-
-      if (expiry > new Date()) {
-        const daysLeft = Math.ceil(
-          (expiry - Date.now()) / (1000 * 60 * 60 * 24)
-        );
+      const expiry = dayjs(user.deleted_at).add(tenureDays, "day");
+      if (expiry.isAfter(dayjs())) {
+        const daysLeft = expiry.diff(dayjs(), "day") + 1;
         return res.status(400).json({
-          message: `Account exists. You may re-register after ${daysLeft} days.`,
+          message: `Account exists. You may re-register after ${daysLeft} day${daysLeft > 1 ? "s" : ""}.`,
           error: STATUS_CODES[400],
           statusCode: 400,
         });
       }
-
-      await User.deleteOne({ _id: user._id });
-      user = null;
+      await userService.deleteUserAccount(user._id);
     }
 
     // Create subscription only after validation passes
@@ -78,7 +72,6 @@ async function signupController(req, res, next) {
     Object.assign(value, { subscription_id: newSubscription._id });
     const newUser = await userService.createUser(value);
     if (!newUser) {
-      await subscriptionService.deleteSubscription(newSubscription._id);
       return res.status(500).json({
         message: Messages.SOMETHING_WENT_WRONG,
         error: STATUS_CODES[500],
@@ -106,7 +99,7 @@ async function signupController(req, res, next) {
     });
 
     return res.status(201).json({
-      message: "User created successfully. Please verify your email.",
+      message: Messages.USER_CREATED,
       statusCode: 201,
     });
   } catch (err) {

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -33,10 +33,11 @@ async function signupController(req, res, next) {
     }
 
     const { email } = value;
-    const emailExists = await userService.getUserByEmail(email);
-    if (emailExists) {
+    try {
+      await userService.canRegister(email);
+    } catch (tenureError) {
       return res.status(400).json({
-        message: Messages.EMAIL_EXISTS,
+        message: tenureError.message,
         error: STATUS_CODES[400],
         statusCode: 400,
       });
@@ -110,19 +111,27 @@ async function signinController(req, res, next) {
           error: STATUS_CODES[422],
         });
       const { email, password } = value;
-      user = await userService.getUserByEmail(email);
+      user = await userService.getAnyUserByEmail(email);
       if (!user)
         return res.status(404).json({
           error: STATUS_CODES[404],
           message: Messages.INCORRECT_EMAIL_PASS,
           statusCode: 404,
         });
+
       if (!user.is_verified)
         return res.status(403).json({
           error: STATUS_CODES[403],
           message: Messages.EMAIL_NOT_VERIFIED,
           statusCode: 403,
         });
+      if (user.is_deleted) {
+        return res.status(400).json({
+          error: STATUS_CODES[400],
+          message: "This email is already used",
+          statusCode: 400,
+        });
+      }
       const matchPassword = await user.matchPassword(password);
       if (!matchPassword) {
         return res.status(404).json({
@@ -140,9 +149,9 @@ async function signinController(req, res, next) {
     /** @type {import("express").CookieOptions}  */
     const cookieOptions = {
       expires: oneDayValidityTimestamp,
-      sameSite: "strict",
-      httpOnly: true,
-      domain: ".openlogo.fyi",
+      // sameSite: "strict",
+      // httpOnly: true,
+      // domain: ".openlogo.fyi",
     };
 
     res.cookie("jwt", user.generateJWT(), cookieOptions);
@@ -173,9 +182,9 @@ function signoutController(req, res, next) {
 
     /** @type {import("express").CookieOptions}  */
     const cookieOptions = {
-      sameSite: "strict",
-      httpOnly: true,
-      domain: ".openlogo.fyi",
+      // sameSite: "strict",
+      // httpOnly: true,
+      // domain: ".openlogo.fyi",
     };
 
     res.clearCookie("jwt", cookieOptions);

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -23,6 +23,7 @@ async function signupController(req, res, next) {
     const userService = new UserService();
     const userTokenService = new UserTokenService();
     const subscriptionService = new SubscriptionService();
+
     const { error, value } = signupPayloadSchema.validate(req.body);
     if (error) {
       return res.status(422).json({
@@ -32,15 +33,7 @@ async function signupController(req, res, next) {
       });
     }
 
-    const newSubscription = await subscriptionService.createSubscription();
-    if (!newSubscription) {
-      return res.status(500).json({
-        message: Messages.SOMETHING_WENT_WRONG,
-        statusCode: 500,
-      });
-    }
-
-    const { email, password, name } = value;
+    const { email } = value;
     let user = await userService.getUserByEmail(email);
 
     // If the user is active (not deleted), block signup
@@ -51,11 +44,13 @@ async function signupController(req, res, next) {
         statusCode: 400,
       });
     }
+
     // Handle soft-deleted users
     if (user?.deleted_at) {
       const tenureDays = 30;
       const expiry = new Date(user.deleted_at);
       expiry.setDate(expiry.getDate() + tenureDays);
+
       if (expiry > new Date()) {
         const daysLeft = Math.ceil(
           (expiry - Date.now()) / (1000 * 60 * 60 * 24)
@@ -66,23 +61,24 @@ async function signupController(req, res, next) {
           statusCode: 400,
         });
       }
+
       await User.deleteOne({ _id: user._id });
       user = null;
     }
 
-    if (user) {
-      await userService.createUser({
-        name,
-        email,
-        password,
-        subscription_id: newSubscription._id,
+    // Create subscription only after validation passes
+    const newSubscription = await subscriptionService.createSubscription();
+    if (!newSubscription) {
+      return res.status(500).json({
+        message: Messages.SOMETHING_WENT_WRONG,
+        statusCode: 500,
       });
-      return res.status(201).json({ message: "User created successfully." });
     }
 
     Object.assign(value, { subscription_id: newSubscription._id });
     const newUser = await userService.createUser(value);
     if (!newUser) {
+      await subscriptionService.deleteSubscription(newSubscription._id);
       return res.status(500).json({
         message: Messages.SOMETHING_WENT_WRONG,
         error: STATUS_CODES[500],
@@ -94,9 +90,9 @@ async function signupController(req, res, next) {
       newUser._id
     );
     if (!verificationToken) {
-      return res.status(201).json({
+      return res.status(500).json({
         message: Messages.SOMETHING_WENT_WRONG,
-        statusCode: 201,
+        statusCode: 500,
       });
     }
 
@@ -109,7 +105,10 @@ async function signupController(req, res, next) {
       },
     });
 
-    return res.status(200).json({ statusCode: 200 });
+    return res.status(201).json({
+      message: "User created successfully. Please verify your email.",
+      statusCode: 201,
+    });
   } catch (err) {
     next(err);
   }

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -13,7 +13,7 @@ const {
 } = require("../schemas/auth");
 const sendEmail = require("../utils/sendEmail");
 const { Messages } = require("../utils/constants");
-
+const User = require("../models/users");
 /**
  * This controller validates the signup payload, checks if the email already exists,
  * creates a new subscription, registers a new user, and send a verification email.
@@ -32,10 +32,19 @@ async function signupController(req, res, next) {
       });
     }
 
-    const { email } = value;
-    const user = await userService.getUserByEmail(email);
+    const newSubscription = await subscriptionService.createSubscription();
+    if (!newSubscription) {
+      return res.status(500).json({
+        message: Messages.SOMETHING_WENT_WRONG,
+        statusCode: 500,
+      });
+    }
+
+    const { email, password, name } = value;
+    let user = await userService.getUserByEmail(email);
 
     if (user) {
+      // If the user is active (not deleted), block signup
       if (!user.is_deleted) {
         return res.status(400).json({
           message: "Account already exists.",
@@ -43,6 +52,7 @@ async function signupController(req, res, next) {
           statusCode: 400,
         });
       }
+      // Handle soft-deleted users
       if (user.deleted_at) {
         const tenureDays = 30;
         const expiry = new Date(user.deleted_at);
@@ -56,16 +66,21 @@ async function signupController(req, res, next) {
             error: STATUS_CODES[400],
             statusCode: 400,
           });
+        } else {
+          await User.deleteOne({ _id: user._id });
+          user = null;
         }
       }
-    }
 
-    const newSubscription = await subscriptionService.createSubscription();
-    if (!newSubscription) {
-      return res.status(500).json({
-        message: Messages.SOMETHING_WENT_WRONG,
-        statusCode: 500,
-      });
+      if (!user) {
+        await userService.createUser({
+          name,
+          email,
+          password,
+          subscription_id: newSubscription._id,
+        });
+        return res.status(201).json({ message: "User created successfully." });
+      }
     }
 
     Object.assign(value, { subscription_id: newSubscription._id });

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -33,14 +33,31 @@ async function signupController(req, res, next) {
     }
 
     const { email } = value;
-    try {
-      await userService.canRegister(email);
-    } catch (tenureError) {
-      return res.status(400).json({
-        message: tenureError.message,
-        error: STATUS_CODES[400],
-        statusCode: 400,
-      });
+    const user = await userService.getUserByEmail(email);
+
+    if (user) {
+      if (!user.is_deleted) {
+        return res.status(400).json({
+          message: "Account already exists.",
+          error: STATUS_CODES[400],
+          statusCode: 400,
+        });
+      }
+      if (user.deleted_at) {
+        const tenureDays = 30;
+        const expiry = new Date(user.deleted_at);
+        expiry.setDate(expiry.getDate() + tenureDays);
+        if (expiry > new Date()) {
+          const daysLeft = Math.ceil(
+            (expiry - new Date()) / (1000 * 60 * 60 * 24)
+          );
+          return res.status(400).json({
+            message: `Account exists. You may re-register after ${daysLeft} days.`,
+            error: STATUS_CODES[400],
+            statusCode: 400,
+          });
+        }
+      }
     }
 
     const newSubscription = await subscriptionService.createSubscription();
@@ -111,7 +128,7 @@ async function signinController(req, res, next) {
           error: STATUS_CODES[422],
         });
       const { email, password } = value;
-      user = await userService.getAnyUserByEmail(email);
+      user = await userService.getUserByEmail(email);
       if (!user)
         return res.status(404).json({
           error: STATUS_CODES[404],
@@ -128,7 +145,7 @@ async function signinController(req, res, next) {
       if (user.is_deleted) {
         return res.status(400).json({
           error: STATUS_CODES[400],
-          message: "This email is already used",
+          message: "Account does not exist.",
           statusCode: 400,
         });
       }

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -43,44 +43,41 @@ async function signupController(req, res, next) {
     const { email, password, name } = value;
     let user = await userService.getUserByEmail(email);
 
-    if (user) {
-      // If the user is active (not deleted), block signup
-      if (!user.is_deleted) {
+    // If the user is active (not deleted), block signup
+    if (user && !user.is_deleted) {
+      return res.status(400).json({
+        message: "Account already exists.",
+        error: STATUS_CODES[400],
+        statusCode: 400,
+      });
+    }
+    // Handle soft-deleted users
+    if (user && user.deleted_at) {
+      const tenureDays = 30;
+      const expiry = new Date(user.deleted_at);
+      expiry.setDate(expiry.getDate() + tenureDays);
+      if (expiry > new Date()) {
+        const daysLeft = Math.ceil(
+          (expiry - Date.now()) / (1000 * 60 * 60 * 24)
+        );
         return res.status(400).json({
-          message: "Account already exists.",
+          message: `Account exists. You may re-register after ${daysLeft} days.`,
           error: STATUS_CODES[400],
           statusCode: 400,
         });
       }
-      // Handle soft-deleted users
-      if (user.deleted_at) {
-        const tenureDays = 30;
-        const expiry = new Date(user.deleted_at);
-        expiry.setDate(expiry.getDate() + tenureDays);
-        if (expiry > new Date()) {
-          const daysLeft = Math.ceil(
-            (expiry - Date.now()) / (1000 * 60 * 60 * 24)
-          );
-          return res.status(400).json({
-            message: `Account exists. You may re-register after ${daysLeft} days.`,
-            error: STATUS_CODES[400],
-            statusCode: 400,
-          });
-        } else {
-          await User.deleteOne({ _id: user._id });
-          user = null;
-        }
-      }
+      await User.deleteOne({ _id: user._id });
+      user = null;
+    }
 
-      if (!user) {
-        await userService.createUser({
-          name,
-          email,
-          password,
-          subscription_id: newSubscription._id,
-        });
-        return res.status(201).json({ message: "User created successfully." });
-      }
+    if (user) {
+      await userService.createUser({
+        name,
+        email,
+        password,
+        subscription_id: newSubscription._id,
+      });
+      return res.status(201).json({ message: "User created successfully." });
     }
 
     Object.assign(value, { subscription_id: newSubscription._id });

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -49,7 +49,7 @@ async function signupController(req, res, next) {
         expiry.setDate(expiry.getDate() + tenureDays);
         if (expiry > new Date()) {
           const daysLeft = Math.ceil(
-            (expiry - new Date()) / (1000 * 60 * 60 * 24)
+            (expiry - Date.now()) / (1000 * 60 * 60 * 24)
           );
           return res.status(400).json({
             message: `Account exists. You may re-register after ${daysLeft} days.`,

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -34,7 +34,7 @@ async function signupController(req, res, next) {
     }
 
     const { email } = value;
-    let user = await userService.getUserByEmail(email);
+    const user = await userService.getUserByEmail(email);
 
     // If the user is active block signup
     if (user?.is_deleted === false) {
@@ -52,7 +52,7 @@ async function signupController(req, res, next) {
       if (expiry.isAfter(dayjs())) {
         const daysLeft = expiry.diff(dayjs(), "day") + 1;
         return res.status(400).json({
-          message: `Account exists. You may re-register after ${daysLeft} day${daysLeft > 1 ? "s" : ""}.`,
+          message: `Account exists. You may re-register after ${daysLeft} days.`,
           error: STATUS_CODES[400],
           statusCode: 400,
         });
@@ -149,7 +149,7 @@ async function signinController(req, res, next) {
       if (user.is_deleted) {
         return res.status(400).json({
           error: STATUS_CODES[400],
-          message: "Account does not exist.",
+          message: Messages.ACCOUNT_DOESNT_EXISTS,
           statusCode: 400,
         });
       }

--- a/packages/app/controllers/users.js
+++ b/packages/app/controllers/users.js
@@ -116,7 +116,7 @@ async function deleteUserAccountController(req, res, next) {
   try {
     const userService = new UserService();
     const { userId } = req.userData;
-    await userService.deleteUserAccount(userId);
+    await userService.markDeleteUser(userId);
     let cookieOptions = {
       sameSite: "none",
       secure: true,

--- a/packages/app/models/users.js
+++ b/packages/app/models/users.js
@@ -42,10 +42,21 @@ const userSchema = new mongoose.Schema({
     type: [mongoose.Schema.Types.ObjectId],
     ref: "keys",
   },
+
   is_deleted: {
     type: Boolean,
     default: false,
   },
+
+  deleted_at: {
+    type: Date,
+    default: null,
+  },
+  block_until: {
+    type: Date,
+    default: null,
+  },
+
   updated_at: {
     type: Date,
     required: true,

--- a/packages/app/models/users.js
+++ b/packages/app/models/users.js
@@ -42,12 +42,10 @@ const userSchema = new mongoose.Schema({
     type: [mongoose.Schema.Types.ObjectId],
     ref: "keys",
   },
-
   is_deleted: {
     type: Boolean,
     default: false,
   },
-
   deleted_at: {
     type: Date,
     default: null,

--- a/packages/app/models/users.js
+++ b/packages/app/models/users.js
@@ -52,11 +52,6 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: null,
   },
-  block_until: {
-    type: Date,
-    default: null,
-  },
-
   updated_at: {
     type: Date,
     required: true,

--- a/packages/app/repositories/base.js
+++ b/packages/app/repositories/base.js
@@ -44,18 +44,15 @@ class BaseRepository {
   }
 
   async update(id, data) {
-    return await this.model.findByIdAndUpdate(id, data, { new: true });
+    return await this.model.findByIdAndUpdate(id, data);
   }
 
   async delete(id) {
-    return await this.model.findByIdAndUpdate(
-      id,
-      {
-        is_deleted: true,
-        deleted_at: new Date(),
-      },
-      { new: true }
-    );
+    return await this.model.findByIdAndDelete(id);
+  }
+
+  async mark_deleted(id) {
+    return await this.model.findByIdAndUpdate(id, { isDeleted: true });
   }
 }
 

--- a/packages/app/repositories/base.js
+++ b/packages/app/repositories/base.js
@@ -41,20 +41,11 @@ class BaseRepository {
   }
 
   async delete(id) {
-    return await this.model.findByIdAndDelete(id);
-  }
-
-  //Tenure-based soft delete
-  async softDelete(id, tenureDays = 30) {
-    const blockUntil = new Date();
-    blockUntil.setDate(blockUntil.getDate() + tenureDays);
-
     return await this.model.findByIdAndUpdate(
       id,
       {
         is_deleted: true,
         deleted_at: new Date(),
-        block_until: blockUntil,
       },
       { new: true }
     );

--- a/packages/app/repositories/base.js
+++ b/packages/app/repositories/base.js
@@ -37,15 +37,27 @@ class BaseRepository {
   }
 
   async update(id, data) {
-    return await this.model.findByIdAndUpdate(id, data);
+    return await this.model.findByIdAndUpdate(id, data, { new: true });
   }
 
   async delete(id) {
     return await this.model.findByIdAndDelete(id);
   }
 
-  async mark_deleted(id) {
-    return await this.model.findByIdAndUpdate(id, { isDeleted: true });
+  //Tenure-based soft delete
+  async softDelete(id, tenureDays = 30) {
+    const blockUntil = new Date();
+    blockUntil.setDate(blockUntil.getDate() + tenureDays);
+
+    return await this.model.findByIdAndUpdate(
+      id,
+      {
+        is_deleted: true,
+        deleted_at: new Date(),
+        block_until: blockUntil,
+      },
+      { new: true }
+    );
   }
 }
 

--- a/packages/app/repositories/users.js
+++ b/packages/app/repositories/users.js
@@ -21,11 +21,6 @@ class UsersRepository extends BaseRepository {
     return await this.model.findOne({ email });
   }
 
-  //delete user with tenure
-  delete(userId) {
-    return super.delete(userId);
-  }
-
   /**
    *
    * @returns {Promise<number>} - Total number of users.

--- a/packages/app/repositories/users.js
+++ b/packages/app/repositories/users.js
@@ -17,17 +17,13 @@ class UsersRepository extends BaseRepository {
    * @param {string} emailId - The email address to search for.
    * @returns {Promise<Object|null>} - Returns the user document if found, otherwise null.
    */
-  async findUserByEmail(emailId) {
-    return await this.model.findOne({ email: emailId, is_deleted: false });
-  }
-
-  async findAnyUserByEmail(email) {
+  async findUserByEmail(email) {
     return await this.model.findOne({ email });
   }
 
-  //Soft delete user with tenure
-  softDelete(userId, tenureDays = 30) {
-    return super.softDelete(userId, tenureDays);
+  //delete user with tenure
+  delete(userId, tenureDays = 30) {
+    return super.delete(userId, tenureDays);
   }
 
   /**

--- a/packages/app/repositories/users.js
+++ b/packages/app/repositories/users.js
@@ -22,8 +22,8 @@ class UsersRepository extends BaseRepository {
   }
 
   //delete user with tenure
-  delete(userId, tenureDays = 30) {
-    return super.delete(userId, tenureDays);
+  delete(userId) {
+    return super.delete(userId);
   }
 
   /**

--- a/packages/app/repositories/users.js
+++ b/packages/app/repositories/users.js
@@ -21,6 +21,15 @@ class UsersRepository extends BaseRepository {
     return await this.model.findOne({ email: emailId, is_deleted: false });
   }
 
+  async findAnyUserByEmail(email) {
+    return await this.model.findOne({ email });
+  }
+
+  //Soft delete user with tenure
+  softDelete(userId, tenureDays = 30) {
+    return super.softDelete(userId, tenureDays);
+  }
+
   /**
    *
    * @returns {Promise<number>} - Total number of users.

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -91,30 +91,8 @@ class UserService {
    * @returns {boolean} - true if user was successfully deleted.
    */
   async deleteUserAccount(userId) {
-    const TENURE_DAYS = 30;
-    const deletedUser = await this.userRepository.softDelete(
-      userId,
-      TENURE_DAYS
-    );
+    const deletedUser = await this.userRepository.delete(userId);
     return deletedUser ? true : false;
-  }
-
-  async canRegister(email) {
-    const user = await this.userRepository.findAnyUserByEmail(email);
-
-    if (!user) return true;
-
-    if (!user.is_deleted) throw new Error("Account already exists.");
-
-    if (user.block_until && user.block_until > new Date()) {
-      const daysLeft = Math.ceil(
-        (user.block_until - new Date()) / (1000 * 60 * 60 * 24)
-      );
-      throw new Error(
-        `Account exists. You may re-register after ${daysLeft} days.`
-      );
-    }
-    return true;
   }
 
   /**
@@ -128,10 +106,6 @@ class UserService {
   /**
    * Fetches a user by email, including deleted users.
    */
-  async getAnyUserByEmail(email) {
-    return await this.userRepository.findAnyUserByEmail(email);
-  }
-
   async getGuestUser() {
     return await this.userRepository.getGuestUser();
   }

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -87,7 +87,7 @@ class UserService {
   }
 
   /*
-   * Soft delete a user: marks as deleted and adds deleted_at timestamp.
+   * Marks `is_deleted` attribute of the user to true and adds deleted_at timestamp.
    * @param {string} userId - The user id to soft delete.
    * @returns {boolean} - true if user was successfully soft deleted.
    */
@@ -104,25 +104,8 @@ class UserService {
    * @returns {boolean} - true if user was successfully deleted.
    */
   async deleteUserAccount(userId) {
-    const user = await this.userRepository.getById(userId);
-
-    // Soft delete if not already deleted
-    if (user?.is_deleted === false) {
-      return this.markDeleteUser(userId);
-    }
-
-    // If already deleted, check tenure expiry
-    const TENURE_DAYS = 30;
-    if (user?.is_deleted && user?.deleted_at) {
-      const expiry = dayjs(user.deleted_at).add(TENURE_DAYS, "day");
-
-      if (expiry.isBefore(dayjs())) {
-        const deletedUser = await this.userRepository.delete(userId);
-        return !!deletedUser;
-      }
-    }
-
-    return false;
+    const deletedUser = await this.userRepository.delete(userId);
+    return !!deletedUser;
   }
 
   /**
@@ -133,10 +116,7 @@ class UserService {
   async getUserByEmail(email) {
     return await this.userRepository.findUserByEmail(email);
   }
-  /**
-   * Fetch a user by email, including soft-deleted users.
-   * @returns {Promise<Object|null>} - The user document if found, otherwise null.
-   */
+
   async getGuestUser() {
     return await this.userRepository.getGuestUser();
   }

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcryptjs");
 const KeyService = require("../services/keys");
 const { UsersRepository } = require("../repositories");
 const { UserType } = require("../utils/constants");
+const dayjs = require("dayjs");
 class UserService {
   constructor() {
     this.userRepository = new UsersRepository();
@@ -85,14 +86,43 @@ class UserService {
     return destroyedKey;
   }
 
-  /**
+  /*
+   * Soft delete a user: marks as deleted and adds deleted_at timestamp.
+   * @param {string} userId - The user id to soft delete.
+   * @returns {boolean} - true if user was successfully soft deleted.
+   */
+  async markDeleteUser(userId) {
+    const deletedUser = await this.userRepository.update(userId, {
+      is_deleted: true,
+      deleted_at: new Date(),
+    });
+    return deletedUser ? true : false;
+  }
+  /*
    * Delete a User Account.
    * @param {string} userId - The user id to delete.
    * @returns {boolean} - true if user was successfully deleted.
    */
   async deleteUserAccount(userId) {
-    const deletedUser = await this.userRepository.delete(userId);
-    return deletedUser ? true : false;
+    const user = await this.userRepository.getById(userId);
+
+    // Soft delete if not already deleted
+    if (user?.is_deleted === false) {
+      return this.markDeleteUser(userId);
+    }
+
+    // If already deleted, check tenure expiry
+    const TENURE_DAYS = 30;
+    if (user?.is_deleted && user?.deleted_at) {
+      const expiry = dayjs(user.deleted_at).add(TENURE_DAYS, "day");
+
+      if (expiry.isBefore(dayjs())) {
+        const deletedUser = await this.userRepository.delete(userId);
+        return deletedUser ? true : false;
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -104,7 +134,8 @@ class UserService {
     return await this.userRepository.findUserByEmail(email);
   }
   /**
-   * Fetches a user by email, including deleted users.
+   * Fetch a user by email, including soft-deleted users.
+   * @returns {Promise<Object|null>} - The user document if found, otherwise null.
    */
   async getGuestUser() {
     return await this.userRepository.getGuestUser();

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -91,8 +91,30 @@ class UserService {
    * @returns {boolean} - true if user was successfully deleted.
    */
   async deleteUserAccount(userId) {
-    const deletedUser = await this.userRepository.delete(userId);
+    const TENURE_DAYS = 30;
+    const deletedUser = await this.userRepository.softDelete(
+      userId,
+      TENURE_DAYS
+    );
     return deletedUser ? true : false;
+  }
+
+  async canRegister(email) {
+    const user = await this.userRepository.findAnyUserByEmail(email);
+
+    if (!user) return true;
+
+    if (!user.is_deleted) throw new Error("Account already exists.");
+
+    if (user.block_until && user.block_until > new Date()) {
+      const daysLeft = Math.ceil(
+        (user.block_until - new Date()) / (1000 * 60 * 60 * 24)
+      );
+      throw new Error(
+        `Account exists. You may re-register after ${daysLeft} days.`
+      );
+    }
+    return true;
   }
 
   /**
@@ -102,6 +124,12 @@ class UserService {
    */
   async getUserByEmail(email) {
     return await this.userRepository.findUserByEmail(email);
+  }
+  /**
+   * Fetches a user by email, including deleted users.
+   */
+  async getAnyUserByEmail(email) {
+    return await this.userRepository.findAnyUserByEmail(email);
   }
 
   async getGuestUser() {

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -96,7 +96,7 @@ class UserService {
       is_deleted: true,
       deleted_at: new Date(),
     });
-    return deletedUser ? true : false;
+    return !!deletedUser;
   }
   /*
    * Delete a User Account.
@@ -118,7 +118,7 @@ class UserService {
 
       if (expiry.isBefore(dayjs())) {
         const deletedUser = await this.userRepository.delete(userId);
-        return deletedUser ? true : false;
+        return !!deletedUser;
       }
     }
 

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -77,6 +77,7 @@ const Messages = {
   INTERNAL_SERVER_ERROR:
     "An unexpected error occurred. Please try again later.",
   FORM_ALREADY_SUBMITTED: "Form already submitted, try again later",
+  USER_CREATED: "User created successfully. Please verify your email.",
   EMAIL_REQUIRED: "Email is required",
   NAME_REQUIRED: "Name is required",
   INVALID_EMAIL: "Invalid email",

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -47,6 +47,7 @@ const Messages = {
   INVALID_USER_ID: "Invalid user id.",
   EMAIL_EXISTS: "Email already exists.",
   EMAIL_DOESNT_EXISTS: "Email doesn't exists.",
+  ACCOUNT_DOESNT_EXISTS: "Account does not exist.",
   USER_NOT_FOUND: "User not found.",
   DATA_NOT_FOUND: "User data not found.",
   SOMETHING_WENT_WRONG:


### PR DESCRIPTION
## Description

Currently, deleted users can potentially re-register immediately, which may lead to abuse or confusion. Implementing a soft delete with a configurable block period:

Closes: #848

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)

https://github.com/user-attachments/assets/74d09d59-9bc7-4577-b6bf-9db1388750e7









## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
