### PR TITLE
feat:  add images available in admin dashboard

### DIFF
--- a/packages/app/__tests__/controllers/catalog/analytics.js
+++ b/packages/app/__tests__/controllers/catalog/analytics.js
@@ -5,6 +5,7 @@ const {
   RequestService,
   SubscriptionService,
   ContactUsService,
+  ImageService,
 } = require("../../../services");
 const app = require("../../../server");
 const jwt = require("jsonwebtoken");
@@ -56,6 +57,10 @@ describe("GET /api/catalog/stats", () => {
     jest
       .spyOn(ContactUsService.prototype, "getFormsCount")
       .mockResolvedValue(MOCK_ANALYTICS_DATA_INPUT[3].value);
+
+    jest
+      .spyOn(ImageService.prototype, "getImagesCount")
+      .mockResolvedValue(MOCK_ANALYTICS_DATA_INPUT[5].value);
 
     const response = await request(app)
       .get("/api/catalog/stats")

--- a/packages/app/controllers/catalog.js
+++ b/packages/app/controllers/catalog.js
@@ -28,6 +28,8 @@ async function getAnalyticsController(req, res, next) {
     const totalRequests = await requestService.getRequestsCount();
     const subscriptionService = new SubscriptionService();
     const totalHits = await subscriptionService.getSubscriptionUsageCount();
+    const imageService = new ImageService();
+    const totalImages = await imageService.getImagesCount();
 
     return res.status(200).json({
       statusCode: 200,
@@ -48,6 +50,10 @@ async function getAnalyticsController(req, res, next) {
         {
           title: "Hits",
           value: totalHits,
+        },
+        {
+          title: "Images",
+          value: totalImages,
         },
       ],
     });

--- a/packages/app/repositories/images.js
+++ b/packages/app/repositories/images.js
@@ -70,6 +70,9 @@ class ImagesRepository extends BaseRepository {
       totalPages: Math.ceil(total / limit),
     };
   }
+  async getImagesCount() {
+    return await Image.countDocuments();
+  }
 }
 
 module.exports = ImagesRepository;

--- a/packages/app/services/images.js
+++ b/packages/app/services/images.js
@@ -153,6 +153,10 @@ class ImageServices {
     return await this.imageRepository.getAllImages(skip, limit, search);
   }
 
+  async getImagesCount() {
+    return await this.imageRepository.getImagesCount();
+  }
+
   async getImageById(id) {
     return await this.imageRepository.getById(id);
   }

--- a/packages/app/utils/mocks.js
+++ b/packages/app/utils/mocks.js
@@ -179,6 +179,10 @@ const MOCK_ANALYTICS_DATA_INPUT = [
     title: "Hits",
     value: 40,
   },
+  {
+    title: "Images",
+    value: 28,
+  },
 ];
 
 const MOCK_ANALYTICS_DATA_OUTPUT = [
@@ -198,6 +202,10 @@ const MOCK_ANALYTICS_DATA_OUTPUT = [
   {
     title: "Hits",
     value: 40,
+  },
+  {
+    title: "Images",
+    value: 28,
   },
 ];
 

--- a/packages/ui/src/components/analytics/AnalyticsCard.module.css
+++ b/packages/ui/src/components/analytics/AnalyticsCard.module.css
@@ -2,7 +2,7 @@
   border-radius: 16px;
   background: #f8f8f9;
   padding: 2rem 1rem;
-  flex: 210px 1 1;
+  flex: 300px 1;
   font-family: Inter, sans-serif;
   font-style: normal;
   line-height: normal;
@@ -18,9 +18,9 @@
 .card-content {
   display: flex;
   width: 100%;
-  gap: 2rem;
+  gap: 1.5rem;
   justify-content: space-between;
-  align-items: last baseline;
+  align-items: first baseline;
 }
 
 .card-title,


### PR DESCRIPTION
## Description
closes #859

This PR would let admin dashboard user i.e. admin can to now see total number of images that have been saved until now & a test case include for this ensuring its working fine providing it some mock values have been also added.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<img width="936" height="792" alt="image" src="https://github.com/user-attachments/assets/c061d106-b10d-4ef4-99e3-b5a9030fcb63" />

## Test & Coverage

<img width="966" height="430" alt="image" src="https://github.com/user-attachments/assets/cd18f997-1bb9-46ac-9574-778f30ba25d9" />

<img width="960" height="243" alt="image" src="https://github.com/user-attachments/assets/0f3492c5-c4f9-461e-8cf8-4146eb51c7f6" />

<img width="854" height="425" alt="image" src="https://github.com/user-attachments/assets/f04ef53d-c913-4e83-b5c6-e58eeec83fa3" />

<img width="955" height="302" alt="image" src="https://github.com/user-attachments/assets/1158ffaf-0d12-4d7c-85e9-a87f306c255d" />



## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
