### PR TITLE
Make S3 CORS origins dynamic with value injection from parameters

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -26,8 +26,8 @@
 Most of the environment variables can be used by copying them from the `.env.example` file. However, if you are trying to run the business APIs locally, you will need some additional environment variables associated with AWS.
 
 - Create a stack using `cloudformation_dev_test.yml` file given inside `app/aws` directory.
-- You can generate the private and public RSA key by following the instructions given [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html).
-- Update cloudformation.dev_test.yml, under the S3bucket resource’s Properties → CorsConfiguration → CorsRules section, update the AllowedOrigins value from "https://stage.openlogo.fyi/" to "http://localhost:<default_frontend_port>". when running locally. This allows your local frontend to make API requests without CORS issues to S3.
+- You can generate the private and public RSA key by following the instructions given [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/       private-content-trusted-signers.html).
+- While creating or updating a stack make sure for `AllowedOriginInS3` parameter select is `http://localhost:8080` to avoid CORS error for S3 in your local development environment.
 
   **NOTE**: Remember to revert it back to the stage URL before committing or deploying.
 

--- a/packages/app/aws/cloudformation_dev_test.yml
+++ b/packages/app/aws/cloudformation_dev_test.yml
@@ -23,6 +23,15 @@ Parameters:
       Ensure the path does not begin or end with a slash.
     AllowedPattern: ^[a-zA-Z0-9]+(/[a-zA-Z0-9]+)*$
 
+  AllowedOriginInS3:
+    Type: String
+    Default: https://stage.openlogo.fyi/
+    Description: |
+      The allowed origins for the S3 bucket
+    AllowedValues:
+      - https://stage.openlogo.fyi/
+      - http://localhost:8080
+
 Resources:
   S3bucket:
     Type: AWS::S3::Bucket
@@ -32,7 +41,7 @@ Resources:
       CorsConfiguration:
         CorsRules:
           - AllowedOrigins:
-              - "https://stage.openlogo.fyi/"
+              - !Sub ${AllowedOriginInS3}
             AllowedMethods:
               - PUT
             AllowedHeaders:

--- a/packages/app/aws/cloudformation_prod.yml
+++ b/packages/app/aws/cloudformation_prod.yml
@@ -14,7 +14,11 @@ Parameters:
       Refer to https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html for guidance.
     Description: |
       The public key is employed to verify the signed URL generated with the private key.
-
+  AllowedOriginInS3:
+    Type: String
+    Default: https://www.openlogo.fyi/
+    Description: |
+      The allowed origin for the S3 bucket
   CDNPathInS3:
     Type: String
     Default: path/to/object
@@ -33,7 +37,7 @@ Resources:
       CorsConfiguration:
         CorsRules:
           - AllowedOrigins:
-              - "https://www.openlogo.fyi/"
+              - !Sub ${AllowedOriginInS3}
             AllowedMethods:
               - PUT
             AllowedHeaders:


### PR DESCRIPTION
closes #869 

## Description

This PR updates the Cloudformation templates to make the S3 bucket’s CORS AllowedOrigins configurable instead of hardcoded.
It introduces a new parameter `AllowedOriginInS3`, allows the deployment of the stack for either local or the stage without manually modifying in the cloudformation template itself.


## What type of PR is this? (Check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [X] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
