### PR TITLE
Frontend: Add resend verification email UI

### DIFF
--- a/packages/ui/__tests__/components/auth/Signin.test.jsx
+++ b/packages/ui/__tests__/components/auth/Signin.test.jsx
@@ -17,10 +17,12 @@ vi.mock("react-router-dom", async () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockedFetchRequest = vi.fn();
 const mockedMakeRequest = vi.fn();
 vi.mock("../../../src/hooks/useApi", () => ({
   useApi: () => ({
     makeRequest: mockedMakeRequest,
+    fetchRequest: mockedFetchRequest,
     errorMsg: "Incorrect email or password.",
   }),
 }));
@@ -97,7 +99,11 @@ describe("SignInForm UI and Functionality Tests", () => {
   it("connectivity test passed", async () => {
     const authContext = mockAuthContext(false);
     const oncloseMock = vi.fn();
-    mockedMakeRequest.mockResolvedValue(true);
+    mockedFetchRequest.mockResolvedValue({
+      success: true,
+      data: { statusCode: 200 },
+      error: null,
+    });
 
     render(
       <BrowserRouter>
@@ -119,7 +125,7 @@ describe("SignInForm UI and Functionality Tests", () => {
     fireEvent.click(screen.getByRole("button", { name: BUTTON_TEXT.signIn }));
 
     await waitFor(() => {
-      expect(mockedMakeRequest).toHaveBeenCalled();
+      expect(mockedFetchRequest).toHaveBeenCalled();
     });
 
     expect(oncloseMock).toHaveBeenCalled();
@@ -128,8 +134,12 @@ describe("SignInForm UI and Functionality Tests", () => {
 
   it("connectivity test failed", async () => {
     const authContext = mockAuthContext(false);
-    mockedMakeRequest.mockResolvedValue(false);
     const errorMsg = "Incorrect email or password.";
+    mockedFetchRequest.mockResolvedValue({
+      success: false,
+      data: null,
+      error: errorMsg,
+    });
 
     render(
       <BrowserRouter>
@@ -151,7 +161,7 @@ describe("SignInForm UI and Functionality Tests", () => {
     fireEvent.click(screen.getByRole("button", { name: BUTTON_TEXT.signIn }));
 
     await waitFor(() => {
-      expect(mockedMakeRequest).toHaveBeenCalled();
+      expect(mockedFetchRequest).toHaveBeenCalled();
     });
 
     const errorMsgText = screen.getAllByText(errorMsg);
@@ -159,12 +169,22 @@ describe("SignInForm UI and Functionality Tests", () => {
   });
 
   const delayedResolve = () =>
-    new Promise((resolve) => setTimeout(() => resolve(true), 1000));
+    new Promise((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            success: true,
+            data: { statusCode: 200 },
+            error: null,
+          }),
+        1000
+      )
+    );
   let authContext;
 
   beforeEach(() => {
     authContext = mockAuthContext(false);
-    mockedMakeRequest.mockImplementation(delayedResolve);
+    mockedFetchRequest.mockImplementation(delayedResolve);
   });
 
   it("disables input fields and submit button when loading", async () => {

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -22,7 +22,7 @@ const SignIn = ({ toggleForm, onClose }) => {
   const { setIsAuthenticated } = useContext(AuthContext);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { makeRequest, errorMsg } = useApi({
+  const { fetchRequest, errorMsg } = useApi({
     method: "post",
     url: isForgotPassword ? `/auth/password/forgot` : `/auth/signin`,
     data: isForgotPassword ? { email: formData.email } : formData,
@@ -72,11 +72,13 @@ const SignIn = ({ toggleForm, onClose }) => {
   const handleSubmit = async (submitEvent) => {
     submitEvent.preventDefault();
     setIsLoading(true);
-    const success = await makeRequest();
+    const { data, success } = await fetchRequest();
     if (success) {
       if (isForgotPassword) {
         toast.success("Password reset link sent to your email");
         setIsForgotPassword(false);
+      } else if (data.source && data.statusCode == 201) {
+        toast.success("Verification email sent. Please verify your account.");
       } else {
         setFormData(SIGNIN.initialValues);
         setIsAuthenticated(true);

--- a/packages/ui/src/page/verification/Verification.jsx
+++ b/packages/ui/src/page/verification/Verification.jsx
@@ -13,8 +13,10 @@ const Verification = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [title, setTitle] = useState(VERIFICATION.title);
   const [message, setMessage] = useState(VERIFICATION.message);
+  const [verifyData, setVerifyData] = useState(null);
+  const [isVerified, setIsVerified] = useState(false);
 
-  const { makeRequest, data, errorMsg } = useApi({
+  const { fetchRequest, errorMsg } = useApi({
     method: "get",
     url: `/auth/verify/${token}`,
   });
@@ -23,21 +25,35 @@ const Verification = () => {
     if (!token || hasVerified.current) return;
     hasVerified.current = true;
 
-    await makeRequest();
-  }, [token, makeRequest]);
+    const { data, success } = await fetchRequest();
+    setVerifyData(data);
+    setIsVerified(success);
+  }, [token, fetchRequest]);
 
   useEffect(() => {
     performVerification();
   }, [performVerification]);
 
   useEffect(() => {
-    if (data) {
-      setIsLoading(false);
-      setTitle("Verified");
-      setMessage(data?.message);
-      setTimeout(() => navigate("/"), 3000);
+    if (!verifyData) return;
+
+    setIsLoading(false);
+
+    if (isVerified) {
+      if (!verifyData.source) {
+        setTitle("Verified");
+        setMessage("Your email has been verified.");
+        setTimeout(() => navigate("/"), 3000);
+      } else if (
+        verifyData.statusCode === 201 &&
+        verifyData.source === "resendEmail"
+      ) {
+        setTitle("Verification Pending");
+        setMessage("Verification email sent. \nPlease verify your account.");
+        setTimeout(() => navigate("/"), 6000);
+      }
     }
-  }, [data, navigate]);
+  }, [verifyData, isVerified, navigate]);
 
   useEffect(() => {
     if (errorMsg) {

--- a/packages/ui/src/page/verification/Verification.module.css
+++ b/packages/ui/src/page/verification/Verification.module.css
@@ -37,6 +37,7 @@
   line-height: 1.5;
   margin-bottom: 1.5rem;
   font-weight: 500;
+  white-space: pre-line;
 }
 
 .loadingContainer {


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->

closes #766 

This PR introduces the UI of **resend email verification** feature .

The feature integrates seamlessly into the **signin** and **verifyEmail** flows, improving user experience and ensuring smoother account activation handling.  

**No buttons are added to trigger resend verification.**

---

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature   
- [x] ✅ Test  
 
---

## 🧩 Key Changes

### 🔹 Frontend Integration
- Integrated the new **signin** and **verifyEmail** flow on the frontend.  
- Moved from `makeRequest` to `fetchRequest` in both modules.  
- Utilizes existing **toast notifications** and **error handling** logic.  
### 🔹 Tests
- Updated existing test.
---

## Screenshots 
<!-- Add screenshots to help explain your changes. -->

### Video 

https://github.com/user-attachments/assets/01ad466e-732e-4e92-9990-bd3e3855311f





Signin.test.jsx
<img width="855" height="404" alt="image" src="https://github.com/user-attachments/assets/0a7386ba-c988-43fd-93b6-26f57952bae3" />


---


## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
