### PR TITLE
Cache invalidation for cloudfront CDN

### DIFF
--- a/packages/app/.env.docker
+++ b/packages/app/.env.docker
@@ -17,6 +17,7 @@ SECRET_ACCESS_KEY=n9qyBGN7R5k2pnBMYand4Ym8mLibrZkYgrYhPMM3
 BUCKET_NAME=AWS_bucket_name
 BUCKET_REGION=AWS_region
 DISTRIBUTION_DOMAIN=https://hmzsbpcw4ex33jxeiage.cloudfront.net
+DISTRIBUTION_ID=CloudFront_Distribution_ID
 CLOUD_FRONT_KEYPAIR_ID=Q8A4T7ZMUYRW3Z
 CLOUD_FRONT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----RSA KEY FOR CLOUDFRONT=-----END RSA PRIVATE KEY-----
 BUCKET_KEY=s3_bucket_folder_name_can_customise_as_per_your_likings

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -17,6 +17,7 @@ SECRET_ACCESS_KEY=n9qyBGN7R5k2pnBMYand4Ym8mLibrZkYgrYhPMM3
 BUCKET_NAME=AWS_bucket_name
 BUCKET_REGION=AWS_region
 DISTRIBUTION_DOMAIN=https://hmzsbpcw4ex33jxeiage.cloudfront.net
+DISTRIBUTION_ID=CloudFront_Distribution_ID
 CLOUD_FRONT_KEYPAIR_ID=Q8A4T7ZMUYRW3Z
 CLOUD_FRONT_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----RSA KEY FOR CLOUDFRONT=-----END RSA PRIVATE KEY-----
 BUCKET_KEY=s3_bucket_folder_name_can_customise_as_per_your_likings

--- a/packages/app/__tests__/controllers/catalog/updateMetaData.js
+++ b/packages/app/__tests__/controllers/catalog/updateMetaData.js
@@ -81,6 +81,10 @@ describe("PUT /api/catalog/logo", () => {
       updatedAt: new Date(),
     });
 
+    jest
+      .spyOn(ImageService.prototype, "invalidateCloudFrontCache")
+      .mockResolvedValue(undefined);
+
     const updatePayload = {
       id: MOCK_IMAGES[0]._id.toString(),
       companyUri: "https://example.com/google",

--- a/packages/app/aws/cloudformation_dev_test.yml
+++ b/packages/app/aws/cloudformation_dev_test.yml
@@ -170,6 +170,12 @@ Resources:
             Resource: !Sub ${S3bucket.Arn}/${CDNPathInS3}/*
             Action:
               - "s3:Put*"
+          - Effect: Allow
+            Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontCDN}
+            Action:
+              - "cloudfront:CreateInvalidation"
+              - "cloudfront:GetInvalidation"
+              - "cloudfront:ListInvalidations"
       Users:
         - !Ref IAMUser
 

--- a/packages/app/aws/cloudformation_prod.yml
+++ b/packages/app/aws/cloudformation_prod.yml
@@ -174,6 +174,12 @@ Resources:
             Resource: !Sub ${S3bucket.Arn}/${CDNPathInS3}/*
             Action:
               - "s3:Put*"
+          - Effect: Allow
+            Resource: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontCDN}
+            Action:
+              - "cloudfront:CreateInvalidation"
+              - "cloudfront:GetInvalidation"
+              - "cloudfront:ListInvalidations"
       Users:
         - !Ref IAMUser
 

--- a/packages/app/controllers/catalog.js
+++ b/packages/app/controllers/catalog.js
@@ -224,12 +224,11 @@ async function getCatalogController(req, res, next) {
 }
 
 /**
- * Manages re-uploading an image for admin users.
- * Validates input, uploads to S3, updates database.
- */
-/**
- * Manages the process of updating an image for admin users.
- * Validates input, updates the image in the database.
+ * Updates an existing catalog image for admin users.
+ * Validates the input, uploads the updated image to S3,
+ * updates the image record in the database, and
+ * invalidates the CloudFront cache on successful update.
+ *
  */
 async function updateCatalogController(req, res, next) {
   try {
@@ -276,6 +275,8 @@ async function updateCatalogController(req, res, next) {
         message: Messages.UPDATE_IMAGE_FAILED,
       });
     }
+
+    await imageServices.invalidateCloudFrontCache(previousImageData);
 
     res.status(200).json({
       statusCode: 200,

--- a/packages/app/repositories/images.js
+++ b/packages/app/repositories/images.js
@@ -1,7 +1,10 @@
 const BaseRepository = require("./base");
 const Image = require("../models/images");
 
-const { cloudFrontSignedURL } = require("../utils/cloudFront");
+const {
+  cloudFrontSignedURL,
+  cloudFrontInvalidate,
+} = require("../utils/cloudFront");
 
 /**
  * The ImageRepository extends BaseRepository to manage ContactUs model operations, inheriting CRUD methods like getById, getAll, create, update, and delete..
@@ -72,6 +75,17 @@ class ImagesRepository extends BaseRepository {
   }
   async getImagesCount() {
     return await Image.countDocuments();
+  }
+
+  /**
+   * Invalidates the CloudFront cache for the specified image path.
+   *
+   * @param {string} imageUrl - The relative path of the image to invalidate.
+   * @returns {Promise<void>} Resolves when the cache invalidation request is completed.
+   */
+  async invalidateCloudFrontCache(imageUrl) {
+    const paths = [`/${imageUrl}`];
+    await cloudFrontInvalidate(paths);
   }
 }
 

--- a/packages/app/services/images.js
+++ b/packages/app/services/images.js
@@ -164,6 +164,19 @@ class ImageServices {
   async getImageByCompanyName(companyName) {
     return await this.imageRepository.fetchImage(companyName);
   }
+
+  /**
+   * Invalidates the CloudFront cache for a specific image based on the provided image data.
+   *
+   * @param {Object} imageData - The image metadata.
+   * @param {string} imageData.extension - File type (png, jpg, etc.) of the image.
+   * @param {string} imageData.company_name - Company identifier used in the image name.
+   * @returns {Promise<Object>} The CloudFront invalidation response.
+   */
+  async invalidateCloudFrontCache(imageData) {
+    const imageUrl = `${imageData.extension}/${imageData.company_name}.${imageData.extension}`;
+    return await this.imageRepository.invalidateCloudFrontCache(imageUrl);
+  }
 }
 
 module.exports = ImageServices;

--- a/packages/app/utils/cloudFront.js
+++ b/packages/app/utils/cloudFront.js
@@ -3,6 +3,7 @@ const {
   CloudFrontClient,
   CreateInvalidationCommand,
 } = require("@aws-sdk/client-cloudfront"); // CommonJS import
+const { CLOUD_FRONT_REGION } = require("./constants");
 
 const getSignedUrl = cloudfrontSigner.getSignedUrl;
 
@@ -39,16 +40,16 @@ function cloudFrontSignedURL(path) {
  *    - Handle responses or errors as needed.
  */
 
-const config = {
-  region: process.env.BUCKET_REGION,
-  credentials: {
-    accessKeyId: process.env.ACCESS_KEY,
-    secretAccessKey: process.env.SECRET_ACCESS_KEY,
-  },
-};
-const client = new CloudFrontClient(config);
-
 async function cloudFrontInvalidate(paths) {
+  const config = {
+    region: CLOUD_FRONT_REGION,
+    credentials: {
+      accessKeyId: process.env.ACCESS_KEY,
+      secretAccessKey: process.env.SECRET_ACCESS_KEY,
+    },
+  };
+
+  const client = new CloudFrontClient(config);
   const distributionId = process.env.DISTRIBUTION_ID;
   const input = {
     DistributionId: distributionId,

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -99,6 +99,8 @@ const Messages = {
 
 const ExtractCompanyNameFromUrlRegex = /:\/\/(?:www\.)?([^./]+)\./i;
 
+const CLOUD_FRONT_REGION = "us-east-1";
+
 const getIsProduction = () =>
   process.env.NODE_ENV?.trim().toLowerCase() === "prod";
 
@@ -112,5 +114,6 @@ module.exports = {
   DefaultSubscriptionPlan,
   Messages,
   TAB_OPTIONS,
+  CLOUD_FRONT_REGION,
   getIsProduction,
 };


### PR DESCRIPTION
## Description
Closes #860  

This PR ensures CloudFront cache is invalidated when an admin updates an existing image.

### Changes Included:
- Reused the existing `cloudFrontInvalidate` function to perform cache invalidation.
- Cache invalidation now occurs automatically when an admin updates an existing image.
- Updated the IAM policy to ensure the created IAM user has the required permissions to perform cache invalidation.

## What type of PR is this? (Check all applicable)

- [x] 🐛 Bug Fix  
- [x] 🔥 Performance Improvements  
- [x] ✅ Test  

## Screenshots (if applicable)


https://github.com/user-attachments/assets/cad1f015-7b15-435f-91bf-50022b562c37



https://github.com/user-attachments/assets/7f447a16-a99a-4d10-a860-fc21cd775c0c


`updateMetaData.js`

<img width="859" height="331" alt="image" src="https://github.com/user-attachments/assets/69c79745-1b70-46ba-9ed2-6253fc78cd59" />

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
