### PR TITLE
Feat/logo-request-logs-backend

### DIFF
--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -8,6 +8,7 @@ const {
   ImageService,
   KeyService,
   SubscriptionService,
+  UserService,
 } = require("../../../services");
 
 describe("getLogoController", () => {
@@ -109,11 +110,12 @@ describe("getLogoController", () => {
     jest
       .spyOn(ImageService.prototype, "fetchImageByCompanyFree")
       .mockResolvedValue(imageUrl);
-
     jest
       .spyOn(SubscriptionService.prototype, "incrementUsageCount")
       .mockResolvedValue([]);
-
+    jest
+      .spyOn(UserService.prototype, "logLogoRequestEntry")
+      .mockResolvedValue({});
     const response = await request(app).get(apiUrl).query(baseQuery);
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
@@ -169,7 +171,9 @@ describe("getLogoController - Operations Order Test", () => {
         operationsOrder.push("image_fetched");
         return imageUrl;
       });
-
+    jest
+      .spyOn(UserService.prototype, "logLogoRequestEntry")
+      .mockResolvedValue({});
     jest
       .spyOn(SubscriptionService.prototype, "incrementUsageCount")
       .mockImplementation(() => {

--- a/packages/app/__tests__/controllers/logoRequestLogs.js/getStats.js
+++ b/packages/app/__tests__/controllers/logoRequestLogs.js/getStats.js
@@ -1,0 +1,303 @@
+const request = require("supertest");
+const { STATUS_CODES } = require("node:http");
+
+const { LogoRequestLogsService } = require("../../../services");
+const {
+  MOCK_USERS,
+  MOCK_WEEKLY_STATS,
+  MOCK_MONTHLY_STATS,
+} = require("../../../utils/mocks");
+const { Users } = require("../../../models");
+const { Messages } = require("../../../utils/constants");
+const app = require("../../../server");
+
+describe("GET LOGO REQUEST STATS", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "Your_JWT_SECRET";
+    process.env.CLIENT_PROXY_URL = "https://validcorsorigin.com";
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+    delete process.env.CLIENT_PROXY_URL;
+  });
+
+  describe("Weekly Stats", () => {
+    it("200 - should return last 7 days stats for authenticated user", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getWeeklyStats")
+        .mockResolvedValue(MOCK_WEEKLY_STATS);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        statusCode: 200,
+        data: MOCK_WEEKLY_STATS,
+      });
+      expect(
+        LogoRequestLogsService.prototype.getWeeklyStats
+      ).toHaveBeenCalledWith(mockUserModel._id.toString());
+    });
+
+    it("200 - should return empty stats when user has no requests in last 7 days", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const emptyStats = {
+        period: "week",
+        startDate: "2025-11-24",
+        endDate: "2025-12-01",
+        summary: {
+          totalCount: 0,
+          totalKB: "0.00",
+        },
+        data: [],
+      };
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getWeeklyStats")
+        .mockResolvedValue(emptyStats);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.summary.totalCount).toBe(0);
+      expect(response.body.data.data).toEqual([]);
+    });
+  });
+
+  describe("Monthly Stats", () => {
+    it("200 - should return last 30 days stats for authenticated user", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getMonthlyStats")
+        .mockResolvedValue(MOCK_MONTHLY_STATS);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=month")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        statusCode: 200,
+        data: MOCK_MONTHLY_STATS,
+      });
+      expect(
+        LogoRequestLogsService.prototype.getMonthlyStats
+      ).toHaveBeenCalledWith(mockUserModel._id.toString());
+    });
+
+    it("200 - should return empty stats when user has no requests in last 30 days", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const emptyStats = {
+        period: "month",
+        startDate: "2025-11-01",
+        endDate: "2025-12-01",
+        summary: {
+          totalCount: 0,
+          totalKB: "0.00",
+        },
+        data: [],
+      };
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getMonthlyStats")
+        .mockResolvedValue(emptyStats);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=month")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.summary.totalCount).toBe(0);
+      expect(response.body.data.data).toEqual([]);
+    });
+  });
+
+  describe("Validation Errors", () => {
+    it("422 - should return validation error when period parameter is missing", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(422);
+      expect(response.body.statusCode).toBe(422);
+      expect(response.body.error).toBe(STATUS_CODES[422]);
+      expect(response.body.message).toContain("Period is required");
+    });
+
+    it("422 - should return validation error when period parameter is invalid", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=invalid")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(422);
+      expect(response.body.statusCode).toBe(422);
+      expect(response.body.error).toBe(STATUS_CODES[422]);
+      expect(response.body.message).toContain(
+        "Period must be either 'week' or 'month'"
+      );
+    });
+
+    it("422 - should return validation error for empty period parameter", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(422);
+      expect(response.body.statusCode).toBe(422);
+      expect(response.body.error).toBe(STATUS_CODES[422]);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("404 - should return not found when stats are null", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getWeeklyStats")
+        .mockResolvedValue(null);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        statusCode: 404,
+        error: STATUS_CODES[404],
+        message: Messages.DATA_NOT_FOUND,
+      });
+    });
+
+    it("404 - should return not found when monthly stats are null", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getMonthlyStats")
+        .mockResolvedValue(null);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=month")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        statusCode: 404,
+        error: STATUS_CODES[404],
+        message: Messages.DATA_NOT_FOUND,
+      });
+    });
+
+    it("500 - should handle unexpected errors during weekly stats fetch", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getWeeklyStats")
+        .mockImplementation(() => {
+          throw new Error("Unexpected database error");
+        });
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(500);
+    });
+
+    it("500 - should handle unexpected errors during monthly stats fetch", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getMonthlyStats")
+        .mockImplementation(() => {
+          throw new Error("Unexpected database error");
+        });
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=month")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("Authentication", () => {
+    it("401 - should return unauthorized when JWT token is missing", async () => {
+      const response = await request(app).get(
+        "/api/logo-requests/stats?period=week"
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it("500 - should return error when JWT token is invalid", async () => {
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week")
+        .set("Cookie", `jwt=invalid_token`);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle case-sensitive period parameter", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=Week")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(422);
+      expect(response.body.message).toContain(
+        "Period must be either 'week' or 'month'"
+      );
+    });
+
+    it("should handle additional query parameters gracefully", async () => {
+      const mockUserModel = new Users(MOCK_USERS[1]);
+      const mockToken = mockUserModel.generateJWT();
+
+      jest
+        .spyOn(LogoRequestLogsService.prototype, "getWeeklyStats")
+        .mockResolvedValue(MOCK_WEEKLY_STATS);
+
+      const response = await request(app)
+        .get("/api/logo-requests/stats?period=week&extra=param")
+        .set("Cookie", `jwt=${mockToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual(MOCK_WEEKLY_STATS);
+    });
+  });
+});

--- a/packages/app/__tests__/services/logoRequestLogs.js
+++ b/packages/app/__tests__/services/logoRequestLogs.js
@@ -1,0 +1,261 @@
+const { LogoRequestLogsService } = require("../../services");
+const { LogoRequestLogsRepository } = require("../../repositories");
+const {
+  MOCK_LOGO_REQUESTS,
+  MOCK_USERS,
+  MOCK_KEYS,
+  MOCK_IMAGES,
+  MOCK_WEEKLY_STATS,
+  MOCK_MONTHLY_STATS,
+} = require("../../utils/mocks");
+
+describe("Logo Request Logs Service", () => {
+  let logoRequestLogsService;
+
+  beforeEach(() => {
+    logoRequestLogsService = new LogoRequestLogsService();
+    jest.clearAllMocks();
+  });
+
+  describe("createEntry", () => {
+    it("should create a new API request entry with all fields", async () => {
+      const requestData = {
+        user_id: MOCK_USERS[0]._id.toString(),
+        key_id: MOCK_KEYS[0]._id.toString(),
+        image_id: MOCK_IMAGES[0]._id.toString(),
+        response_size_bytes: 1024,
+      };
+
+      const mockCreatedRequest = {
+        ...requestData,
+        _id: MOCK_LOGO_REQUESTS[0]._id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "create")
+        .mockResolvedValue(mockCreatedRequest);
+
+      const result = await logoRequestLogsService.createEntry(requestData);
+
+      expect(result).toBeDefined();
+      expect(result.user_id).toBe(requestData.user_id);
+      expect(result.key_id).toBe(requestData.key_id);
+      expect(result.image_id).toBe(requestData.image_id);
+      expect(result.response_size_bytes).toBe(1024);
+      expect(LogoRequestLogsRepository.prototype.create).toHaveBeenCalledWith({
+        user_id: requestData.user_id,
+        key_id: requestData.key_id,
+        image_id: requestData.image_id,
+        response_size_bytes: 1024,
+      });
+    });
+
+    it("should create API request entry with default response_size_bytes when not provided", async () => {
+      const requestData = {
+        user_id: MOCK_USERS[0]._id.toString(),
+        key_id: MOCK_KEYS[0]._id.toString(),
+        image_id: MOCK_IMAGES[0]._id.toString(),
+      };
+
+      const mockCreatedRequest = {
+        ...requestData,
+        response_size_bytes: 0,
+        _id: MOCK_LOGO_REQUESTS[0]._id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "create")
+        .mockResolvedValue(mockCreatedRequest);
+
+      const result = await logoRequestLogsService.createEntry(requestData);
+
+      expect(result).toBeDefined();
+      expect(result.response_size_bytes).toBe(0);
+      expect(LogoRequestLogsRepository.prototype.create).toHaveBeenCalledWith({
+        user_id: requestData.user_id,
+        key_id: requestData.key_id,
+        image_id: requestData.image_id,
+        response_size_bytes: 0,
+      });
+    });
+
+    it("should create API request entry with 0 when response_size_bytes is 0", async () => {
+      const requestData = {
+        user_id: MOCK_USERS[0]._id.toString(),
+        key_id: MOCK_KEYS[0]._id.toString(),
+        image_id: MOCK_IMAGES[0]._id.toString(),
+        response_size_bytes: 0,
+      };
+
+      const mockCreatedRequest = {
+        ...requestData,
+        _id: MOCK_LOGO_REQUESTS[0]._id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "create")
+        .mockResolvedValue(mockCreatedRequest);
+
+      const result = await logoRequestLogsService.createEntry(requestData);
+
+      expect(result).toBeDefined();
+      expect(result.response_size_bytes).toBe(0);
+    });
+
+    it("should handle repository errors during creation", async () => {
+      const requestData = {
+        user_id: MOCK_USERS[0]._id.toString(),
+        key_id: MOCK_KEYS[0]._id.toString(),
+        image_id: MOCK_IMAGES[0]._id.toString(),
+        response_size_bytes: 1024,
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "create")
+        .mockRejectedValue(new Error("Database error"));
+
+      await expect(
+        logoRequestLogsService.createEntry(requestData)
+      ).rejects.toThrow("Database error");
+    });
+  });
+
+  describe("getWeeklyStats", () => {
+    it("should return last 7 days stats for a valid user", async () => {
+      const userId = MOCK_USERS[0]._id.toString();
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentWeekData")
+        .mockResolvedValue(MOCK_WEEKLY_STATS);
+
+      const result = await logoRequestLogsService.getWeeklyStats(userId);
+
+      expect(result).toBeDefined();
+      expect(result.period).toBe("week");
+      expect(result.startDate).toBeDefined();
+      expect(result.endDate).toBeDefined();
+      expect(result.summary).toBeDefined();
+      expect(result.summary.totalCount).toBe(15);
+      expect(result.summary.totalKB).toBe("45.50");
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(
+        LogoRequestLogsRepository.prototype.getCurrentWeekData
+      ).toHaveBeenCalledWith(userId);
+    });
+
+    it("should return empty stats when user has no requests in last 7 days", async () => {
+      const userId = MOCK_USERS[1]._id.toString();
+      const emptyStats = {
+        period: "week",
+        startDate: "2025-11-24",
+        endDate: "2025-12-01",
+        summary: {
+          totalCount: 0,
+          totalKB: "0.00",
+        },
+        data: [],
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentWeekData")
+        .mockResolvedValue(emptyStats);
+
+      const result = await logoRequestLogsService.getWeeklyStats(userId);
+
+      expect(result).toBeDefined();
+      expect(result.summary.totalCount).toBe(0);
+      expect(result.data).toEqual([]);
+    });
+
+    it("should handle repository errors when fetching weekly stats", async () => {
+      const userId = MOCK_USERS[0]._id.toString();
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentWeekData")
+        .mockRejectedValue(new Error("Database connection failed"));
+
+      await expect(
+        logoRequestLogsService.getWeeklyStats(userId)
+      ).rejects.toThrow("Database connection failed");
+    });
+  });
+
+  describe("getMonthlyStats", () => {
+    it("should return last 30 days stats for a valid user", async () => {
+      const userId = MOCK_USERS[0]._id.toString();
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentMonthData")
+        .mockResolvedValue(MOCK_MONTHLY_STATS);
+
+      const result = await logoRequestLogsService.getMonthlyStats(userId);
+
+      expect(result).toBeDefined();
+      expect(result.period).toBe("month");
+      expect(result.startDate).toBeDefined();
+      expect(result.endDate).toBeDefined();
+      expect(result.summary).toBeDefined();
+      expect(result.summary.totalCount).toBe(50);
+      expect(result.summary.totalKB).toBe("150.75");
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.data.length).toBeGreaterThan(0);
+      expect(
+        LogoRequestLogsRepository.prototype.getCurrentMonthData
+      ).toHaveBeenCalledWith(userId);
+    });
+
+    it("should return empty stats when user has no requests in last 30 days", async () => {
+      const userId = MOCK_USERS[2]._id.toString();
+      const emptyStats = {
+        period: "month",
+        startDate: "2025-11-01",
+        endDate: "2025-12-01",
+        summary: {
+          totalCount: 0,
+          totalKB: "0.00",
+        },
+        data: [],
+      };
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentMonthData")
+        .mockResolvedValue(emptyStats);
+
+      const result = await logoRequestLogsService.getMonthlyStats(userId);
+
+      expect(result).toBeDefined();
+      expect(result.summary.totalCount).toBe(0);
+      expect(result.data).toEqual([]);
+    });
+
+    it("should handle repository errors when fetching monthly stats", async () => {
+      const userId = MOCK_USERS[0]._id.toString();
+
+      jest
+        .spyOn(LogoRequestLogsRepository.prototype, "getCurrentMonthData")
+        .mockRejectedValue(new Error("Aggregation failed"));
+
+      await expect(
+        logoRequestLogsService.getMonthlyStats(userId)
+      ).rejects.toThrow("Aggregation failed");
+    });
+  });
+
+  describe("service instance", () => {
+    it("should create service instance with repository", () => {
+      expect(logoRequestLogsService).toBeDefined();
+      expect(logoRequestLogsService.LogoRequestLogsRepository).toBeDefined();
+      expect(
+        logoRequestLogsService.LogoRequestLogsRepository instanceof
+          LogoRequestLogsRepository
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -3,7 +3,6 @@ const {
   ImageService,
   KeyService,
   SubscriptionService,
-  LogoRequestLogsService,
   UserService,
 } = require("../services");
 const {
@@ -22,7 +21,6 @@ async function getLogoController(req, res, next) {
     const imageService = new ImageService();
     const keyService = new KeyService();
     const subscriptionService = new SubscriptionService();
-    const logoRequestLogsService = new LogoRequestLogsService();
     const userService = new UserService();
 
     const { error, value } = getLogoQuerySchema.validate(req.query);
@@ -63,22 +61,8 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-    try {
-      const [imageDoc, userRef] = await Promise.all([
-        imageService.getImageByCompanyName(company),
-        userService.getUserBySubscriptionId(userSubscription._id),
-      ]);
-      const requestPayload = {
-        user_id: userRef._id,
-        key_id: keyRef._id,
-        image_id: imageDoc && imageDoc._id,
-        response_size_bytes: (imageDoc && imageDoc.image_size) || 0,
-      };
-      await logoRequestLogsService.createEntry(requestPayload);
-    } catch (err) {
 
-      console.error("Failed to create API request entry:", err.message);
-    }
+    await userService.logLogoRequestEntry(company, userSubscription, keyRef);
 
     subscriptionService.incrementUsageCount(userSubscription).catch((err) => {
       console.error("Failed to increment usage count:", err.message);

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -63,7 +63,6 @@ async function getLogoController(req, res, next) {
         error: STATUS_CODES[404],
       });
     }
-    //Create an API request entry for analytics/usage tracking.
     try {
       const [imageDoc, userRef] = await Promise.all([
         imageService.getImageByCompanyName(company),
@@ -77,7 +76,7 @@ async function getLogoController(req, res, next) {
       };
       await logoRequestLogsService.createEntry(requestPayload);
     } catch (err) {
-      // non-fatal: log and continue
+
       console.error("Failed to create API request entry:", err.message);
     }
 

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -3,6 +3,8 @@ const {
   ImageService,
   KeyService,
   SubscriptionService,
+  LogoRequestLogsService,
+  UserService,
 } = require("../services");
 const {
   getLogoQuerySchema,
@@ -20,6 +22,8 @@ async function getLogoController(req, res, next) {
     const imageService = new ImageService();
     const keyService = new KeyService();
     const subscriptionService = new SubscriptionService();
+    const logoRequestLogsService = new LogoRequestLogsService();
+    const userService = new UserService();
 
     const { error, value } = getLogoQuerySchema.validate(req.query);
     if (error) {
@@ -58,6 +62,23 @@ async function getLogoController(req, res, next) {
         statusCode: 404,
         error: STATUS_CODES[404],
       });
+    }
+    //Create an API request entry for analytics/usage tracking.
+    try {
+      const [imageDoc, userRef] = await Promise.all([
+        imageService.getImageByCompanyName(company),
+        userService.getUserBySubscriptionId(userSubscription._id),
+      ]);
+      const requestPayload = {
+        user_id: userRef._id,
+        key_id: keyRef._id,
+        image_id: imageDoc && imageDoc._id,
+        response_size_bytes: (imageDoc && imageDoc.image_size) || 0,
+      };
+      await logoRequestLogsService.createEntry(requestPayload);
+    } catch (err) {
+      // non-fatal: log and continue
+      console.error("Failed to create API request entry:", err.message);
     }
 
     subscriptionService.incrementUsageCount(userSubscription).catch((err) => {

--- a/packages/app/controllers/logoRequestLogs.js
+++ b/packages/app/controllers/logoRequestLogs.js
@@ -11,7 +11,7 @@ const { Messages } = require("../utils/constants");
 async function getLogoRequestStatsController(req, res, next) {
   try {
     const logoRequestLogsService = new LogoRequestLogsService();
-    
+
     const { error } = getStatsQuerySchema.validate(req.query);
     if (error) {
       return res.status(422).json({

--- a/packages/app/controllers/logoRequestLogs.js
+++ b/packages/app/controllers/logoRequestLogs.js
@@ -11,8 +11,7 @@ const { Messages } = require("../utils/constants");
 async function getLogoRequestStatsController(req, res, next) {
   try {
     const logoRequestLogsService = new LogoRequestLogsService();
-
-    // Validate query parameters
+    
     const { error } = getStatsQuerySchema.validate(req.query);
     if (error) {
       return res.status(422).json({
@@ -27,7 +26,6 @@ async function getLogoRequestStatsController(req, res, next) {
 
     let stats;
 
-    // Get stats based on period
     if (period === "week") {
       stats = await logoRequestLogsService.getWeeklyStats(userId);
     } else if (period === "month") {

--- a/packages/app/controllers/logoRequestLogs.js
+++ b/packages/app/controllers/logoRequestLogs.js
@@ -1,0 +1,56 @@
+const { STATUS_CODES } = require("http");
+const { LogoRequestLogsService } = require("../services");
+const { getStatsQuerySchema } = require("../schemas/logoRequestLogs");
+const { Messages } = require("../utils/constants");
+
+/**
+ * This controller fetches API request statistics for the authenticated user
+ * based on the query parameter 'period' (week or month).
+ * It validates the query parameter and returns the corresponding statistics.
+ */
+async function getLogoRequestStatsController(req, res, next) {
+  try {
+    const logoRequestLogsService = new LogoRequestLogsService();
+
+    // Validate query parameters
+    const { error } = getStatsQuerySchema.validate(req.query);
+    if (error) {
+      return res.status(422).json({
+        statusCode: 422,
+        message: error.message,
+        error: STATUS_CODES[422],
+      });
+    }
+
+    const { userId } = req.userData;
+    const { period } = req.query;
+
+    let stats;
+
+    // Get stats based on period
+    if (period === "week") {
+      stats = await logoRequestLogsService.getWeeklyStats(userId);
+    } else if (period === "month") {
+      stats = await logoRequestLogsService.getMonthlyStats(userId);
+    }
+
+    if (!stats) {
+      return res.status(404).json({
+        statusCode: 404,
+        error: STATUS_CODES[404],
+        message: Messages.DATA_NOT_FOUND,
+      });
+    }
+
+    return res.status(200).json({
+      statusCode: 200,
+      data: stats,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = {
+  getLogoRequestStatsController,
+};

--- a/packages/app/models/index.js
+++ b/packages/app/models/index.js
@@ -5,6 +5,7 @@ const Subscriptions = require("./subscriptions");
 const UserToken = require("./usertoken");
 const Users = require("./users");
 const Request = require("./request");
+const LogoRequestLogs = require("./logoRequestLogs");
 
 module.exports = {
   ContactUs,
@@ -14,4 +15,5 @@ module.exports = {
   UserToken,
   Users,
   Request,
+  LogoRequestLogs,
 };

--- a/packages/app/models/logoRequestLogs.js
+++ b/packages/app/models/logoRequestLogs.js
@@ -1,0 +1,42 @@
+const Schema = require("mongoose").Schema;
+const model = require("mongoose").model;
+/**
+ * Logo Request Logs Model: Lightweight records for tracking logo requests over time.
+ * Kept minimal to enable time-series graphs (createdAt) and basic aggregation.
+ */
+const logoRequestLogsSchema = new Schema(
+  {
+    user_id: {
+      type: Schema.Types.ObjectId,
+      ref: "users",
+      required: true,
+    },
+    key_id: {
+      type: Schema.Types.ObjectId,
+      ref: "keys",
+    },
+    image_id: {
+      type: Schema.Types.ObjectId,
+      ref: "images",
+      required: true,
+    },
+    response_size_bytes: {
+      type: Number,
+      default: 0,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// Index to make descending sort faster.
+logoRequestLogsSchema.index({ createdAt: -1 });
+logoRequestLogsSchema.index({ user_id: 1 });
+
+const LogoRequestLogs = model(
+  "logo_request_log",
+  logoRequestLogsSchema,
+  "logo_request_logs"
+);
+module.exports = LogoRequestLogs;

--- a/packages/app/models/logoRequestLogs.js
+++ b/packages/app/models/logoRequestLogs.js
@@ -30,7 +30,6 @@ const logoRequestLogsSchema = new Schema(
   }
 );
 
-// Index to make descending sort faster.
 logoRequestLogsSchema.index({ createdAt: -1 });
 logoRequestLogsSchema.index({ user_id: 1 });
 

--- a/packages/app/repositories/index.js
+++ b/packages/app/repositories/index.js
@@ -5,6 +5,7 @@ const SubscriptionsRepository = require("./subscriptions");
 const UserTokenRepository = require("./usertoken");
 const UsersRepository = require("./users");
 const RequestRepository = require("./request");
+const LogoRequestLogsRepository = require("./logoRequestLogs");
 module.exports = {
   ContactUsRepository,
   ImagesRepository,
@@ -13,4 +14,5 @@ module.exports = {
   UserTokenRepository,
   UsersRepository,
   RequestRepository,
+  LogoRequestLogsRepository,
 };

--- a/packages/app/repositories/logoRequestLogs.js
+++ b/packages/app/repositories/logoRequestLogs.js
@@ -8,10 +8,75 @@ const mongoose = require("mongoose");
  * It passes the LogoRequestLogs model to the base repository for database interactions.
  * Custom methods specific to LogoRequestLogs can also be added as needed.
  */
-
 class LogoRequestLogsRepository extends BaseRepository {
   constructor() {
     super(LogoRequestLogs);
+  }
+
+  /**
+   * Generic method to get aggregated data for a date range
+   * @param {string} userId - The user ID to filter by
+   * @param {number} days - Number of days to look back
+   * @param {string} period - Period label (e.g., 'week', 'month')
+   * @returns {Promise<Object>} - An object containing the count of requests for each day
+   */
+  async getDataForPeriod(userId, days, period) {
+    const today = dayjs();
+    const startDate = today.subtract(days, "day").startOf("day");
+    const endDate = today.endOf("day");
+
+    const result = await this.model.aggregate([
+      {
+        $match: {
+          user_id: new mongoose.Types.ObjectId(userId),
+          createdAt: {
+            $gte: startDate.toDate(),
+            $lte: endDate.toDate(),
+          },
+        },
+      },
+      {
+        $addFields: {
+          dateOnly: {
+            $dateToString: {
+              format: "%Y-%m-%d",
+              date: "$createdAt",
+            },
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$dateOnly",
+          count: { $sum: 1 },
+          totalBytes: { $sum: "$response_size_bytes" },
+        },
+      },
+      {
+        $sort: { _id: 1 },
+      },
+      {
+        $project: {
+          _id: 0,
+          date: "$_id",
+          count: 1,
+          totalKB: { $round: [{ $divide: ["$totalBytes", 1024] }, 2] },
+        },
+      },
+    ]);
+
+    const summary = {
+      totalCount: result.reduce((sum, day) => sum + day.count, 0),
+      totalKB: result.reduce((sum, day) => sum + day.totalKB, 0).toFixed(2),
+    };
+
+    return {
+      period,
+      startDate: startDate.format("YYYY-MM-DD"),
+      endDate: endDate.format("YYYY-MM-DD"),
+      summary,
+      data: result,
+    };
   }
 
   /**
@@ -19,65 +84,8 @@ class LogoRequestLogsRepository extends BaseRepository {
    * @param {string} userId - The user ID to filter by
    * @returns {Promise<Object>} - An object containing the count of requests for each day
    */
-  async getCurrentWeekData(userId) {
-    const today = dayjs();
-    const weekStart = today.subtract(7, "day").startOf("day");
-    const weekEnd = today.endOf("day");
-    const weekStartDate = weekStart.toDate();
-    const weekEndDate = weekEnd.toDate();
-
-    const result = await this.model.aggregate([
-      {
-        $match: {
-          user_id: new mongoose.Types.ObjectId(userId),
-          createdAt: {
-            $gte: weekStartDate,
-            $lte: weekEndDate,
-          },
-        },
-      },
-      {
-        $addFields: {
-          dateOnly: {
-            $dateToString: {
-              format: "%Y-%m-%d",
-              date: "$createdAt",
-            },
-          },
-        },
-      },
-      {
-        $group: {
-          _id: "$dateOnly",
-          count: { $sum: 1 },
-          totalBytes: { $sum: "$response_size_bytes" },
-        },
-      },
-      {
-        $sort: { _id: 1 },
-      },
-      {
-        $project: {
-          _id: 0,
-          date: "$_id",
-          count: 1,
-          totalKB: { $round: [{ $divide: ["$totalBytes", 1024] }, 2] },
-        },
-      },
-    ]);
-
-    const summary = {
-      totalCount: result.reduce((sum, day) => sum + day.count, 0),
-      totalKB: result.reduce((sum, day) => sum + day.totalKB, 0).toFixed(2),
-    };
-
-    return {
-      period: "week",
-      startDate: weekStart.format("YYYY-MM-DD"),
-      endDate: weekEnd.format("YYYY-MM-DD"),
-      summary: summary,
-      data: result,
-    };
+  getCurrentWeekData(userId) {
+    return this.getDataForPeriod(userId, 7, "week");
   }
 
   /**
@@ -85,65 +93,8 @@ class LogoRequestLogsRepository extends BaseRepository {
    * @param {string} userId - The user ID to filter by
    * @returns {Promise<Object>} - An object containing the count of requests for each day
    */
-  async getCurrentMonthData(userId) {
-    const today = dayjs();
-    const monthStart = today.subtract(30, "day").startOf("day");
-    const monthEnd = today.endOf("day");
-    const monthStartDate = monthStart.toDate();
-    const monthEndDate = monthEnd.toDate();
-
-    const result = await this.model.aggregate([
-      {
-        $match: {
-          user_id: new mongoose.Types.ObjectId(userId),
-          createdAt: {
-            $gte: monthStartDate,
-            $lte: monthEndDate,
-          },
-        },
-      },
-      {
-        $addFields: {
-          dateOnly: {
-            $dateToString: {
-              format: "%Y-%m-%d",
-              date: "$createdAt",
-            },
-          },
-        },
-      },
-      {
-        $group: {
-          _id: "$dateOnly",
-          count: { $sum: 1 },
-          totalBytes: { $sum: "$response_size_bytes" },
-        },
-      },
-      {
-        $sort: { _id: 1 },
-      },
-      {
-        $project: {
-          _id: 0,
-          date: "$_id",
-          count: 1,
-          totalKB: { $round: [{ $divide: ["$totalBytes", 1024] }, 2] },
-        },
-      },
-    ]);
-
-    const summary = {
-      totalCount: result.reduce((sum, day) => sum + day.count, 0),
-      totalKB: result.reduce((sum, day) => sum + day.totalKB, 0).toFixed(2),
-    };
-
-    return {
-      period: "month",
-      startDate: monthStart.format("YYYY-MM-DD"),
-      endDate: monthEnd.format("YYYY-MM-DD"),
-      summary: summary,
-      data: result,
-    };
+  getCurrentMonthData(userId) {
+    return this.getDataForPeriod(userId, 30, "month");
   }
 }
 

--- a/packages/app/repositories/logoRequestLogs.js
+++ b/packages/app/repositories/logoRequestLogs.js
@@ -1,0 +1,160 @@
+const { LogoRequestLogs } = require("../models");
+const BaseRepository = require("./base");
+const dayjs = require("dayjs");
+const mongoose = require("mongoose");
+
+/**
+ * The LogoRequestLogsRepository extends BaseRepository to manage LogoRequestLogs model operations, inheriting CRUD methods like getById, getAll, create, update, and delete..
+ * It passes the LogoRequestLogs model to the base repository for database interactions.
+ *  Custom methods specific to LogoRequestLogs can also be added as needed.
+ */
+
+class LogoRequestLogsRepository extends BaseRepository {
+  constructor() {
+    super(LogoRequestLogs);
+  }
+
+  /**
+   * Get last 7 days data for a specific user
+   * @param {string} userId - The user ID to filter by
+   * @returns {Promise<Object>} - An object containing the count of requests for each day
+   */
+  async getCurrentWeekData(userId) {
+    const today = dayjs();
+    const weekStart = today.subtract(7, "day").startOf("day");
+    const weekEnd = today.endOf("day");
+    const weekStartDate = weekStart.toDate();
+    const weekEndDate = weekEnd.toDate();
+
+    const result = await this.model.aggregate([
+      {
+        $addFields: {
+          createdDate: { $toDate: "$createdAt" },
+        },
+      },
+      {
+        $match: {
+          user_id: new mongoose.Types.ObjectId(userId),
+          createdDate: {
+            $gte: weekStartDate,
+            $lte: weekEndDate,
+          },
+        },
+      },
+      {
+        $addFields: {
+          dateOnly: {
+            $dateToString: {
+              format: "%Y-%m-%d",
+              date: "$createdDate",
+            },
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$dateOnly",
+          count: { $sum: 1 },
+          totalBytes: { $sum: "$response_size_bytes" },
+        },
+      },
+      {
+        $sort: { _id: 1 },
+      },
+      {
+        $project: {
+          _id: 0,
+          date: "$_id",
+          count: 1,
+          totalKB: { $round: [{ $divide: ["$totalBytes", 1024] }, 2] },
+        },
+      },
+    ]);
+
+    const summary = {
+      totalCount: result.reduce((sum, day) => sum + day.count, 0),
+      totalKB: result.reduce((sum, day) => sum + day.totalKB, 0).toFixed(2),
+    };
+
+    return {
+      period: "week",
+      startDate: weekStart.format("YYYY-MM-DD"),
+      endDate: weekEnd.format("YYYY-MM-DD"),
+      summary: summary,
+      data: result,
+    };
+  }
+
+  /**
+   * Get last 30 days data for a specific user
+   * @param {string} userId - The user ID to filter by
+   * @returns {Promise<Object>} - An object containing the count of requests for each day
+   */
+  async getCurrentMonthData(userId) {
+    const today = dayjs();
+    const monthStart = today.subtract(30, "day").startOf("day");
+    const monthEnd = today.endOf("day");
+    const monthStartDate = monthStart.toDate();
+    const monthEndDate = monthEnd.toDate();
+
+    const result = await this.model.aggregate([
+      {
+        $addFields: {
+          createdDate: { $toDate: "$createdAt" },
+        },
+      },
+      {
+        $match: {
+          user_id: new mongoose.Types.ObjectId(userId),
+          createdDate: {
+            $gte: monthStartDate,
+            $lte: monthEndDate,
+          },
+        },
+      },
+      {
+        $addFields: {
+          dateOnly: {
+            $dateToString: {
+              format: "%Y-%m-%d",
+              date: "$createdDate",
+            },
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$dateOnly",
+          count: { $sum: 1 },
+          totalBytes: { $sum: "$response_size_bytes" },
+        },
+      },
+      {
+        $sort: { _id: 1 },
+      },
+      {
+        $project: {
+          _id: 0,
+          date: "$_id",
+          count: 1,
+          totalKB: { $round: [{ $divide: ["$totalBytes", 1024] }, 2] },
+        },
+      },
+    ]);
+
+    const summary = {
+      totalCount: result.reduce((sum, day) => sum + day.count, 0),
+      totalKB: result.reduce((sum, day) => sum + day.totalKB, 0).toFixed(2),
+    };
+
+    return {
+      period: "month",
+      startDate: dayjs(monthStart).format("YYYY-MM-DD"),
+      endDate: dayjs(monthEnd).format("YYYY-MM-DD"),
+      summary: summary,
+      data: result,
+    };
+  }
+}
+
+module.exports = { LogoRequestLogsRepository };

--- a/packages/app/repositories/logoRequestLogs.js
+++ b/packages/app/repositories/logoRequestLogs.js
@@ -4,9 +4,9 @@ const dayjs = require("dayjs");
 const mongoose = require("mongoose");
 
 /**
- * The LogoRequestLogsRepository extends BaseRepository to manage LogoRequestLogs model operations, inheriting CRUD methods like getById, getAll, create, update, and delete..
+ * The LogoRequestLogsRepository extends BaseRepository to manage LogoRequestLogs model operations, inheriting CRUD methods like getById, getAll, create, update, and delete.
  * It passes the LogoRequestLogs model to the base repository for database interactions.
- *  Custom methods specific to LogoRequestLogs can also be added as needed.
+ * Custom methods specific to LogoRequestLogs can also be added as needed.
  */
 
 class LogoRequestLogsRepository extends BaseRepository {
@@ -28,14 +28,9 @@ class LogoRequestLogsRepository extends BaseRepository {
 
     const result = await this.model.aggregate([
       {
-        $addFields: {
-          createdDate: { $toDate: "$createdAt" },
-        },
-      },
-      {
         $match: {
           user_id: new mongoose.Types.ObjectId(userId),
-          createdDate: {
+          createdAt: {
             $gte: weekStartDate,
             $lte: weekEndDate,
           },
@@ -46,7 +41,7 @@ class LogoRequestLogsRepository extends BaseRepository {
           dateOnly: {
             $dateToString: {
               format: "%Y-%m-%d",
-              date: "$createdDate",
+              date: "$createdAt",
             },
           },
         },
@@ -99,14 +94,9 @@ class LogoRequestLogsRepository extends BaseRepository {
 
     const result = await this.model.aggregate([
       {
-        $addFields: {
-          createdDate: { $toDate: "$createdAt" },
-        },
-      },
-      {
         $match: {
           user_id: new mongoose.Types.ObjectId(userId),
-          createdDate: {
+          createdAt: {
             $gte: monthStartDate,
             $lte: monthEndDate,
           },
@@ -117,7 +107,7 @@ class LogoRequestLogsRepository extends BaseRepository {
           dateOnly: {
             $dateToString: {
               format: "%Y-%m-%d",
-              date: "$createdDate",
+              date: "$createdAt",
             },
           },
         },
@@ -149,8 +139,8 @@ class LogoRequestLogsRepository extends BaseRepository {
 
     return {
       period: "month",
-      startDate: dayjs(monthStart).format("YYYY-MM-DD"),
-      endDate: dayjs(monthEnd).format("YYYY-MM-DD"),
+      startDate: monthStart.format("YYYY-MM-DD"),
+      endDate: monthEnd.format("YYYY-MM-DD"),
       summary: summary,
       data: result,
     };

--- a/packages/app/repositories/logoRequestLogs.js
+++ b/packages/app/repositories/logoRequestLogs.js
@@ -157,4 +157,4 @@ class LogoRequestLogsRepository extends BaseRepository {
   }
 }
 
-module.exports = { LogoRequestLogsRepository };
+module.exports = LogoRequestLogsRepository;

--- a/packages/app/repositories/users.js
+++ b/packages/app/repositories/users.js
@@ -38,6 +38,18 @@ class UsersRepository extends BaseRepository {
   async getGuestUser() {
     return await this.model.findOne({ role: "GUEST" });
   }
+
+  /**
+   * This return userId by subscriptionId
+   * @param {string} subscriptionId - The subscription ID to search for.
+   * @returns {Promise<Object|null>} - Returns the user document with only _id field if found, otherwise null.
+   */
+  async findUserBySubscriptionId(subscriptionId) {
+    return await this.model
+      .findOne({ subscription_id: subscriptionId })
+      .select("_id")
+      .lean();
+  }
 }
 
 module.exports = UsersRepository;

--- a/packages/app/routes/index.js
+++ b/packages/app/routes/index.js
@@ -6,6 +6,7 @@ const authRouter = require("./auth");
 const businessRouter = require("./logo");
 const adminRouter = require("./catalog");
 const requestRouter = require("./request");
+const logoRequestLogsRouter = require("./logoRequestLogs");
 const { logoLimiter, baseLimiter } = require("../middlewares/rateLimiter");
 
 const privateRouteCORS = {
@@ -31,5 +32,11 @@ router.use("/auth", baseLimiter, cors(privateRouteCORS), authRouter);
 router.use("/logo", logoLimiter, cors(privateRouteCORS), businessRouter);
 router.use("/catalog", baseLimiter, cors(privateRouteCORS), adminRouter);
 router.use("/requests", baseLimiter, cors(privateRouteCORS), requestRouter);
+router.use(
+  "/logo-requests",
+  baseLimiter,
+  cors(privateRouteCORS),
+  logoRequestLogsRouter
+);
 
 module.exports = router;

--- a/packages/app/routes/logoRequestLogs.js
+++ b/packages/app/routes/logoRequestLogs.js
@@ -1,0 +1,16 @@
+const router = require("express").Router();
+const authMiddleware = require("../middlewares/auth");
+const {
+  getLogoRequestStatsController,
+} = require("../controllers/logoRequestLogs");
+const { UserType } = require("../utils/constants");
+
+router.get(
+  "/stats",
+  authMiddleware({
+    roles: [UserType.ADMIN, UserType.OPERATOR, UserType.CUSTOMER],
+  }),
+  getLogoRequestStatsController
+);
+
+module.exports = router;

--- a/packages/app/schemas/logoRequestLogs.js
+++ b/packages/app/schemas/logoRequestLogs.js
@@ -1,0 +1,16 @@
+const Joi = require("joi");
+
+/**
+ * Schema for validating API request statistics query parameters
+ * Accepts 'period' as either 'week' or 'month'
+ */
+const getStatsQuerySchema = Joi.object({
+  period: Joi.string().valid("week", "month").required().messages({
+    "any.required": "Period is required",
+    "any.only": "Period must be either 'week' or 'month'",
+  }),
+}).unknown(true);
+
+module.exports = {
+  getStatsQuerySchema,
+};

--- a/packages/app/server.js
+++ b/packages/app/server.js
@@ -31,7 +31,7 @@ app.use(cookieParser());
 app.disable("x-powered-by");
 app.use(express.json());
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-app.use("/api/", routes);
+app.use("/api", routes);
 
 if (process.env.NODE_ENV !== "test") {
   const PORT = process.env.PORT;

--- a/packages/app/server.js
+++ b/packages/app/server.js
@@ -31,7 +31,7 @@ app.use(cookieParser());
 app.disable("x-powered-by");
 app.use(express.json());
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-app.use("/api", routes);
+app.use("/api/", routes);
 
 if (process.env.NODE_ENV !== "test") {
   const PORT = process.env.PORT;

--- a/packages/app/services/index.js
+++ b/packages/app/services/index.js
@@ -5,6 +5,7 @@ const SubscriptionService = require("./subscriptions");
 const UserTokenService = require("./usertoken");
 const UserService = require("./users");
 const RequestService = require("./request");
+const LogoRequestLogsService = require("./logoRequestlogs");
 
 module.exports = {
   ContactUsService,
@@ -14,4 +15,5 @@ module.exports = {
   UserTokenService,
   UserService,
   RequestService,
+  LogoRequestLogsService,
 };

--- a/packages/app/services/logoRequestlogs.js
+++ b/packages/app/services/logoRequestlogs.js
@@ -1,0 +1,46 @@
+const { LogoRequestLogsRepository } = require("../repositories");
+
+class LogoRequestLogsService {
+  constructor() {
+    this.LogoRequestLogsRepository = new LogoRequestLogsRepository();
+  }
+
+  /**
+   * Create a new API request record
+   * @param {Object} requestData - The data for the new API request
+   * @param {string} requestData.user_id - The ID of the user making the request
+   * @param {string} requestData.key_id - The ID of the API key used for the request
+   * @param {string} requestData.image_id - The ID of the image requested
+   * @param {number} [requestData.response_size_bytes=0] - The size of the response in bytes
+   * @returns {Promise<Object>} - The newly created API request object
+   */
+  async createEntry(requestData) {
+    const newRequest = {
+      user_id: requestData.user_id,
+      key_id: requestData.key_id,
+      image_id: requestData.image_id,
+      response_size_bytes: requestData.response_size_bytes || 0,
+    };
+    return await this.LogoRequestLogsRepository.create(newRequest);
+  }
+
+  /**
+   * Get Weekly API request statistics for a user.
+   * @param {string} userId - The ID of the user
+   * @returns {Promise<Object>} - An object containing weekly statistics
+   */
+  async getWeeklyStats(userId) {
+    return await this.LogoRequestLogsRepository.getCurrentWeekData(userId);
+  }
+
+  /**
+   * Get Monthly API request statistics for a user.
+   * @param {string} userId - The ID of the user
+   * @returns {Promise<Object>} - An object containing monthly statistics
+   */
+  async getMonthlyStats(userId) {
+    return await this.LogoRequestLogsRepository.getCurrentMonthData(userId);
+  }
+}
+
+module.exports = LogoRequestLogsService;

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -1,14 +1,18 @@
 const bcrypt = require("bcryptjs");
 const KeyService = require("../services/keys");
+
 const SubscriptionService = require("../services/subscriptions");
 const { UsersRepository, RequestRepository } = require("../repositories");
 const { UserType } = require("../utils/constants");
+const ImageService = require("../services/images");
+const LogoRequestLogsService = require("../services/logoRequestlogs");
 
 class UserService {
   constructor() {
     this.userRepository = new UsersRepository();
     this.keyService = new KeyService();
-
+    this.imageService = new ImageService();
+    this.logoRequestLogsService = new LogoRequestLogsService();
     this.subscriptionService = new SubscriptionService();
     this.requestRepository = new RequestRepository();
   }
@@ -274,6 +278,32 @@ class UserService {
    */
   async getUserBySubscriptionId(subscriptionId) {
     return await this.userRepository.findUserBySubscriptionId(subscriptionId);
+  }
+
+  /**
+   * Logs an API request entry for a logo fetch operation.
+   * This is a non-fatal operation - failures are logged but do not interrupt the flow.
+   * @param {string} company - The company name.
+   * @param {Object} userSubscription - The user's subscription object.
+   * @param {Object} keyRef - The API key reference object.
+   * @returns {Promise<void>} - No return value, failures are silently logged.
+   */
+  async logLogoRequestEntry(company, userSubscription, keyRef) {
+    try {
+      const [imageDoc, userRef] = await Promise.all([
+        this.imageService.getImageByCompanyName(company),
+        this.getUserBySubscriptionId(userSubscription._id),
+      ]);
+      const requestPayload = {
+        user_id: userRef._id,
+        key_id: keyRef._id,
+        image_id: imageDoc && imageDoc._id,
+        response_size_bytes: (imageDoc && imageDoc.image_size) || 0,
+      };
+      await this.logoRequestLogsService.createEntry(requestPayload);
+    } catch (err) {
+      console.error("Failed to create API request entry:", err.message);
+    }
   }
 }
 

--- a/packages/app/services/users.js
+++ b/packages/app/services/users.js
@@ -266,6 +266,15 @@ class UserService {
     );
     return updatedUser;
   }
+
+  /**
+   * Gets userId from subscriptionId.
+   * @param {String} subscriptionId - The subscriptionId of the user.
+   * @returns {Object} - User Object.
+   */
+  async getUserBySubscriptionId(subscriptionId) {
+    return await this.userRepository.findUserBySubscriptionId(subscriptionId);
+  }
 }
 
 module.exports = UserService;

--- a/packages/app/utils/mocks.js
+++ b/packages/app/utils/mocks.js
@@ -142,6 +142,7 @@ const MOCK_USERTOKENS = [
 
 const MOCK_KEYS = [
   {
+    _id: new mongoose.Types.ObjectId(),
     user: new mongoose.Types.ObjectId(),
     key: "28482DNDO483ND3",
     key_description: "API-KEY-1",
@@ -149,6 +150,7 @@ const MOCK_KEYS = [
     updatedAt: Date.now(),
   },
   {
+    _id: new mongoose.Types.ObjectId(),
     user: new mongoose.Types.ObjectId(),
     key: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     key_description: "API-KEY-1",
@@ -363,6 +365,66 @@ const MOCK_CONTACTUS_FORM_DATA = [
   },
 ];
 
+const MOCK_LOGO_REQUESTS = [
+  {
+    _id: new mongoose.Types.ObjectId(),
+    user_id: MOCK_USERS[0]._id,
+    key_id: MOCK_KEYS[0]._id,
+    image_id: MOCK_IMAGES[0]._id,
+    response_size_bytes: 1024,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    _id: new mongoose.Types.ObjectId(),
+    user_id: MOCK_USERS[1]._id,
+    key_id: MOCK_KEYS[1]._id,
+    image_id: MOCK_IMAGES[1]._id,
+    response_size_bytes: 2048,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    _id: new mongoose.Types.ObjectId(),
+    user_id: MOCK_USERS[0]._id,
+    key_id: MOCK_KEYS[0]._id,
+    image_id: MOCK_IMAGES[2]._id,
+    response_size_bytes: 3072,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+const MOCK_WEEKLY_STATS = {
+  period: "week",
+  startDate: "2025-11-24",
+  endDate: "2025-12-01",
+  summary: {
+    totalCount: 15,
+    totalKB: "45.50",
+  },
+  data: [
+    { date: "2025-11-24", count: 2, totalKB: 5.25 },
+    { date: "2025-11-25", count: 3, totalKB: 8.75 },
+    { date: "2025-11-26", count: 4, totalKB: 12 },
+  ],
+};
+
+const MOCK_MONTHLY_STATS = {
+  period: "month",
+  startDate: "2025-11-01",
+  endDate: "2025-12-01",
+  summary: {
+    totalCount: 50,
+    totalKB: "150.75",
+  },
+  data: [
+    { date: "2025-11-01", count: 5, totalKB: 15.25 },
+    { date: "2025-11-05", count: 8, totalKB: 24.5 },
+    { date: "2025-11-10", count: 12, totalKB: 36 },
+  ],
+};
+
 module.exports = {
   MOCK_SUBSCRIPTION,
   MOCK_USERS,
@@ -376,4 +438,7 @@ module.exports = {
   MOCK_PRESIGNED_REQUEST_UPDATE,
   MOCK_REQUESTS_LIST,
   MOCK_CONTACTUS_FORM_DATA,
+  MOCK_LOGO_REQUESTS,
+  MOCK_WEEKLY_STATS,
+  MOCK_MONTHLY_STATS,
 };


### PR DESCRIPTION
## Description
closes #868 
Added Feature to track logo requests made by the user using generated api keys.
The user can see their weekly and monthly usage statistics.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Demo: API Key Verification (Postman)
Attached below is a short video demonstrating the API key working in Postman and returning valid data.


https://github.com/user-attachments/assets/91fcaa51-b31e-45f9-bdf8-331cd9532ee6

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
