### PR TITLE
fix: Automatic Catelog backend empty search fix

### DIFF
--- a/packages/app/__tests__/controllers/catalog/getlogos.js
+++ b/packages/app/__tests__/controllers/catalog/getlogos.js
@@ -212,17 +212,21 @@ describe("GET /api/catalog/logos", () => {
       source: "web-search",
       data: [
         {
+          bufferBase64: "",
           companyName: "TestCompany",
           url: "https://logo.png",
           companyUri: "https://testcompany.com/",
           extension: "png",
+          mimeType: "",
           size: 1024,
         },
         {
+          bufferBase64: "",
           companyName: "TestCompany",
           url: "https://logo2.png",
           companyUri: "https://testcompany.com/",
           extension: "png",
+          mimeType: "",
           size: 2048,
         },
       ],
@@ -270,17 +274,21 @@ describe("GET /api/catalog/logos", () => {
       source: "web-search",
       data: [
         {
+          bufferBase64: "",
           companyName: "TestCompany",
           url: "https://logo.png",
           companyUri: "https://testcompany.com/",
           extension: "png",
+          mimeType: "",
           size: 1024,
         },
         {
+          bufferBase64: "",
           companyName: "TestCompany",
           url: "https://logo2.png",
           companyUri: "https://testcompany.com/",
           extension: "png",
+          mimeType: "",
           size: 2048,
         },
       ],

--- a/packages/app/controllers/catalog.js
+++ b/packages/app/controllers/catalog.js
@@ -247,9 +247,10 @@ async function getCatalogController(req, res, next) {
           error: STATUS_CODES[404],
         });
       } catch (error) {
+        console.error("Failed to fetch logos from external source", error);
         return res.status(502).json({
           statusCode: 502,
-          message: "Failed to fetch logos from external source" + error,
+          message: "Failed to fetch logos from external source",
           error: STATUS_CODES[502],
         });
       }

--- a/packages/app/controllers/catalog.js
+++ b/packages/app/controllers/catalog.js
@@ -222,18 +222,18 @@ async function getCatalogController(req, res, next) {
         });
       }
     }
-    if (imageData.data.length === 0) {
+    if (search && imageData?.data?.length === 0) {
       try {
         const webSearchResult = await grabCompanyLogos(search);
-        if (webSearchResult.logos.length > 0) {
-          const logoOptions = webSearchResult.logos.map((logo) => ({
+        if (webSearchResult?.logos?.length > 0) {
+          const logoOptions = webSearchResult?.logos?.map((logo) => ({
             companyName: logo.companyName,
             url: logo.url,
             companyUri: logo.companyUri,
             extension: logo.extension,
             size: logo.size,
-            bufferBase64: logo.bufferBase64,
-            mimeType: logo.mimeType,
+            bufferBase64: logo.bufferBase64 || "",
+            mimeType: logo.mimeType || "",
           }));
           return res.status(200).json({
             statusCode: 200,
@@ -241,14 +241,18 @@ async function getCatalogController(req, res, next) {
             source: "web-search",
           });
         }
-      } catch (webSearchError) {
-        console.error("Web search failed:", webSearchError.message);
+        return res.status(404).json({
+          message: Messages.LOGO_NOT_FOUND,
+          statusCode: 404,
+          error: STATUS_CODES[404],
+        });
+      } catch (error) {
+        return res.status(502).json({
+          statusCode: 502,
+          message: "Failed to fetch logos from external source" + error,
+          error: STATUS_CODES[502],
+        });
       }
-      return res.status(404).json({
-        message: Messages.LOGO_NOT_FOUND,
-        statusCode: 404,
-        error: STATUS_CODES[404],
-      });
     }
     return res.status(200).json({
       statusCode: 200,


### PR DESCRIPTION
Closes: #875
## Description
- Fixes production issue by preventing web logo search when the search query is empty. Ensures empty searches return DB results only, avoiding false 404s and external dependency failures.

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [x] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screen Recording

https://github.com/user-attachments/assets/0c53f9c8-f0be-4ae9-8380-fee3862d9932



## Screenshots
<!-- Add screenshots to help explain your changes. -->
<img width="1941" height="766" alt="image" src="https://github.com/user-attachments/assets/2d552fd6-48ac-4da9-9da9-cee8f4536277" />

_Coverage report_


<img width="1019" height="871" alt="image" src="https://github.com/user-attachments/assets/9e7680d7-c411-4b99-8820-385fd65e1034" />

_Test report_
## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
