### PR TITLE
 Show date of expiry for generated keys & ensure clean response is only returned. 

### DIFF
--- a/packages/app/models/keys.js
+++ b/packages/app/models/keys.js
@@ -46,8 +46,8 @@ keySchema.methods.data = function () {
   return {
     _id: this._id,
     key_description: this.key_description,
-    api_key: this.api_key,
     subscription_id: this.subscription_id,
+    expires_at: this.expires_at,
     created_at: this._id.getTimestamp(),
     updated_at: this.updated_at,
   };

--- a/packages/app/models/keys.js
+++ b/packages/app/models/keys.js
@@ -46,6 +46,7 @@ keySchema.methods.data = function () {
   return {
     _id: this._id,
     key_description: this.key_description,
+    api_key: this.api_key,
     subscription_id: this.subscription_id,
     expires_at: this.expires_at,
     created_at: this._id.getTimestamp(),

--- a/packages/app/repositories/keys.js
+++ b/packages/app/repositories/keys.js
@@ -18,9 +18,11 @@ class KeysRepository extends BaseRepository {
    * @returns {Array<Object>} - Keys Object Array.
    */
   async getMultipleKeys(keyIds) {
-    return await this.model.find({
-      _id: { $in: keyIds },
-    });
+    return await this.model
+      .find({
+        _id: { $in: keyIds },
+      })
+      .select("key_description subscription_id updated_at expires_at _id");
   }
 
   /**

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -102,8 +102,8 @@ const Messages = {
   RESEND_EMAIL_FAILED: "Failed to resend verification email.",
   TOO_MANY_REQUESTS: "Too many requests. Please try again later.",
   SENT_FORGOT_PASSWORD_EMAIL: "Email sent to reset password.",
-  API_KEY_EXPIRED: "Your Key has been expired",
-  UPDATE_API_KEY: "Your API Key needs an update",
+  API_KEY_EXPIRED: "This Key has got expired.",
+  UPDATE_API_KEY: "This Key needs an update.",
 };
 
 const ExtractCompanyNameFromUrlRegex = /:\/\/(?:www\.)?([^./]+)\./i;

--- a/packages/ui/__tests__/page/dashboard/Dashboard.test.jsx
+++ b/packages/ui/__tests__/page/dashboard/Dashboard.test.jsx
@@ -207,6 +207,29 @@ describe("Dashboard", () => {
     expect(dashboard).toBeInTheDocument();
   });
 
+  it("should apply warning className to expiring API keys", async () => {
+    const expiringKey = {
+      ...MOCK_USER_DATA.keys[0],
+      expires_at: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+
+    const userContext = mockUserContext(
+      {
+        ...MOCK_USER_DATA,
+        keys: [expiringKey],
+      },
+      false
+    );
+
+    renderDashboard({ userContextValue: userContext });
+
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    const dataRow = rows[1];
+
+    expect(dataRow.className).toContain("expiry-warning-row");
+  });
+
   it("should render nothing if options array is empty", () => {
     render(
       <Dropdown options={[]} selectedOption="" setSelectedOption={vi.fn()} />

--- a/packages/ui/src/components/apikeyform/ApiKeyForm.jsx
+++ b/packages/ui/src/components/apikeyform/ApiKeyForm.jsx
@@ -11,6 +11,7 @@ import {
   API_KEY,
   BUTTON_TEXT,
   API_KEY_FORM,
+  EXPIRY_KEYS_OPTION,
 } from "../../utils/Constants.js";
 import { useToast } from "../../hooks/useToast.js";
 import { formatDate, validate } from "../../utils/Helpers.js";
@@ -24,14 +25,6 @@ function ApiKeyForm({ isGuest, onKeyGenerated }) {
   const [copyMessage, setCopyMessage] = useState("");
   const [expiresInDays, setExpiresInDays] = useState(365);
   const toast = useToast();
-
-  const expiryOptions = [
-    { value: 7, label: "1 Week" },
-    { value: 30, label: "1 Month" },
-    { value: 90, label: "3 Months" },
-    { value: 180, label: "6 Months" },
-    { value: 365, label: "1 Year" },
-  ];
 
   const { makeRequest, data, loading, errorMsg } = useApi({
     method: "post",
@@ -132,7 +125,7 @@ function ApiKeyForm({ isGuest, onKeyGenerated }) {
             {API_KEY_FORM.expiryDescription}
           </p>
           <Dropdown
-            options={expiryOptions}
+            options={EXPIRY_KEYS_OPTION}
             selectedOption={String(expiresInDays)}
             setSelectedOption={(value) => setExpiresInDays(Number(value))}
             testId="testid-expiry-dropdown"

--- a/packages/ui/src/components/common/table/Table.jsx
+++ b/packages/ui/src/components/common/table/Table.jsx
@@ -19,30 +19,38 @@ const Table = ({ headers, rows, emptyMessage, onDelete, isGuest }) => {
         </thead>
         <tbody>
           {hasData ? (
-            rows.map((cells, index) => (
-              <tr key={`${cells[index]}-${index}`}>
-                {cells.map((cell, CIndex) => (
-                  <td
-                    key={`${cell}-${CIndex}`}
-                    className={styles["table-cell"]}
-                  >
-                    {cell}
-                  </td>
-                ))}
-                {onDelete && (
-                  <td className={styles["table-cell"]}>
-                    <Button
-                      variant="danger"
-                      className={styles["delete-btn"]}
-                      onClick={() => onDelete(index)}
-                      disabled={isGuest}
+            rows.map((cells, index) => {
+              const isArrayFormat = Array.isArray(cells);
+              const cellsData = isArrayFormat ? cells : cells.cells;
+              const rowClassName = isArrayFormat
+                ? ""
+                : cells.rowClassName || "";
+
+              return (
+                <tr key={`${cellsData[0]}-${index}`} className={rowClassName}>
+                  {cellsData.map((cell, CIndex) => (
+                    <td
+                      key={`${cell}-${CIndex}`}
+                      className={styles["table-cell"]}
                     >
-                      {BUTTON_TEXT.delete}
-                    </Button>
-                  </td>
-                )}
-              </tr>
-            ))
+                      {cell}
+                    </td>
+                  ))}
+                  {onDelete && (
+                    <td className={styles["table-cell"]}>
+                      <Button
+                        variant="danger"
+                        className={styles["delete-btn"]}
+                        onClick={() => onDelete(index)}
+                        disabled={isGuest}
+                      >
+                        {BUTTON_TEXT.delete}
+                      </Button>
+                    </td>
+                  )}
+                </tr>
+              );
+            })
           ) : (
             <tr>
               <td

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -48,9 +48,10 @@ function Dashboard() {
   });
 
   const apiKeyTableData = useMemo(() => {
-    return apiKeys.map(({ key_description, updated_at }) => [
+    return apiKeys.map(({ key_description, updated_at, expires_at }) => [
       key_description,
       formatDate(updated_at),
+      formatDate(expires_at),
     ]);
   }, [apiKeys]);
 

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -48,11 +48,27 @@ function Dashboard() {
   });
 
   const apiKeyTableData = useMemo(() => {
-    return apiKeys.map(({ key_description, updated_at, expires_at }) => [
-      key_description,
-      formatDate(updated_at),
-      formatDate(expires_at),
-    ]);
+    const result = apiKeys.map(
+      ({ key_description, updated_at, expires_at }) => {
+        const expiryDate = new Date(expires_at);
+        const today = new Date();
+        const daysUntilExpiry = Math.floor(
+          (expiryDate - today) / (1000 * 60 * 60 * 24)
+        );
+        const isExpiringSoon = daysUntilExpiry <= 7;
+
+        return {
+          cells: [
+            key_description,
+            formatDate(updated_at),
+            formatDate(expires_at),
+          ],
+          rowClassName: isExpiringSoon ? styles["expiry-warning-row"] : "",
+        };
+      }
+    );
+
+    return result;
   }, [apiKeys]);
 
   useEffect(() => {

--- a/packages/ui/src/page/dashboard/Dashboard.module.css
+++ b/packages/ui/src/page/dashboard/Dashboard.module.css
@@ -88,6 +88,15 @@
   text-align: center;
 }
 
+.expiry-warning-row {
+  background-color: #fee2e2;
+}
+
+.expiry-warning-row td {
+  color: #dc2626;
+  font-weight: 500;
+}
+
 @media screen and (max-width: 768px) {
   .dashboard-container {
     flex-direction: column;

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -624,7 +624,7 @@ export const DOCUMENTATION = {
 };
 
 export const API_KEY_TABLE = {
-  headers: ["Description", "Created", "Action"],
+  headers: ["Description", "Created", "Expires", "Action"],
   emptyMessage:
     "Your api keys will be visible here, click on generate key to add new api key",
 };
@@ -806,7 +806,13 @@ export const API_KEY_FORM = {
   expiryLabel: "Expiry Period",
   expiryDescription: "Choose how long your API key will remain valid.",
 };
-
+export const EXPIRY_KEYS_OPTION = [
+  { value: 7, label: "1 Week" },
+  { value: 30, label: "1 Month" },
+  { value: 90, label: "3 Months" },
+  { value: 180, label: "6 Months" },
+  { value: 365, label: "1 Year" },
+];
 export const IMAGE_UPLOAD_MODEL = {
   dragAndDropImage: "Drag and drop image",
   or: "OR",


### PR DESCRIPTION
## Description
closes #925

This PR improves Ux for user by showing expiration dates in a table with warnings when keys are about to expire also it consist of backend changes done to ensure clean response is being sent to user without containing anything sensitive information about API key which is meant to be shown only when created .

## What type of PR is this? (Check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots.
### Frontend

The UI enhancement makes API Key that would expire expire very soon user, get warn with red

<img width="1222" height="790" alt="image" src="https://github.com/user-attachments/assets/097ebc17-6f17-4ec8-992c-aea8e3ac0792" />

#### Frontend test
<img width="1091" height="107" alt="image" src="https://github.com/user-attachments/assets/b5935aa5-a6f8-44e8-ace8-ce31ecac2ac1" />

#### Coverage for Frontend
<img width="631" height="892" alt="image" src="https://github.com/user-attachments/assets/d565966d-b4c3-42a4-8dee-309ab951a21f" />


-----
### Backend
#### The response sent now does not consist of sensitive info about keys.
<img width="1389" height="898" alt="image" src="https://github.com/user-attachments/assets/6091b6bb-2667-4c89-8807-c294085b7551" />

#### Existing backend test are running fine.
<img width="464" height="111" alt="image" src="https://github.com/user-attachments/assets/af52a8ee-17c4-4fe8-a19d-555add7b62e1" />

#### Coverage of backend 
<img width="779" height="1025" alt="image" src="https://github.com/user-attachments/assets/493a2369-ef30-42a3-9a78-f0964ecc7cff" />



## Checklist
- [X] I have performed a self-review of my code  
- [X] New and existing unit tests pass locally with my changes
