### PR TITLE
toast notification when user reaches limits

### DIFF
--- a/packages/ui/__tests__/components/Usage.test.jsx
+++ b/packages/ui/__tests__/components/Usage.test.jsx
@@ -1,9 +1,23 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import Usage from "../../src/components/usage/Usage";
 import { MOCK_USER_DATA } from "../../src/utils/Constants";
 
+const mockToastWarning = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("../../src/hooks/useToast.js", () => ({
+  useToast: () => ({
+    warning: mockToastWarning,
+    error: mockToastError,
+  }),
+}));
+
 describe("Usage Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("Should show correct usage count, usage limit", () => {
     render(
       <Usage
@@ -38,5 +52,71 @@ describe("Usage Component", () => {
     const percentageText = screen.getByText(`${usedPercent}%`);
     expect(pieGraph).toBeInTheDocument();
     expect(percentageText).toBeInTheDocument();
+  });
+
+  describe("Toast Notifications Logic", () => {
+    const LIMIT = 500;
+
+    it("should not trigger any toast when usage is below 80%", () => {
+      render(<Usage usageCount={350} usageLimit={LIMIT} />);
+      expect(mockToastWarning).not.toHaveBeenCalled();
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    it("should trigger warning toast exactly once at 80%", () => {
+      render(<Usage usageCount={400} usageLimit={LIMIT} />);
+      expect(mockToastWarning).toHaveBeenCalledTimes(1);
+      expect(mockToastWarning).toHaveBeenCalledWith(
+        expect.stringContaining("80%")
+      );
+    });
+
+    it("should trigger only the highest threshold warning (90%) and suppress lower ones", () => {
+      render(<Usage usageCount={450} usageLimit={LIMIT} />);
+      expect(mockToastWarning).toHaveBeenCalledTimes(1);
+      expect(mockToastWarning).toHaveBeenCalledWith(
+        expect.stringContaining("90%")
+      );
+    });
+
+    it("should trigger error toast at 95% and suppress warnings", () => {
+      render(<Usage usageCount={475} usageLimit={LIMIT} />);
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining("95%")
+      );
+      expect(mockToastWarning).not.toHaveBeenCalled();
+    });
+
+    it("should trigger error toast at 100% and suppress lower thresholds", () => {
+      render(<Usage usageCount={500} usageLimit={LIMIT} />);
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining("100%")
+      );
+      expect(mockToastWarning).not.toHaveBeenCalled();
+    });
+
+    it("should handle sequential usage increases correctly (no duplicates)", () => {
+      const { rerender } = render(
+        <Usage usageCount={400} usageLimit={LIMIT} />
+      );
+      expect(mockToastWarning).toHaveBeenCalledTimes(1);
+      expect(mockToastWarning).toHaveBeenCalledWith(
+        expect.stringContaining("80%")
+      );
+
+      vi.clearAllMocks();
+
+      rerender(<Usage usageCount={425} usageLimit={LIMIT} />);
+      expect(mockToastWarning).not.toHaveBeenCalled();
+
+      rerender(<Usage usageCount={480} usageLimit={LIMIT} />);
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.stringContaining("96%")
+      );
+      expect(mockToastWarning).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/usage/Usage.jsx
+++ b/packages/ui/src/components/usage/Usage.jsx
@@ -2,9 +2,45 @@ import PropTypes from "prop-types";
 import PieGraph from "./PieGraph";
 import styles from "./Usage.module.css";
 import { USAGE } from "../../utils/Constants";
+import { useEffect, useRef, useMemo } from "react";
+import { useToast } from "../../hooks/useToast.js";
 
 function Usage({ usageCount, usageLimit }) {
-  const percentage = (usageCount / usageLimit) * 100;
+  const percentage = useMemo(
+    () => (usageCount / usageLimit) * 100,
+    [usageCount, usageLimit]
+  );
+  const toast = useToast();
+  const notifiedRef = useRef({ 80: false, 90: false, 95: false, 100: false });
+
+  useEffect(() => {
+    if (!Number.isFinite(percentage) || usageLimit <= 0 || !toast) return;
+
+    const thresholds = [
+      { p: 100, type: "error" },
+      { p: 95, type: "error" },
+      { p: 90, type: "warning" },
+      { p: 80, type: "warning" },
+    ];
+
+    const crossedThreshold = thresholds.find(({ p }) => percentage >= p);
+
+    if (crossedThreshold) {
+      const { p, type } = crossedThreshold;
+
+      if (!notifiedRef.current[p]) {
+        const msg = `You have used ${Math.floor(percentage)}% of your monthly API limit (${usageCount}/${usageLimit}).`;
+        toast[type](msg);
+
+        thresholds.forEach((t) => {
+          if (t.p <= p) {
+            notifiedRef.current[t.p] = true;
+          }
+        });
+      }
+    }
+  }, [percentage, usageCount, usageLimit, toast]);
+
   return (
     <>
       <div className={styles["usage-body-container"]}>


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->
this pr closes #931 
This feature displays a toast notification for the user when they reach 80% , 90% , 95% and 100%.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="1898" height="933" alt="Screenshot from 2026-01-09 17-41-25" src="https://github.com/user-attachments/assets/b9017178-9874-460f-820c-9f2e4d394f1b" />
<img width="1898" height="933" alt="Screenshot from 2026-01-09 17-41-49" src="https://github.com/user-attachments/assets/30bbfe7e-51c7-4c6c-852d-3a04cee66ca8" />
<img width="1898" height="933" alt="Screenshot from 2026-01-09 17-42-04" src="https://github.com/user-attachments/assets/e50dddf5-f441-4abb-bb86-cb374cf1d8ec" />
<img width="1898" height="933" alt="Screenshot from 2026-01-09 17-45-36" src="https://github.com/user-attachments/assets/32d45918-3097-46ae-ac28-4ec0929734ea" />

## test cases
<img width="1794" height="588" alt="Screenshot from 2026-01-09 17-45-58" src="https://github.com/user-attachments/assets/e3c19bc7-b56e-4224-b5d0-42e49f3d646a" />

## coverage 

<img width="1354" height="85" alt="image" src="https://github.com/user-attachments/assets/bbeae994-086a-46a8-a3a3-11c4b919ddc5" />

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
