### PR TITLE
fix: Enhance password reset and update logic to prevent same password…

### DIFF
--- a/packages/app/__tests__/controllers/auth/reset-password.js
+++ b/packages/app/__tests__/controllers/auth/reset-password.js
@@ -1,6 +1,7 @@
 const request = require("supertest");
 const { STATUS_CODES } = require("http");
 const { ENDPOINTS } = require("../../../utils/testconstants");
+const { Users } = require("../../../models");
 const {
   UserService,
   UserTokenService,
@@ -9,9 +10,21 @@ const {
 const { Messages } = require("../../../utils/constants");
 
 const app = require("../../../server");
-const { MOCK_SESSION_ID, MOCK_USER_SESSIONS } = require("../../../utils/mocks");
+const {
+  MOCK_SESSION_ID,
+  MOCK_USER_SESSIONS,
+  MOCK_USERS,
+} = require("../../../utils/mocks");
 const dummyPassword =
   require("../../../utils/generatePassword").generatePassword();
+const bcrypt = require("bcryptjs");
+
+function createMockUser(password = dummyPassword) {
+  return new Users({
+    ...MOCK_USERS[0],
+    password: bcrypt.hashSync(password, 10),
+  });
+}
 
 describe("RESET PASSWORD API", () => {
   it("401 - User is not signed in", async () => {
@@ -206,17 +219,27 @@ describe("RESET PASSWORD API", () => {
     });
   });
 
-  it("400 - Failed to update password", async () => {
-    jest.spyOn(UserService.prototype, "getUser").mockResolvedValue(null);
+  it("400 - New password cannot be same as old password", async () => {
+    const mockUser = {
+      ...MOCK_USERS[0],
+      matchPassword: jest.fn().mockResolvedValue(true),
+    };
+
     jest
-      .spyOn(UserService.prototype, "updateUserPassword")
-      .mockResolvedValue(null);
+      .spyOn(PasswordResetService.prototype, "findAndUpdateActiveSession")
+      .mockResolvedValue({
+        ...MOCK_USER_SESSIONS[0],
+        userId: mockUser,
+      });
+
     jest
       .spyOn(UserTokenService.prototype, "fetchUserToken")
       .mockResolvedValue({ token: "validToken" });
+
     jest
-      .spyOn(PasswordResetService.prototype, "findAndUpdateActiveSession")
-      .mockResolvedValue(MOCK_USER_SESSIONS[0]);
+      .spyOn(UserTokenService.prototype, "deleteUserToken")
+      .mockResolvedValue({});
+
     const response = await request(app)
       .patch(ENDPOINTS.RESET_PASSWORD)
       .set("Cookie", [`resetPasswordSessionId=${MOCK_SESSION_ID}`])
@@ -229,11 +252,44 @@ describe("RESET PASSWORD API", () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       error: STATUS_CODES[400],
+      message: Messages.SAME_PASSWORD,
+      statusCode: 400,
+    });
+  });
+  it("400 - Failed to update password", async () => {
+    const mockUser = createMockUser();
+
+    jest
+      .spyOn(PasswordResetService.prototype, "findAndUpdateActiveSession")
+      .mockResolvedValue({
+        ...MOCK_USER_SESSIONS[0],
+        userId: mockUser,
+      });
+
+    jest
+      .spyOn(UserService.prototype, "updateUserPassword")
+      .mockResolvedValue(null);
+
+    jest
+      .spyOn(UserTokenService.prototype, "fetchUserToken")
+      .mockResolvedValue({ token: "validToken" });
+
+    const response = await request(app)
+      .patch(ENDPOINTS.RESET_PASSWORD)
+      .set("Cookie", [`resetPasswordSessionId=${MOCK_SESSION_ID}`])
+      .send({
+        newPassword: dummyPassword + "1",
+        confirmPassword: dummyPassword + "1",
+        token: "validToken",
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: STATUS_CODES[400],
       message: Messages.PASS_FAILED,
       statusCode: 400,
     });
   });
-
   it("403 - Invalid credentials", async () => {
     jest.spyOn(UserService.prototype, "getUser").mockResolvedValue(null);
     jest
@@ -264,26 +320,33 @@ describe("RESET PASSWORD API", () => {
   });
 
   it("200 - Success", async () => {
-    jest.spyOn(UserService.prototype, "getUser").mockResolvedValue(null);
+    const mockUser = createMockUser();
+
+    jest
+      .spyOn(PasswordResetService.prototype, "findAndUpdateActiveSession")
+      .mockResolvedValue({
+        ...MOCK_USER_SESSIONS[0],
+        userId: mockUser,
+      });
+
     jest
       .spyOn(UserService.prototype, "updateUserPassword")
       .mockResolvedValue({});
+
     jest
       .spyOn(UserTokenService.prototype, "fetchUserToken")
       .mockResolvedValue({ token: "validToken" });
+
     jest
       .spyOn(UserTokenService.prototype, "deleteUserToken")
       .mockResolvedValue({});
-    jest
-      .spyOn(PasswordResetService.prototype, "findAndUpdateActiveSession")
-      .mockResolvedValue(MOCK_USER_SESSIONS[0]);
 
     const response = await request(app)
       .patch(ENDPOINTS.RESET_PASSWORD)
       .set("Cookie", [`resetPasswordSessionId=${MOCK_SESSION_ID}`])
       .send({
-        newPassword: dummyPassword,
-        confirmPassword: dummyPassword,
+        newPassword: dummyPassword + "1",
+        confirmPassword: dummyPassword + "1",
         token: "validToken",
       });
 

--- a/packages/app/__tests__/controllers/users/updatepassword.js
+++ b/packages/app/__tests__/controllers/users/updatepassword.js
@@ -116,6 +116,34 @@ describe("Update User Password", () => {
     });
   });
 
+  it("400 - New password cannot be same as old password", async () => {
+    const mockUserModel = new Users({
+      ...MOCK_USERS[1],
+      password: bcrypt.hashSync(dummyPassword, 10),
+    });
+
+    const mockInput = {
+      currPassword: dummyPassword,
+      newPassword: dummyPassword,
+    };
+
+    jest
+      .spyOn(UserService.prototype, "getUserByEmail")
+      .mockResolvedValue(mockUserModel);
+
+    const response = await request(app)
+      .put("/api/user/password")
+      .set("Cookie", `sessionId=${MOCK_SESSION_ID}`)
+      .send(mockInput);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: Messages.SAME_PASSWORD,
+      statusCode: 400,
+      error: STATUS_CODES[400],
+    });
+  });
+
   it("500 - Something went wrong. Try again later", async () => {
     const mockUserModel = new Users({
       ...MOCK_USERS[1],
@@ -123,7 +151,7 @@ describe("Update User Password", () => {
     });
     const mockInput = {
       currPassword: dummyPassword,
-      newPassword: dummyPassword,
+      newPassword: dummyPassword + "1",
     };
     jest
       .spyOn(UserService.prototype, "getUserByEmail")
@@ -152,7 +180,7 @@ describe("Update User Password", () => {
     });
     const mockInput = {
       currPassword: dummyPassword,
-      newPassword: dummyPassword,
+      newPassword: dummyPassword + "1",
     };
     jest
       .spyOn(UserService.prototype, "getUserByEmail")
@@ -178,7 +206,7 @@ describe("Update User Password", () => {
     });
     const mockInput = {
       currPassword: dummyPassword,
-      newPassword: dummyPassword,
+      newPassword: dummyPassword + "1",
     };
     jest
       .spyOn(UserService.prototype, "getUserByEmail")

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -532,7 +532,6 @@ async function resetPasswordController(req, res, next) {
       });
     }
     const { userId: user } = resetSession;
-
     if (resetSession.token !== value.token) {
       return res.status(403).json({
         error: STATUS_CODES[403],
@@ -540,14 +539,19 @@ async function resetPasswordController(req, res, next) {
         statusCode: 403,
       });
     }
-
     const userToken = await userTokenService.fetchUserToken(value.token);
-
+    const isSameAsOldPassword = await user.matchPassword(value.newPassword);
+    if (isSameAsOldPassword) {
+      return res.status(400).json({
+        error: STATUS_CODES[400],
+        message: Messages.SAME_PASSWORD,
+        statusCode: 400,
+      });
+    }
     const result = await userService.updateUserPassword(
       user,
       value.newPassword
     );
-
     if (!result) {
       return res.status(400).json({
         error: STATUS_CODES[400],

--- a/packages/app/controllers/users.js
+++ b/packages/app/controllers/users.js
@@ -309,8 +309,16 @@ async function updatePasswordController(req, res, next) {
         error: STATUS_CODES[400],
       });
     }
+    const isSameAsOldPassword = await user.matchPassword(newPassword);
+    if (isSameAsOldPassword) {
+      return res.status(400).json({
+        message: Messages.SAME_PASSWORD,
+        statusCode: 400,
+        error: STATUS_CODES[400],
+      });
+    }
 
-    const userUpdateSuccessful = userService.updateUserPassword(
+    const userUpdateSuccessful = await userService.updateUserPassword(
       user,
       newPassword
     );

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -80,7 +80,8 @@ const Messages = {
   IMAGE_NOT_EXIST: "Image does not exist",
   ALREADY_SEND_RESPOND: "Already sent the response.",
   UPDATE_SUCCESS: "Responded successfully.",
-  INCORRECT_PASSWORD: "Current password is incorrect",
+  INCORRECT_PASSWORD: "Current password is incorrect", 
+  SAME_PASSWORD:"Current password is same as old password",
   INTERNAL_SERVER_ERROR:
     "An unexpected error occurred. Please try again later.",
   FORM_ALREADY_SUBMITTED: "Form already submitted, try again later",


### PR DESCRIPTION


## Description
 Closes #975 
 
 Summary

This PR introduces validation in the password reset flow to prevent users from setting a new password that is the same as their current password.

Problem

 during the password reset process, the system allowed users to reset their password to the same value as their existing password.

Solution

A password comparison check has been added before updating the user's password. The system now verifies whether the provided new password matches the current hashed password stored in the database.

If the new password matches the existing password:

The reset request is rejected.

A 400 response is returned with an appropriate error message.

Implementation Details

## What type of PR is this? (Check all applicable) 

- [ ] 🍕 Feature
- [✔️ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [✔️ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. --> 
<img width="584" height="277" alt="Screenshot 2026-03-10 212543" src="https://github.com/user-attachments/assets/17ebf872-6403-406b-b138-3eb00ff36c7a" />


## Checklist
- [✔️ ] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ✔️] I have added tests that prove my fix is effective or that my feature works  
- [ ✔️] New and existing unit tests pass locally with my changes
