### PR TITLE
fix: bugs and improve redirect flow for createLogo page

### DIFF
--- a/packages/ui/__tests__/page/createlogo/CreateLogo.test.jsx
+++ b/packages/ui/__tests__/page/createlogo/CreateLogo.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import CreateLogo from "../../../src/page/createlogo/CreateLogo";
-import { UserContext } from "../../../src/contexts/Contexts";
+import { UserContext, AuthContext } from "../../../src/contexts/Contexts";
 
 // Mock fabric
 vi.mock("fabric", async (importOriginal) => {
@@ -70,6 +70,8 @@ vi.mock("../../../src/hooks/useToast", () => ({
   useToast: () => mockToast,
 }));
 
+const mockOpenAuthModal = vi.fn();
+
 // Mock useCanvasControls
 vi.mock("../../../src/components/logo/useCanvasControls", () => ({
   useCanvasControls: () => {
@@ -129,9 +131,13 @@ vi.mock("../../../src/components/logo/useFileOperations", () => ({
 
 const renderCreateLogo = (role = "USER") =>
   render(
-    <UserContext.Provider value={{ userData: { role } }}>
-      <CreateLogo />
-    </UserContext.Provider>
+    <AuthContext.Provider value={{ isAuthenticated: role !== "GUEST" }}>
+      {" "}
+      {/* 👈 */}
+      <UserContext.Provider value={{ userData: { role } }}>
+        <CreateLogo openAuthModal={mockOpenAuthModal} />
+      </UserContext.Provider>
+    </AuthContext.Provider>
   );
 
 describe("CreateLogo", () => {

--- a/packages/ui/src/App.jsx
+++ b/packages/ui/src/App.jsx
@@ -18,7 +18,9 @@ import CreateLogo from "./page/createlogo/CreateLogo.jsx";
 
 function App() {
   const [authModal, setAuthModal] = useState(false);
-  const openCloseAuthModal = () => {
+  const [redirectAfterLogin, setRedirectAfterLogin] = useState("/dashboard");
+  const openCloseAuthModal = (redirectPath = "/dashboard") => {
+    setRedirectAfterLogin(redirectPath);
     setAuthModal(!authModal);
   };
   return (
@@ -36,7 +38,10 @@ function App() {
           <Route path="/verify" element={<Verification />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/release" element={<Release />} />
-          <Route path="/createlogo" element={<CreateLogo />} />
+          <Route
+            path="/createlogo"
+            element={<CreateLogo openAuthModal={openCloseAuthModal} />}
+          />
           <Route
             path="/dashboard"
             element={
@@ -49,7 +54,11 @@ function App() {
         </Routes>
       </div>
       <Footer />
-      <AuthModal isOpen={authModal} onClose={openCloseAuthModal} />
+      <AuthModal
+        isOpen={authModal}
+        onClose={openCloseAuthModal}
+        redirectAfterLogin={redirectAfterLogin}
+      />{" "}
     </div>
   );
 }

--- a/packages/ui/src/components/auth/Auth.jsx
+++ b/packages/ui/src/components/auth/Auth.jsx
@@ -4,7 +4,7 @@ import Modal from "../common/modal/Modal";
 import SignUp from "./Signup";
 import SignIn from "./Signin";
 
-const AuthModal = ({ isOpen, onClose }) => {
+const AuthModal = ({ isOpen, onClose, redirectAfterLogin }) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [showSignUp, setShowSignUp] = useState(false);
@@ -25,7 +25,13 @@ const AuthModal = ({ isOpen, onClose }) => {
       <div
         style={{ opacity: isTransitioning ? 0 : 1, transition: "opacity 0.3s" }}
       >
-        {!showSignUp && <SignIn toggleForm={toggleForm} onClose={onClose} />}
+        {!showSignUp && (
+          <SignIn
+            toggleForm={toggleForm}
+            onClose={onClose}
+            redirectAfterLogin={redirectAfterLogin}
+          />
+        )}
         {showSignUp && <SignUp toggleForm={toggleForm} onClose={onClose} />}
       </div>
     </Modal>
@@ -35,6 +41,7 @@ const AuthModal = ({ isOpen, onClose }) => {
 AuthModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  redirectAfterLogin: PropTypes.string,
 };
 
 export default AuthModal;

--- a/packages/ui/src/components/auth/Signin.jsx
+++ b/packages/ui/src/components/auth/Signin.jsx
@@ -11,7 +11,8 @@ import { useApi } from "../../hooks/useApi";
 import { AuthContext } from "../../contexts/Contexts";
 import { useToast } from "../../hooks/useToast.js";
 
-const SignIn = ({ toggleForm, onClose }) => {
+const SignIn = ({ toggleForm, onClose, redirectAfterLogin = "/dashboard" }) => {
+  console.log("redirectAfterLogin:", redirectAfterLogin);
   const toast = useToast();
   const navigate = useNavigate();
   const [formData, setFormData] = useState(SIGNIN.initialValues);
@@ -137,7 +138,9 @@ const SignIn = ({ toggleForm, onClose }) => {
           setFormData(SIGNIN.initialValues);
           setIsAuthenticated(true);
           onClose();
-          navigate("/dashboard");
+          if (window.location.pathname !== redirectAfterLogin) {
+            navigate(redirectAfterLogin);
+          }
           toast.success(MESSAGES.SIGN_IN_SUCCESS);
         }
         setFocusedField(null);
@@ -154,7 +157,9 @@ const SignIn = ({ toggleForm, onClose }) => {
       setIsAuthenticated(true);
       setIsSubmit(false);
       onClose();
-      navigate("/dashboard");
+      if (window.location.pathname !== redirectAfterLogin) {
+        navigate(redirectAfterLogin);
+      }
       toast.success(MESSAGES.GUEST_SIGN_IN_SUCCESS);
     }
   };
@@ -286,6 +291,7 @@ const SignIn = ({ toggleForm, onClose }) => {
 SignIn.propTypes = {
   toggleForm: PropTypes.func.isRequired,
   onClose: PropTypes.func,
+  redirectAfterLogin: PropTypes.string,
 };
 
 export default SignIn;

--- a/packages/ui/src/components/demo/Demo.jsx
+++ b/packages/ui/src/components/demo/Demo.jsx
@@ -61,14 +61,6 @@ const Demo = ({ openAuthModal }) => {
     }
   };
 
-  const handleCreateLogoClick = () => {
-    if (isAuthenticated) {
-      navigate("/createLogo");
-    } else {
-      openAuthModal();
-    }
-  };
-
   return (
     <>
       <div data-testid="demo" id="demo" className={styles["demo-container"]}>
@@ -115,8 +107,8 @@ const Demo = ({ openAuthModal }) => {
                         {BUTTON_TEXT.requestLogo}
                       </Button>
                       <Button
-                        onClick={handleCreateLogoClick}
-                        variant={"primary"}
+                        onClick={() => navigate("/createlogo")}
+                        variant="primary"
                       >
                         {BUTTON_TEXT.createLogo}
                       </Button>

--- a/packages/ui/src/page/createlogo/CreateLogo.jsx
+++ b/packages/ui/src/page/createlogo/CreateLogo.jsx
@@ -219,6 +219,7 @@ export default function CreateLogo({ openAuthModal }) {
   const handleUploadClick = () => {
     if (!isAuthenticated || isGuest) {
       openAuthModal("/createlogo");
+      setIsUploadModalOpen(true);
       return;
     }
     setIsUploadModalOpen(true);

--- a/packages/ui/src/page/createlogo/CreateLogo.jsx
+++ b/packages/ui/src/page/createlogo/CreateLogo.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useContext, useRef } from "react";
-import { UserContext } from "../../contexts/Contexts.jsx";
+import { UserContext, AuthContext } from "../../contexts/Contexts.jsx";
 import { useToast } from "../../hooks/useToast.js";
 import styles from "./CreateLogo.module.css";
 import { useCanvasControls } from "../../components/logo/useCanvasControls.js";
@@ -7,13 +7,14 @@ import { useFileOperations } from "../../components/logo/useFileOperations.js";
 import TopToolbar from "../../components/logo/TopToolbar.jsx";
 import ToolbarSection from "../../components/logo/ToolbarSection.jsx";
 import LogoUploadForm from "../../components/logo/LogoUploadForm.jsx";
+import PropTypes from "prop-types";
 
-export default function CreateLogo() {
+export default function CreateLogo({ openAuthModal }) {
   const fileInputRef = useRef(null);
   const { userData } = useContext(UserContext);
+  const { isAuthenticated } = useContext(AuthContext);
   const toast = useToast();
   const isGuest = userData?.role === "GUEST";
-  const isAuthenticated = !isGuest;
 
   // State
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -129,6 +130,15 @@ export default function CreateLogo() {
   };
 
   const handleKeyDown = (e) => {
+    const canvas = canvasControls.fabricCanvasRef.current;
+    const activeObj = canvas?.getActiveObject();
+    const isEditingText = activeObj?.isEditing;
+    const isTypingInInput = ["INPUT", "TEXTAREA"].includes(
+      document.activeElement?.tagName
+    );
+
+    if (isEditingText || isTypingInInput) return;
+
     if (e.key === "Delete" || e.key === "Backspace") {
       e.preventDefault();
       canvasControls.deleteSelected();
@@ -207,16 +217,16 @@ export default function CreateLogo() {
   };
 
   const handleUploadClick = () => {
-    if (!isAuthenticated) {
-      toast?.error("Please log in to upload logos");
+    if (!isAuthenticated || isGuest) {
+      openAuthModal("/createlogo");
       return;
     }
     setIsUploadModalOpen(true);
   };
 
   const handleExportClick = () => {
-    if (!isAuthenticated) {
-      toast?.error("Please log in to export logos");
+    if (!isAuthenticated || isGuest) {
+      openAuthModal("/createlogo");
       return;
     }
     fileOperations.handleExport(exportType);
@@ -280,9 +290,9 @@ export default function CreateLogo() {
         canvasControls.fabricCanvasRef.current.isDrawingMode = newMode;
         if (newMode) {
           canvasControls.setupDrawing(currentColor, drawingConfig.brushSize);
-          setActiveTool("draw"); // Activate draw tool
+          setActiveTool("draw");
         } else {
-          setActiveTool(null); // Deactivate draw tool
+          setActiveTool(null);
         }
       },
       setBrushSize: (size) => {
@@ -346,3 +356,6 @@ export default function CreateLogo() {
     </div>
   );
 }
+CreateLogo.propTypes = {
+  openAuthModal: PropTypes.func.isRequired,
+};

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -863,7 +863,7 @@ export const RELEASE_PAGE = {
     title: "Changelog",
     description: "Changelog with often recorded's versions",
     versionsData: [
-          {
+      {
         versionName: "0.7.0 version",
         releaseDate: "Mar 2026",
         imgSrc: version07,


### PR DESCRIPTION
## Description
Issue #978 
## Fix the following bugs on the createLogo page-

1. The backspace button should follow standard behavior and delete character-by-character.
2. URL for the logo on upload should have the option to backspace/delete to allow room for error.

## Enhancement-
Allow unauthenticated users to access CreateLogo page; fix post-login redirect
Previously, clicking "Create Logo" required authentication before accessing the page. Users who drew a logo and then tried to upload it were redirected to /dashboard after login, losing their canvas work.

### Changes:

- ```/createlogo``` route is now publicly accessible; auth is only required on upload/export action
- ```openAuthModal``` now accepts an optional ```redirectAfterLogin``` path (defaults to /dashboard) so callers can control post-login destination
- ```redirectAfterLogin``` is threaded through ```App → AuthModal → SignIn``` and used instead of the hardcoded /dashboard navigate call
- Added a ```window.location.pathname``` check in SignIn to skip navigation if the user is already on the target page, preserving canvas state
- CreateLogo passes ```/createlogo``` as the redirect path when prompting unauthenticated users to sign in
- Removed auth gate from ```Demo.jsx``` "Create Logo" button — now navigates directly to ```/createlogo```


## What type of PR is this? (Check all applicable)


- [x] 🐛 Bug Fix
- [x] 👨‍💻 Code Refactor
- [x] ✅ Test

## Screenshots (if applicable)

https://github.com/user-attachments/assets/40115395-d6a1-478b-b2b0-c3a8dc5aaeeb


https://github.com/user-attachments/assets/e03dfba2-7194-4e36-a222-6c227ef614e8




## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
