### PR TITLE
branch & PR naming conventions via husky + GitHub Actions

### DIFF
--- a/.github/workflows/check-naming-conventions.yml
+++ b/.github/workflows/check-naming-conventions.yml
@@ -1,0 +1,36 @@
+name: Naming Convention Checks
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-branch-name:
+    name: Branch Name Convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Branch Name
+        run: |
+          BRANCH="$ github.head_ref "
+          PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
+          if ! echo "$BRANCH" | grep -Eq "$PATTERN"; then
+            echo "❌ Invalid branch name: '$BRANCH'"
+            echo "Expected format: Fix/issue-931-short-description"
+            exit 1
+          fi
+          echo "✅ Branch name is valid."
+
+  check-pr-title:
+    name: PR Title Convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Title
+        run: |
+          TITLE="$ github.event.pull_request.title "
+          PATTERN="^\[(Feat|Fix|HotFix|Refact|Docs|Test)\] issue-[a-zA-Z0-9]+ .+$"
+          if ! echo "$TITLE" | grep -Eq "$PATTERN"; then
+            echo "❌ PR title does not follow convention."
+            echo "Expected format: [Fix] issue-931 Fix something meaningful"
+            exit 1
+          fi
+          echo "✅ PR title is valid."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,27 @@
+#!/usr/bin/env sh
+
+BRANCH=$(git symbolic-ref --short HEAD)
+PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
+
+echo "🔍 Checking branch name: '$BRANCH'"
+
+if ! echo "$BRANCH" | grep -Eq "$PATTERN"; then
+  echo ""
+  echo "❌ Invalid branch name: '$BRANCH'"
+  echo "✅ Required format: <Type>/issue-<id>-<short-description>"
+  echo ""
+  echo "   Examples:"
+  echo "     ✅ Fix/issue-931-fix-login-redirect"
+  echo "     ✅ Feat/issue-912-add-oauth"
+  echo "     ❌ fix/issue-931"
+  echo "     ❌ issue-931-fix-something"
+  echo ""
+  exit 1
+fi
+
+echo "✅ Branch name is valid."
+echo ""
+
 pnpm lint
 pnpm check
 pnpm test


### PR DESCRIPTION
closes: #983 

## Description
Enforce standardized branch & PR naming conventions

What this PR does:

 - Adds husky pre-commit hook to validate branch names against convention (e.g. Fix/issue-931-fix-login-redirect )

- Configures GitHub Actions workflow to enforce PR title naming on push/PR creation

- Blocks invalid names with clear error messages and suggested formats

Branch naming example :
`Feat/issue-912-add-oauth-support `

PR title example:
`[Fix] Issue-931 Fix broken login redirect`


## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="1390" height="483" alt="image" src="https://github.com/user-attachments/assets/bf740c90-21f1-4563-b27b-57dd321dd54f" />
<img width="1492" height="686" alt="image" src="https://github.com/user-attachments/assets/1a78b2b1-ce10-4dee-a62e-18c708642236" />


## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
