### PR TITLE
[Feat] Issue-983 Branch PR naming conventions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.husky/pre-commit text eol=lf

--- a/.github/workflows/check-naming-conventions.yaml
+++ b/.github/workflows/check-naming-conventions.yaml
@@ -2,43 +2,53 @@ name: Check naming conventions
 
 on:
   pull_request:
-    types: [opened, ready_for_review, edited]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches:
       - stage
 
 jobs:
   check-branch-name:
     name: Branch Name Convention
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 3
+
     steps:
       - name: Validate Branch Name
         env:
-          BRANCH: ${{ github.head_ref }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
+          echo "Branch: $BRANCH"
+          echo "Is Draft: ${{ github.event.pull_request.draft }}"
+
           PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
+
           if ! echo "$BRANCH" | grep -Eq "$PATTERN"; then
             echo "❌ Invalid branch name: '$BRANCH'"
             echo "Expected format: Fix/issue-931-short-description"
             exit 1
           fi
+
           echo "✅ Branch name is valid."
 
   check-pr-title:
     name: PR Title Convention
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 3
+
     steps:
       - name: Validate PR Title
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
+          echo "PR Title: $TITLE"
+          echo "Is Draft: ${{ github.event.pull_request.draft }}"
+
           PATTERN="^\[(Feat|Fix|HotFix|Refact|Docs|Test)\] Issue-[a-zA-Z0-9]+ .+$"
+
           if ! echo "$TITLE" | grep -Eq "$PATTERN"; then
             echo "❌ PR title does not follow convention."
             echo "Expected format: [Fix] Issue-931 Fix something meaningful"
             exit 1
           fi
+
           echo "✅ PR title is valid."

--- a/.github/workflows/check-naming-conventions.yaml
+++ b/.github/workflows/check-naming-conventions.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-branch-name:
     name: Branch Name Convention
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 3
 
@@ -18,7 +19,6 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "Branch: $BRANCH"
-          echo "Is Draft: ${{ github.event.pull_request.draft }}"
 
           PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
 
@@ -32,6 +32,7 @@ jobs:
 
   check-pr-title:
     name: PR Title Convention
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 3
 
@@ -41,7 +42,6 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo "PR Title: $TITLE"
-          echo "Is Draft: ${{ github.event.pull_request.draft }}"
 
           PATTERN="^\[(Feat|Fix|HotFix|Refact|Docs|Test)\] Issue-[a-zA-Z0-9]+ .+$"
 

--- a/.github/workflows/check-naming-conventions.yaml
+++ b/.github/workflows/check-naming-conventions.yaml
@@ -1,0 +1,44 @@
+name: Check naming conventions
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, edited]
+    branches:
+      - stage
+
+jobs:
+  check-branch-name:
+    name: Branch Name Convention
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Validate Branch Name
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
+          if ! echo "$BRANCH" | grep -Eq "$PATTERN"; then
+            echo "❌ Invalid branch name: '$BRANCH'"
+            echo "Expected format: Fix/issue-931-short-description"
+            exit 1
+          fi
+          echo "✅ Branch name is valid."
+
+  check-pr-title:
+    name: PR Title Convention
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Validate PR Title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PATTERN="^\[(Feat|Fix|HotFix|Refact|Docs|Test)\] Issue-[a-zA-Z0-9]+ .+$"
+          if ! echo "$TITLE" | grep -Eq "$PATTERN"; then
+            echo "❌ PR title does not follow convention."
+            echo "Expected format: [Fix] Issue-931 Fix something meaningful"
+            exit 1
+          fi
+          echo "✅ PR title is valid."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,27 @@
+#!/usr/bin/env sh
+
+BRANCH=$(git symbolic-ref --short HEAD)
+PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"
+
+echo "🔍 Checking branch name: '$BRANCH'"
+
+if ! echo "$BRANCH" | grep -Eq "$PATTERN"; then
+  echo ""
+  echo "❌ Invalid branch name: '$BRANCH'"
+  echo "✅ Required format: <Type>/issue-<id>-<short-description>"
+  echo ""
+  echo "   Examples:"
+  echo "     ✅ Fix/issue-931-fix-login-redirect"
+  echo "     ✅ Feat/issue-912-add-oauth"
+  echo "     ❌ fix/issue-931"
+  echo "     ❌ issue-931-fix-something"
+  echo ""
+  exit 1
+fi
+
+echo "✅ Branch name is valid."
+echo ""
+
 pnpm lint
 pnpm check
 pnpm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 BRANCH=$(git symbolic-ref --short HEAD)
 PATTERN="^(Feat|Fix|HotFix|Refact|Docs|Test)/issue-[a-zA-Z0-9]+-[a-zA-Z0-9-]+$"


### PR DESCRIPTION
closes #983 

## Description
Enforce standardized branch & PR naming conventions

What this PR does:

-  Adds husky pre-commit hook to validate branch names against convention (e.g. Fix/issue-931-fix-login-redirect )

- Configures GitHub Actions workflow to enforce PR title naming on push/PR creation

- Blocks invalid names with clear error messages and suggested formats

Branch naming example :
Feat/issue-912-add-oauth-support 

PR title example:
[Fix] issue-931 Fix broken login redirect

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
