### PR TITLE
[fix] Issue-994 Add: standard procedure for mongoDB-migrations

### DIFF
--- a/packages/app/migrate-mongo-config.js
+++ b/packages/app/migrate-mongo-config.js
@@ -1,0 +1,11 @@
+require("dotenv").config();
+
+module.exports = {
+  mongodb: {
+    url: process.env.MONGO_URL,
+    databaseName: process.env.MONGO_DB_NAME,
+  },
+  migrationsDir: "migrations",
+  changelogCollectionName: "changelog",
+  moduleSystem: "commonjs",
+};

--- a/packages/app/migrations/20260412061259-add-dates-to-subscriptions.js
+++ b/packages/app/migrations/20260412061259-add-dates-to-subscriptions.js
@@ -1,0 +1,50 @@
+module.exports = {
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db) {
+    try {
+      console.log("=== MIGRATION START ===");
+
+      // List all collections
+      const collections = await db.listCollections().toArray();
+      console.log(
+        "All collections:",
+        collections.map((c) => c.name)
+      );
+
+      // Count documents
+      const count = await db.collection("subscriptions").countDocuments({});
+      console.log(`Total subscriptions: ${count}`);
+
+      if (count === 0) {
+        console.log("⚠️ No documents found in subscriptions collection!");
+        return;
+      }
+
+      // Try the update
+      const result = await db
+        .collection("subscriptions")
+        .updateMany({}, { $set: { startDate: new Date(), endDate: null } });
+
+      console.log(`✅ Updated ${result.modifiedCount} documents`);
+      console.log(`Matched: ${result.matchedCount}`);
+    } catch (error) {
+      console.error("❌ Migration error:", error.message);
+      throw error;
+    }
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db) {
+    await db
+      .collection("subscriptions")
+      .updateMany({}, { $unset: { startDate: "", endDate: "" } });
+  },
+};

--- a/packages/app/migrations/template/_template.js
+++ b/packages/app/migrations/template/_template.js
@@ -1,0 +1,36 @@
+// HOW TO CREATE A NEW MIGRATION:
+// 1. Run: npx migrate-mongo create <descriptive-name>
+//    Example: npx migrate-mongo create add-phone-to-users
+// 2. Fill in the up() and down() functions below
+// 3. Run locally first: npm run migrate:up
+// 4. Commit the migration file and your model change together
+// 5. Push — Vercel will run the migration automatically on deploy
+// ─────────────────────────────────────────────────────────────
+/* eslint-disable no-undef */
+module.exports = {
+  async up(db) {
+    // WHAT TO DO HERE:
+    // - Add new fields to existing documents
+    // - Always filter with $exists: false so it's safe to re-run
+    // - Log how many documents were affected
+
+    const result = await db.collection("COLLECTION_NAME").updateMany(
+      { NEW_FIELD: { $exists: false } }, // only touch docs missing the field
+      { $set: { NEW_FIELD: DEFAULT_VALUE } }
+    );
+
+    console.log(`Migration up: updated ${result.modifiedCount} documents`);
+  },
+
+  async down(db) {
+    // WHAT TO DO HERE:
+    // - Undo exactly what up() did.
+    // - This runs when someone does: npm run migrate:down
+
+    await db
+      .collection("COLLECTION_NAME")
+      .updateMany({}, { $unset: { NEW_FIELD: "" } });
+
+    console.log("Migration down: removed NEW_FIELD from COLLECTION_NAME");
+  },
+};

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,7 +11,10 @@
     "test": "jest --watchAll=false",
     "coverage": "jest --coverage --watchAll=false",
     "format": "prettier --write .",
-    "check": "prettier --check ."
+    "check": "prettier --check .",
+    "migrate:up": "migrate-mongo up",
+    "migrate:down": "migrate-mongo down",
+    "migrate:status": "migrate-mongo status"
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.693.0",
@@ -31,6 +34,7 @@
     "image-size": "^2.0.2",
     "joi": "^17.12.3",
     "jsonwebtoken": "^9.0.2",
+    "migrate-mongo": "^14.0.7",
     "mongoose": "^8.5.1",
     "multer": "^1.4.5-lts.1",
     "otplib": "^12.0.1",

--- a/packages/app/utils/constants.js
+++ b/packages/app/utils/constants.js
@@ -80,8 +80,8 @@ const Messages = {
   IMAGE_NOT_EXIST: "Image does not exist",
   ALREADY_SEND_RESPOND: "Already sent the response.",
   UPDATE_SUCCESS: "Responded successfully.",
-  INCORRECT_PASSWORD: "Current password is incorrect", 
-  SAME_PASSWORD:"Current password is same as old password",
+  INCORRECT_PASSWORD: "Current password is incorrect",
+  SAME_PASSWORD: "Current password is same as old password",
   INTERNAL_SERVER_ERROR:
     "An unexpected error occurred. Please try again later.",
   FORM_ALREADY_SUBMITTED: "Form already submitted, try again later",

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "npm run migrate:up",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Description
#994 

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature

### What this PR does
Sets up the migration infrastructure so schema changes can be made safely without breaking production.

### Changes
- Added `migrate-mongo` package
- Added `migrate-mongo-config.js` at `packages/app` root
- Added `migrations/` directory with `.gitkeep` and `_template.js` for engineer reference
- Added `migrate:up`, `migrate:down`, `migrate:status` scripts to `package.json`
- Updated `vercel.json` to run `migrate:up` automatically before every deployment

### Why
Adding `required: true` fields to existing Mongoose models without backfilling existing documents crashes the app on deploy. This setup ensures migrations always run before new code goes live.

### How to make a schema change going forward
1. `npx migrate-mongo create <name>` — generate a migration file
2. Fill in `up()` to backfill the field and `down()` to undo it
3. Deploy with the field as optional first, then required in a follow-up deploy

Refer to the migration guide in Notion for the full process.
https://www.notion.so/mongodb-migration-guide-337fefb8307180029b2de948a9794017?source=copy_link

### Testing
- Verified locally: `migrate:up`, `migrate:status`, and `migrate:down` all work correctly
- Verified on Vercel: migration step runs in build logs before deployment completes
