### PR TITLE
feat: implement rate limiting for demo search endpoint and enhance se…

### DIFF
--- a/packages/app/__tests__/controllers/logo/demo-search.js
+++ b/packages/app/__tests__/controllers/logo/demo-search.js
@@ -69,4 +69,64 @@ describe("GET /api/logo/demo-search", () => {
 
     expect(res.status).toBe(500);
   });
+  it("429 - blocks requests from same IP after limit", async () => {
+    const ip = "1.1.1.1";
+    let res;
+
+    jest
+      .spyOn(ImageService.prototype, "fetchCompanyList")
+      .mockResolvedValue(["Google"]);
+
+    jest
+      .spyOn(ImageService.prototype, "getDataList")
+      .mockResolvedValue([{ name: "Google", logoUrl: "logo" }]);
+
+    // 30 allowed
+    for (let i = 0; i < 30; i++) {
+      res = await request(app)
+        .get("/api/logo/demo-search?key=Go")
+        .set("X-Forwarded-For", ip);
+
+      expect(res.status).not.toBe(429);
+    }
+
+    // 31st blocked
+    res = await request(app)
+      .get("/api/logo/demo-search?key=Go")
+      .set("X-Forwarded-For", ip);
+
+    expect(res.status).toBe(429);
+  });
+
+  it("should allow requests from different IPs even after one IP is blocked", async () => {
+    const blockedIP = "1.1.1.1";
+    const newIP = "2.2.2.2";
+
+    let res;
+
+    jest
+      .spyOn(ImageService.prototype, "fetchCompanyList")
+      .mockResolvedValue(["Google"]);
+
+    jest
+      .spyOn(ImageService.prototype, "getDataList")
+      .mockResolvedValue([{ name: "Google", logoUrl: "logo" }]);
+
+    // Exhaust limit for first IP
+    for (let i = 0; i < 31; i++) {
+      res = await request(app)
+        .get("/api/logo/demo-search?key=Go")
+        .set("X-Forwarded-For", blockedIP);
+    }
+
+    expect(res.status).toBe(429);
+
+    // Different IP should pass
+    res = await request(app)
+      .get("/api/logo/demo-search?key=Go")
+      .set("X-Forwarded-For", newIP);
+
+    expect(res.status).not.toBe(429);
+    expect(res.status).toBe(200);
+  });
 });

--- a/packages/app/middlewares/rateLimiter.js
+++ b/packages/app/middlewares/rateLimiter.js
@@ -14,4 +14,11 @@ const baseLimiter = rateLimit({
   legacyHeaders: false,
 });
 
-module.exports = { logoLimiter, baseLimiter };
+const searchLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+  standardHeaders: "draft-8", //  eigth draft of the IETF rate limit header specification
+  legacyHeaders: false,
+});
+
+module.exports = { logoLimiter, baseLimiter, searchLimiter };

--- a/packages/app/routes/logo.js
+++ b/packages/app/routes/logo.js
@@ -4,9 +4,10 @@ const {
   searchLogoController,
   demoSearchLogoController,
 } = require("../controllers/logo");
+const { searchLimiter } = require("../middlewares/rateLimiter");
 
 router.get("/", getLogoController);
 router.get("/search", searchLogoController);
-router.get("/demo-search", demoSearchLogoController);
+router.get("/demo-search", searchLimiter, demoSearchLogoController);
 
 module.exports = router;

--- a/packages/app/server.js
+++ b/packages/app/server.js
@@ -29,10 +29,12 @@ if (process.env.NODE_ENV !== "test") {
 const app = express();
 app.use(cookieParser());
 app.disable("x-powered-by");
+// Trust first proxy (needed for correct client IP when behind load balancer / reverse proxy)
+// Ensures req.ip is accurate for rate limiting, logging, etc.
+app.set("trust proxy", 1);
 app.use(express.json());
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use("/api/", routes);
-
 if (process.env.NODE_ENV !== "test") {
   const PORT = process.env.PORT;
   app.listen(PORT, () => {


### PR DESCRIPTION


## Description
 this pr closes  #1013  


this pr added rate limiting for the search logo in home bar using ip address now  in 1 min 30 req are allowed 

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->
<img width="603" height="724" alt="Screenshot 2026-04-24 213252" src="https://github.com/user-attachments/assets/771985f7-8bb9-447d-83cb-65bd238fac8a" />

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
