### PR TITLE
[Fix] Issue-1011 Correct analytics date ranges, and the PR description must include Fixes

### DIFF
--- a/packages/app/__tests__/controllers/logoRequestLogs.js/getStats.js
+++ b/packages/app/__tests__/controllers/logoRequestLogs.js/getStats.js
@@ -30,7 +30,7 @@ describe("GET LOGO REQUEST STATS", () => {
   });
 
   describe("Weekly Stats", () => {
-    it("200 - should return last 7 days stats for authenticated user", async () => {
+    it("200 - should return current week stats for authenticated user", async () => {
       const mockUserModel = new Users(MOCK_USERS[0]);
       jest
         .spyOn(UserSessionService.prototype, "validateSession")
@@ -53,11 +53,11 @@ describe("GET LOGO REQUEST STATS", () => {
       ).toHaveBeenCalledWith(mockUserModel._id.toString());
     });
 
-    it("200 - should return empty stats when user has no requests in last 7 days", async () => {
+    it("200 - should return empty stats when user has no requests in the current week", async () => {
       const emptyStats = {
         period: "week",
-        startDate: "2025-11-24",
-        endDate: "2025-12-01",
+        startDate: "2025-11-23",
+        endDate: "2025-11-29",
         summary: {
           totalCount: 0,
           totalKB: "0.00",
@@ -83,7 +83,7 @@ describe("GET LOGO REQUEST STATS", () => {
   });
 
   describe("Monthly Stats", () => {
-    it("200 - should return last 30 days stats for authenticated user", async () => {
+    it("200 - should return current month stats for authenticated user", async () => {
       const mockUserModel = new Users(MOCK_USERS[0]);
       jest
         .spyOn(UserSessionService.prototype, "validateSession")
@@ -106,11 +106,11 @@ describe("GET LOGO REQUEST STATS", () => {
       ).toHaveBeenCalledWith(mockUserModel._id.toString());
     });
 
-    it("200 - should return empty stats when user has no requests in last 30 days", async () => {
+    it("200 - should return empty stats when user has no requests in the current month", async () => {
       const emptyStats = {
         period: "month",
         startDate: "2025-11-01",
-        endDate: "2025-12-01",
+        endDate: "2025-11-30",
         summary: {
           totalCount: 0,
           totalKB: "0.00",

--- a/packages/app/__tests__/repositories/logoRequestLogs.js
+++ b/packages/app/__tests__/repositories/logoRequestLogs.js
@@ -1,0 +1,88 @@
+const { LogoRequestLogsRepository } = require("../../repositories");
+const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
+
+dayjs.extend(utc);
+
+describe("LogoRequestLogsRepository", () => {
+  let repository;
+
+  beforeEach(() => {
+    repository = new LogoRequestLogsRepository();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe("getCurrentMonthData", () => {
+    it("uses the current calendar month boundaries", async () => {
+      const aggregateSpy = jest
+        .spyOn(repository.model, "aggregate")
+        .mockResolvedValue([
+          {
+            date: "2026-04-01",
+            count: 3,
+            totalKB: 1.5,
+          },
+        ]);
+
+      const result = await repository.getCurrentMonthData(
+        "64f1b2c3d4e5f67890123456"
+      );
+
+      expect(aggregateSpy).toHaveBeenCalledTimes(1);
+
+      const pipeline = aggregateSpy.mock.calls[0][0];
+      const matchStage = pipeline[0].$match;
+
+      expect(dayjs.utc(matchStage.createdAt.$gte).format("YYYY-MM-DD")).toBe(
+        "2026-04-01"
+      );
+      expect(dayjs.utc(matchStage.createdAt.$lte).format("YYYY-MM-DD")).toBe(
+        "2026-04-30"
+      );
+      expect(result.period).toBe("month");
+      expect(result.startDate).toBe("2026-04-01");
+      expect(result.endDate).toBe("2026-04-30");
+    });
+  });
+
+  describe("getCurrentWeekData", () => {
+    it("uses the current calendar week boundaries", async () => {
+      const aggregateSpy = jest
+        .spyOn(repository.model, "aggregate")
+        .mockResolvedValue([
+          {
+            date: "2026-04-26",
+            count: 3,
+            totalKB: 1.5,
+          },
+        ]);
+
+      const result = await repository.getCurrentWeekData(
+        "64f1b2c3d4e5f67890123456"
+      );
+
+      expect(aggregateSpy).toHaveBeenCalledTimes(1);
+
+      const pipeline = aggregateSpy.mock.calls[0][0];
+      const matchStage = pipeline[0].$match;
+
+      // April 27, 2026 is a Monday. startOf('week') depends on locale but usually it's Sunday (April 26)
+      // dayjs().startOf('week') for 2026-04-27 will be 2026-04-26
+      expect(dayjs.utc(matchStage.createdAt.$gte).format("YYYY-MM-DD")).toBe(
+        "2026-04-26"
+      );
+      expect(dayjs.utc(matchStage.createdAt.$lte).format("YYYY-MM-DD")).toBe(
+        "2026-05-02"
+      );
+      expect(result.period).toBe("week");
+      expect(result.startDate).toBe("2026-04-26");
+      expect(result.endDate).toBe("2026-05-02");
+    });
+  });
+});

--- a/packages/app/__tests__/services/logoRequestLogs.js
+++ b/packages/app/__tests__/services/logoRequestLogs.js
@@ -127,7 +127,7 @@ describe("Logo Request Logs Service", () => {
   });
 
   describe("getWeeklyStats", () => {
-    it("should return last 7 days stats for a valid user", async () => {
+    it("should return current week stats for a valid user", async () => {
       const userId = MOCK_USERS[0]._id.toString();
 
       jest
@@ -150,12 +150,12 @@ describe("Logo Request Logs Service", () => {
       ).toHaveBeenCalledWith(userId);
     });
 
-    it("should return empty stats when user has no requests in last 7 days", async () => {
+    it("should return empty stats when user has no requests in the current week", async () => {
       const userId = MOCK_USERS[1]._id.toString();
       const emptyStats = {
         period: "week",
-        startDate: "2025-11-24",
-        endDate: "2025-12-01",
+        startDate: "2025-11-23",
+        endDate: "2025-11-29",
         summary: {
           totalCount: 0,
           totalKB: "0.00",
@@ -188,7 +188,7 @@ describe("Logo Request Logs Service", () => {
   });
 
   describe("getMonthlyStats", () => {
-    it("should return last 30 days stats for a valid user", async () => {
+    it("should return current month stats for a valid user", async () => {
       const userId = MOCK_USERS[0]._id.toString();
 
       jest
@@ -211,12 +211,12 @@ describe("Logo Request Logs Service", () => {
       ).toHaveBeenCalledWith(userId);
     });
 
-    it("should return empty stats when user has no requests in last 30 days", async () => {
+    it("should return empty stats when user has no requests in the current month", async () => {
       const userId = MOCK_USERS[2]._id.toString();
       const emptyStats = {
         period: "month",
         startDate: "2025-11-01",
-        endDate: "2025-12-01",
+        endDate: "2025-11-30",
         summary: {
           totalCount: 0,
           totalKB: "0.00",

--- a/packages/app/repositories/logoRequestLogs.js
+++ b/packages/app/repositories/logoRequestLogs.js
@@ -1,7 +1,10 @@
 const { LogoRequestLogs } = require("../models");
 const BaseRepository = require("./base");
 const dayjs = require("dayjs");
+const utc = require("dayjs/plugin/utc");
 const mongoose = require("mongoose");
+
+dayjs.extend(utc);
 
 /**
  * The LogoRequestLogsRepository extends BaseRepository to manage LogoRequestLogs model operations, inheriting CRUD methods like getById, getAll, create, update, and delete.
@@ -16,15 +19,12 @@ class LogoRequestLogsRepository extends BaseRepository {
   /**
    * Generic method to get aggregated data for a date range
    * @param {string} userId - The user ID to filter by
-   * @param {number} days - Number of days to look back
+   * @param {dayjs.Dayjs} startDate - Start of the date range
+   * @param {dayjs.Dayjs} endDate - End of the date range
    * @param {string} period - Period label (e.g., 'week', 'month')
    * @returns {Promise<Object>} - An object containing the count of requests for each day
    */
-  async getDataForPeriod(userId, days, period) {
-    const today = dayjs();
-    const startDate = today.subtract(days, "day").startOf("day");
-    const endDate = today.endOf("day");
-
+  async getDataForPeriod(userId, startDate, endDate, period) {
     const result = await this.model.aggregate([
       {
         $match: {
@@ -80,21 +80,29 @@ class LogoRequestLogsRepository extends BaseRepository {
   }
 
   /**
-   * Get last 7 days data for a specific user
+   * Get current calendar week data for a specific user
    * @param {string} userId - The user ID to filter by
    * @returns {Promise<Object>} - An object containing the count of requests for each day
    */
   getCurrentWeekData(userId) {
-    return this.getDataForPeriod(userId, 7, "week");
+    const today = dayjs.utc();
+    const startDate = today.startOf("week").startOf("day");
+    const endDate = today.endOf("week").endOf("day");
+
+    return this.getDataForPeriod(userId, startDate, endDate, "week");
   }
 
   /**
-   * Get last 30 days data for a specific user
+   * Get current calendar month data for a specific user
    * @param {string} userId - The user ID to filter by
    * @returns {Promise<Object>} - An object containing the count of requests for each day
    */
   getCurrentMonthData(userId) {
-    return this.getDataForPeriod(userId, 30, "month");
+    const today = dayjs.utc();
+    const startDate = today.startOf("month").startOf("day");
+    const endDate = today.endOf("month").endOf("day");
+
+    return this.getDataForPeriod(userId, startDate, endDate, "month");
   }
 }
 

--- a/packages/app/utils/mocks.js
+++ b/packages/app/utils/mocks.js
@@ -429,8 +429,8 @@ const MOCK_LOGO_REQUESTS = [
 
 const MOCK_WEEKLY_STATS = {
   period: "week",
-  startDate: "2025-11-24",
-  endDate: "2025-12-01",
+  startDate: "2025-11-23",
+  endDate: "2025-11-29",
   summary: {
     totalCount: 15,
     totalKB: "45.50",
@@ -445,7 +445,7 @@ const MOCK_WEEKLY_STATS = {
 const MOCK_MONTHLY_STATS = {
   period: "month",
   startDate: "2025-11-01",
-  endDate: "2025-12-01",
+  endDate: "2025-11-30",
   summary: {
     totalCount: 50,
     totalKB: "150.75",

--- a/packages/ui/__tests__/components/Graph.test.jsx
+++ b/packages/ui/__tests__/components/Graph.test.jsx
@@ -11,6 +11,8 @@ vi.mock("react-chartjs-2", () => ({
 vi.mock("../../src/hooks/useApi", () => {
   const mockWeekApiResponse = {
     data: {
+      startDate: "2025-11-01",
+      endDate: "2025-11-07",
       data: [
         { date: "2025-11-01T00:00:00Z", count: 2 },
         { date: "2025-11-02T00:00:00Z", count: 3 },
@@ -24,6 +26,8 @@ vi.mock("../../src/hooks/useApi", () => {
   };
   const mockMonthApiResponse = {
     data: {
+      startDate: "2025-11-01",
+      endDate: "2025-11-30",
       data: Array.from({ length: 30 }, (_, dayIndex) => ({
         date: new Date(2025, 10, dayIndex + 1).toISOString(),
         count: Math.floor(Math.random() * 8),

--- a/packages/ui/src/components/graph/Graph.jsx
+++ b/packages/ui/src/components/graph/Graph.jsx
@@ -114,23 +114,25 @@ function generateDummyData(period) {
   return [labels, counts];
 }
 
-function parseStatsDataForPeriod(data, period) {
-  if (!Array.isArray(data)) {
+function parseStatsDataForPeriod(apiData) {
+  const data = apiData?.data;
+  if (!Array.isArray(data) || !apiData.startDate || !apiData.endDate) {
     return [[], []];
   }
 
-  const daysToDisplay = period === "week" ? 7 : 30;
+  const startTime = Date.parse(apiData.startDate);
+  const endTime = Date.parse(apiData.endDate);
 
-  const today = new Date();
+  if (Number.isNaN(startTime) || Number.isNaN(endTime)) {
+    return [[], []];
+  }
 
   const dateRange = [];
-  for (let offset = daysToDisplay - 1; offset >= 0; offset--) {
-    const date = new Date(today);
-    const dayPadding = 3;
-    date.setDate(date.getDate() + dayPadding);
-    date.setDate(date.getDate() - offset);
-    dateRange.push(date);
+  const dayInMs = 24 * 60 * 60 * 1000;
+  for (let time = startTime; time <= endTime; time += dayInMs) {
+    dateRange.push(new Date(time));
   }
+
   const dateToCount = new Map();
   data.forEach((item) => {
     if (item?.date && item.count !== undefined) {
@@ -149,6 +151,7 @@ function parseStatsDataForPeriod(data, period) {
     const label = new Intl.DateTimeFormat("en-GB", {
       day: "2-digit",
       month: "short",
+      timeZone: "UTC",
     }).format(date);
 
     labels.push(label);
@@ -217,45 +220,39 @@ export default function Graph({ isGuest = false }) {
     if (isGuest) {
       const [labels, counts] = generateDummyData(selectedPeriod);
       setChartData({ labels, dataPoints: counts });
+    }
+  }, [isGuest, selectedPeriod]);
+
+  useEffect(() => {
+    if (isGuest) {
       return;
     }
+
     fetchWeekData();
     fetchMonthData();
-  }, [fetchWeekData, fetchMonthData]);
+  }, []);
 
   useEffect(() => {
     if (weekLoaded && weekResponse) {
       setCachedWeekData(weekResponse);
     }
+  }, [weekLoaded, weekResponse]);
 
+  useEffect(() => {
     if (monthLoaded && monthResponse) {
       setCachedMonthData(monthResponse);
     }
+  }, [monthLoaded, monthResponse]);
 
-    if (selectedPeriod === "week" && cachedWeekData?.data?.data) {
-      const [labels, counts] = parseStatsDataForPeriod(
-        cachedWeekData.data.data,
-        "week"
-      );
+  useEffect(() => {
+    const currentCache =
+      selectedPeriod === "week" ? cachedWeekData : cachedMonthData;
+
+    if (currentCache?.data?.data) {
+      const [labels, counts] = parseStatsDataForPeriod(currentCache.data);
       setChartData({ labels, dataPoints: counts });
     }
-
-    if (selectedPeriod === "month" && cachedMonthData?.data?.data) {
-      const [labels, counts] = parseStatsDataForPeriod(
-        cachedMonthData.data.data,
-        "month"
-      );
-      setChartData({ labels, dataPoints: counts });
-    }
-  }, [
-    selectedPeriod,
-    weekLoaded,
-    monthLoaded,
-    weekResponse,
-    monthResponse,
-    cachedWeekData,
-    cachedMonthData,
-  ]);
+  }, [selectedPeriod, cachedWeekData, cachedMonthData]);
 
   const { yMax, step } = useMemo(() => {
     const values = chartData.dataPoints;


### PR DESCRIPTION
## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->

Currently for a month we should be getting the data of current month, and same for the week, and that is not the case as of now, from backend as well we are getting correct data for week but not for month, month data should start from 1st of currrent month and end at the last of current month as it is there for the week. We need to confirm this if it is correct for the week or not as well.

## Issue:
#1011
#997 

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
