### PR TITLE
[Feat] Issue-1047 SEO optimizations (robots.txt, sitemap, meta tags)

### DIFF
--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/openlogo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Openlogo gives you instant access to a vast library of brand logos through a simple API, plus tools to design and export your own."
+    />
+    <meta property="og:site_name" content="Openlogo" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Openlogo | Access hundreds of logos." />
+    <meta
+      property="og:description"
+      content="Openlogo gives you instant access to a vast library of brand logos through a simple API, plus tools to design and export your own."
+    />
+    <meta property="og:image" content="https://openlogo.fyi/openlogo.svg" />
+    <meta property="og:url" content="https://openlogo.fyi" />
+    <meta name="twitter:card" content="summary_large_image" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Lato:wght@700&family=Nunito&family=Poppins&display=swap"
       rel="stylesheet"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-router": "7.12.0",
     "react-router-dom": "^7.0.2"
   },

--- a/packages/ui/public/robots.txt
+++ b/packages/ui/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /dashboard
+Disallow: /verify
+Disallow: /reset-password
+
+Sitemap: https://openlogo.fyi/sitemap.xml

--- a/packages/ui/public/sitemap.xml
+++ b/packages/ui/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://openlogo.fyi/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://openlogo.fyi/docs</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://openlogo.fyi/createlogo</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://openlogo.fyi/release</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://openlogo.fyi/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/packages/ui/src/components/common/PageMeta.jsx
+++ b/packages/ui/src/components/common/PageMeta.jsx
@@ -1,0 +1,36 @@
+import { Helmet } from "react-helmet-async";
+import PropTypes from "prop-types";
+import { buildPageMeta } from "../../utils/metadata";
+
+const PageMeta = ({ title, description, ogImage, path, noindex }) => {
+  const meta = buildPageMeta({ title, description, ogImage, path, noindex });
+
+  return (
+    <Helmet>
+      <title>{meta.title}</title>
+      <meta name="description" content={meta.description} />
+      {meta.noindex && <meta name="robots" content="noindex" />}
+      <meta property="og:site_name" content="Openlogo" />
+      <meta property="og:title" content={meta.ogTitle} />
+      <meta property="og:description" content={meta.ogDescription} />
+      <meta property="og:image" content={meta.ogImage} />
+      <meta property="og:url" content={meta.ogUrl} />
+      <meta property="og:type" content="website" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={meta.ogTitle} />
+      <meta name="twitter:description" content={meta.ogDescription} />
+      <meta name="twitter:image" content={meta.ogImage} />
+      <link rel="canonical" href={meta.canonical} />
+    </Helmet>
+  );
+};
+
+PageMeta.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  ogImage: PropTypes.string,
+  path: PropTypes.string,
+  noindex: PropTypes.bool,
+};
+
+export default PageMeta;

--- a/packages/ui/src/main.jsx
+++ b/packages/ui/src/main.jsx
@@ -6,21 +6,24 @@ import "./index.css";
 import { AuthProvider } from "./contexts/AuthContext.jsx";
 import { UserProvider } from "./contexts/UserContext.jsx";
 import { BrowserRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
 import { ToastProvider } from "./contexts/ToastContext.jsx";
 import { ThemeProvider } from "./contexts/ThemeContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <BrowserRouter>
-      <ToastProvider>
-        <AuthProvider>
-          <UserProvider>
-            <ThemeProvider>
-              <App />
-            </ThemeProvider>
-          </UserProvider>
-        </AuthProvider>
-      </ToastProvider>
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <ToastProvider>
+          <AuthProvider>
+            <UserProvider>
+              <ThemeProvider>
+                <App />
+              </ThemeProvider>
+            </UserProvider>
+          </AuthProvider>
+        </ToastProvider>
+      </BrowserRouter>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/packages/ui/src/page/documentation/Documentation.jsx
+++ b/packages/ui/src/page/documentation/Documentation.jsx
@@ -5,6 +5,7 @@ import styles from "./Documentation.module.css";
 import CodeBlock from "./CodeBlock.jsx";
 import ContactForm from "../../components/contact/ContactForm.jsx";
 import { getBaseApiUrl } from "../../utils/Helpers.js";
+import PageMeta from "../../components/common/PageMeta.jsx";
 
 const RESPONSE_EXAMPLES = {
   "Logo Retrieval": `{
@@ -47,6 +48,11 @@ const Documentation = () => {
 
   return (
     <section className={`container ${styles.documentationShell}`}>
+      <PageMeta
+        title="API Documentation"
+        path="/docs"
+        description="Comprehensive guide to the Openlogo API. Fetch brand logos by domain with simple HTTP requests, with examples in JavaScript, Python, and more."
+      />
       <div className={styles.docsLayout}>
         <main className={styles.contentColumn}>
           <section className={styles.introPanel}>

--- a/packages/ui/src/page/home/Home.jsx
+++ b/packages/ui/src/page/home/Home.jsx
@@ -9,6 +9,7 @@ import FAQs from "../../components/faqs/FAQs";
 import Pricing from "../../components/pricing/Pricing";
 import GetInTouch from "../../components/contact/GetInTouch";
 import { AuthContext, UserContext } from "../../contexts/Contexts";
+import PageMeta from "../../components/common/PageMeta";
 
 const Home = ({ openAuthModal }) => {
   const navigate = useNavigate();
@@ -20,6 +21,10 @@ const Home = ({ openAuthModal }) => {
 
   return (
     <div className="container">
+      <PageMeta
+        path="/"
+        description="Tap into a vast logo library with thousands of brands. Openlogo gives developers a simple API to fetch logos by domain, plus a free in-browser logo maker."
+      />
       <HeroSection
         onPrimaryButtonClick={onHeroSectionButtonClick}
         isAuthenticated={isAuthenticated}

--- a/packages/ui/src/utils/metadata.js
+++ b/packages/ui/src/utils/metadata.js
@@ -1,0 +1,37 @@
+export const SITE_DEFAULTS = {
+  siteName: "Openlogo",
+  defaultTitle: "Openlogo | Access hundreds of logos.",
+  titleTemplate: "%s | Openlogo",
+  description:
+    "Openlogo gives you instant access to a vast library of brand logos through a simple API, plus tools to design and export your own.",
+  ogImage: "/openlogo.svg",
+  siteUrl: "https://openlogo.fyi",
+};
+
+export function buildPageMeta(overrides = {}) {
+  const { title, description, ogImage, path, noindex = false } = overrides;
+
+  const resolvedTitle = title
+    ? SITE_DEFAULTS.titleTemplate.replace("%s", title)
+    : SITE_DEFAULTS.defaultTitle;
+
+  const resolvedDescription = description ?? SITE_DEFAULTS.description;
+  const resolvedOgImage = ogImage ?? SITE_DEFAULTS.ogImage;
+  const absoluteOgImage = resolvedOgImage.startsWith("http")
+    ? resolvedOgImage
+    : `${SITE_DEFAULTS.siteUrl}${resolvedOgImage}`;
+  const canonical = path
+    ? `${SITE_DEFAULTS.siteUrl}${path}`
+    : SITE_DEFAULTS.siteUrl;
+
+  return {
+    title: resolvedTitle,
+    description: resolvedDescription,
+    ogTitle: resolvedTitle,
+    ogDescription: resolvedDescription,
+    ogImage: absoluteOgImage,
+    ogUrl: canonical,
+    canonical,
+    noindex,
+  };
+}


### PR DESCRIPTION
## Closes #1047

### What
Adds SEO optimizations across the UI app.

- Add `robots.txt` and `sitemap.xml` in `public/`
- Add reusable `PageMeta` component (react-helmet-async) for per-page `<title>`, description, canonical, Open Graph, and Twitter Card tags
- Add `metadata.js` with site defaults + `buildPageMeta()` helper
- Wire `HelmetProvider` in `main.jsx`; use `PageMeta` on Home and Documentation
- Add base meta/OG/Twitter tags in `index.html`

### Verification
- ESLint: 0 errors
- Vite build: passes