### PR TITLE
[Feat] Issue-1084 Copy logo API URL from demo search results

### DIFF
--- a/packages/ui/__tests__/components/Demo.test.jsx
+++ b/packages/ui/__tests__/components/Demo.test.jsx
@@ -104,6 +104,53 @@ describe("Demo Component", () => {
     });
   });
 
+  it("copies the logo URL with a placeholder API key when Copy Link is clicked", async () => {
+    const authContext = mockAuthContext(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    mockUseApi.mockReturnValue({
+      makeRequest: vi.fn(),
+      data: {
+        data: [
+          {
+            companyName: "google",
+            image:
+              "https://d123.cloudfront.net/png/google.com.png?Expires=1785766385&Signature=abc",
+          },
+        ],
+      },
+      loading: false,
+      errorMsg: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthContext.Provider value={authContext}>
+          <ToastContext.Provider value={mockToastContext}>
+            <Demo openAuthModal={mockOpenAuthModal} />
+          </ToastContext.Provider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(searchPlaceholder), {
+      target: { value: "google" },
+    });
+
+    fireEvent.click(await screen.findByText(BUTTON_TEXT.copyLink));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "http://localhost:5000/api/logo?key=google.com&API_KEY=YOUR_API_KEY"
+      );
+    });
+    expect(await screen.findByText(BUTTON_TEXT.copied)).toBeInTheDocument();
+  });
+
   it("shows Loading spinner when loading is true", async () => {
     const authContext = mockAuthContext(true);
     mockUseApi.mockReturnValue({

--- a/packages/ui/src/components/demo/Demo.jsx
+++ b/packages/ui/src/components/demo/Demo.jsx
@@ -5,7 +5,11 @@ import { BUTTON_TEXT, DEMO, TILTED_BRANDS } from "../../utils/Constants.js";
 import styles from "./Demo.module.css";
 import Button from "../common/button/Button.jsx";
 import PropTypes from "prop-types";
-import { firstLetterCapitalString } from "../../utils/Helpers.js";
+import {
+  firstLetterCapitalString,
+  getBaseApiUrl,
+  getLogoDomain,
+} from "../../utils/Helpers.js";
 import { useApi } from "../../hooks/useApi.js";
 import LogoRequestForm from "./LogoRequestForm.jsx";
 import { AuthContext } from "../../contexts/Contexts.jsx";
@@ -14,6 +18,7 @@ import LoadingSpinner from "../common/loadingspinner/LoadingSpinner.jsx";
 const Demo = ({ openAuthModal }) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
+  const [copiedCompany, setCopiedCompany] = useState(null);
   const { makeRequest, data, loading, errorMsg } = useApi({
     method: "GET",
     url: "/logo/demo-search",
@@ -42,6 +47,23 @@ const Demo = ({ openAuthModal }) => {
       .slice(0, 3);
   }, [errorMsg, data, showResults, searchTerm]);
   const { isAuthenticated } = useContext(AuthContext);
+  const baseApiUrl = useMemo(
+    () =>
+      getBaseApiUrl(
+        typeof window !== "undefined" ? window.location.origin : ""
+      ).replace("Base URL: ", ""),
+    []
+  );
+
+  const buildLogoUrl = ({ image, companyName }) =>
+    `${baseApiUrl}/logo?key=${getLogoDomain(image, companyName)}&API_KEY=YOUR_API_KEY`;
+
+  const handleCopyLink = (company) => {
+    navigator.clipboard.writeText(buildLogoUrl(company)).then(() => {
+      setCopiedCompany(company.companyName);
+      setTimeout(() => setCopiedCompany(null), 2000);
+    });
+  };
 
   useEffect(() => {
     const debounceTimer = setTimeout(() => {
@@ -139,6 +161,14 @@ const Demo = ({ openAuthModal }) => {
                               <h3>
                                 {firstLetterCapitalString(company.companyName)}
                               </h3>
+                              <Button
+                                variant="primary"
+                                onClick={() => handleCopyLink(company)}
+                              >
+                                {copiedCompany === company.companyName
+                                  ? BUTTON_TEXT.copied
+                                  : BUTTON_TEXT.copyLink}
+                              </Button>
                             </div>
                           </div>
                         ))}

--- a/packages/ui/src/components/demo/Demo.module.css
+++ b/packages/ui/src/components/demo/Demo.module.css
@@ -348,13 +348,15 @@
 .resultHeader {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1.2rem;
 }
 
 .resultHeader img {
   width: 48px;
   height: 48px;
+  flex-shrink: 0;
+  object-fit: contain;
   border-radius: 12px;
   border: 1px solid var(--border-color);
   padding: 0.4rem;
@@ -362,6 +364,7 @@
 }
 
 .resultHeader h3 {
+  flex: 1;
   font-size: 1.2rem;
   font-weight: 600;
   color: var(--black);

--- a/packages/ui/src/utils/Constants.js
+++ b/packages/ui/src/utils/Constants.js
@@ -475,6 +475,8 @@ export const BUTTON_TEXT = {
   upload: "Upload",
   selectAnImage: "Select an image",
   uploadLogo: "Create New Logo",
+  copyLink: "Copy Link",
+  copied: "Copied!",
 };
 
 export const BRANDING = {

--- a/packages/ui/src/utils/Helpers.js
+++ b/packages/ui/src/utils/Helpers.js
@@ -323,6 +323,20 @@ export const getBaseApiUrl = (domain) => {
   }
 };
 
+/**
+ * Extracts the full company domain from a logo asset URL.
+ *
+ * @param {string} imageUrl - Logo asset URL, e.g. "https://.../png/google.com.png".
+ * @param {string} companyName - Company name without the TLD, used as a fallback.
+ * @returns {string} - The domain (e.g. "google.com") when the asset name holds
+ * one, otherwise the given company name.
+ */
+export const getLogoDomain = (imageUrl, companyName) => {
+  const fileName = (imageUrl || "").split("?")[0].split("/").pop() || "";
+  const domain = fileName.replace(/\.[^.]+$/, "");
+  return domain.includes(".") ? domain : companyName;
+};
+
 export const firstLetterCapitalString = (string) => {
   string = string.toLowerCase();
   return string.charAt(0).toUpperCase() + string.slice(1);


### PR DESCRIPTION
#1084 

Add a Copy Link button to each demo search result that copies the logo retrieval URL with the API key left as a placeholder, so developers can paste it straight into their code and swap in their own key.
- Resolve the full domain from the asset URL, since demo search returns the company name with the TLD stripped
- Select the base URL per environment (local / stage / prod)
- Track which company was copied so only that card shows "Copied!"

## Description
<!-- Link your ticket using #{ISSUE_NUMBER}. And add a clear and concise description of what this PR does. -->

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [ ] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
